### PR TITLE
Add .NET version 3.1.x to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -301,7 +301,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: |
-            3.1.x          
+            3.1.x
             5.0.x
             6.0.x
             7.0.x


### PR DESCRIPTION
Added .NET version 3.1.x to the setup in multiple locations.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor

