### PR TITLE
Add 2-param (reader/stream, logger) constructors to extractor and loader

### DIFF
--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
@@ -98,6 +98,29 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
 
     /// <summary>
     /// Initializes a new <see cref="FixedWidthExtractor{TRecord}"/> that reads
+    /// from the specified <see cref="TextReader"/> with diagnostic logging.
+    /// </summary>
+    /// <param name="reader">
+    /// The <see cref="TextReader"/> to read fixed-width records from.
+    /// </param>
+    /// <param name="logger">The logger instance for diagnostic output.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="reader"/> or <paramref name="logger"/> is null.
+    /// </exception>
+    public FixedWidthExtractor
+    (
+        TextReader reader,
+        ILogger<FixedWidthExtractor<TRecord>> logger
+    )
+    {
+        _reader = reader ?? throw new ArgumentNullException(nameof(reader));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new <see cref="FixedWidthExtractor{TRecord}"/> that reads
     /// from the specified <see cref="TextReader"/> and uses the supplied
     /// <see cref="IProgressTimer"/> instead of the default system timer.
     /// </summary>
@@ -144,6 +167,34 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
         _reader = new StreamReader(stream, encoding: System.Text.Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: DefaultBufferSize, leaveOpen: true);
         _ownsReader = true;
         _logger = NullLogger.Instance;
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new <see cref="FixedWidthExtractor{TRecord}"/> that reads
+    /// from the specified <see cref="Stream"/> with diagnostic logging.
+    /// The extractor creates an internal <see cref="StreamReader"/> with a 64 KB
+    /// buffer for improved throughput on large files.
+    /// </summary>
+    /// <param name="stream">
+    /// The <see cref="Stream"/> to read fixed-width records from. The stream must be
+    /// readable. The caller retains ownership — the extractor does not dispose the stream.
+    /// </param>
+    /// <param name="logger">The logger instance for diagnostic output.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="stream"/> or <paramref name="logger"/> is null.
+    /// </exception>
+    public FixedWidthExtractor
+    (
+        Stream stream,
+        ILogger<FixedWidthExtractor<TRecord>> logger
+    )
+    {
+        if (stream == null) throw new ArgumentNullException(nameof(stream));
+        _reader = new StreamReader(stream, encoding: System.Text.Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: DefaultBufferSize, leaveOpen: true);
+        _ownsReader = true;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
 

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthLoader.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthLoader.cs
@@ -97,6 +97,29 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
 
     /// <summary>
     /// Initializes a new <see cref="FixedWidthLoader{TRecord}"/> that writes
+    /// to the specified <see cref="TextWriter"/> with diagnostic logging.
+    /// </summary>
+    /// <param name="writer">
+    /// The <see cref="TextWriter"/> to write fixed-width records to.
+    /// </param>
+    /// <param name="logger">The logger instance for diagnostic output.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="writer"/> or <paramref name="logger"/> is null.
+    /// </exception>
+    public FixedWidthLoader
+    (
+        TextWriter writer,
+        ILogger<FixedWidthLoader<TRecord>> logger
+    )
+    {
+        _writer = writer ?? throw new ArgumentNullException(nameof(writer));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new <see cref="FixedWidthLoader{TRecord}"/> that writes
     /// to the specified <see cref="TextWriter"/> and uses the supplied
     /// <see cref="IProgressTimer"/> instead of the default system timer.
     /// </summary>
@@ -143,6 +166,34 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
         _writer = new StreamWriter(stream, encoding: System.Text.Encoding.UTF8, bufferSize: DefaultBufferSize, leaveOpen: true);
         _ownsWriter = true;
         _logger = NullLogger.Instance;
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new <see cref="FixedWidthLoader{TRecord}"/> that writes
+    /// to the specified <see cref="Stream"/> with diagnostic logging.
+    /// The loader creates an internal <see cref="StreamWriter"/> with a 64 KB
+    /// buffer for improved throughput on large files.
+    /// </summary>
+    /// <param name="stream">
+    /// The <see cref="Stream"/> to write fixed-width records to. The stream must be
+    /// writable. The caller retains ownership — the loader does not dispose the stream.
+    /// </param>
+    /// <param name="logger">The logger instance for diagnostic output.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="stream"/> or <paramref name="logger"/> is null.
+    /// </exception>
+    public FixedWidthLoader
+    (
+        Stream stream,
+        ILogger<FixedWidthLoader<TRecord>> logger
+    )
+    {
+        if (stream == null) throw new ArgumentNullException(nameof(stream));
+        _writer = new StreamWriter(stream, encoding: System.Text.Encoding.UTF8, bufferSize: DefaultBufferSize, leaveOpen: true);
+        _ownsWriter = true;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
 

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthStreamCtorTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthStreamCtorTests.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Wolfgang.Etl.FixedWidth.Tests.Unit;

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthStreamCtorTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthStreamCtorTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Wolfgang.Etl.FixedWidth.Tests.Unit;
@@ -30,6 +31,38 @@ public class FixedWidthExtractorStreamCtorTests
         Assert.Throws<ArgumentNullException>
         (
             () => new FixedWidthExtractor<PersonRecord>((Stream)null!)
+        );
+    }
+
+
+
+    [Fact]
+    public void Constructor_TextReader_Logger_when_logger_is_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>
+        (
+            () => new FixedWidthExtractor<PersonRecord>
+            (
+                new StringReader(PersonLine),
+                logger: null!
+            )
+        );
+    }
+
+
+
+    [Fact]
+    public void Constructor_Stream_Logger_when_logger_is_null_throws_ArgumentNullException()
+    {
+        using var stream = ToStream(PersonLine);
+
+        Assert.Throws<ArgumentNullException>
+        (
+            () => new FixedWidthExtractor<PersonRecord>
+            (
+                stream,
+                logger: null!
+            )
         );
     }
 
@@ -104,6 +137,38 @@ public class FixedWidthLoaderStreamCtorTests
         Assert.Throws<ArgumentNullException>
         (
             () => new FixedWidthLoader<PersonRecord>((Stream)null!)
+        );
+    }
+
+
+
+    [Fact]
+    public void Constructor_TextWriter_Logger_when_logger_is_null_throws_ArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>
+        (
+            () => new FixedWidthLoader<PersonRecord>
+            (
+                new StringWriter(),
+                logger: null!
+            )
+        );
+    }
+
+
+
+    [Fact]
+    public void Constructor_Stream_Logger_when_logger_is_null_throws_ArgumentNullException()
+    {
+        using var stream = new MemoryStream();
+
+        Assert.Throws<ArgumentNullException>
+        (
+            () => new FixedWidthLoader<PersonRecord>
+            (
+                stream,
+                logger: null!
+            )
         );
     }
 


### PR DESCRIPTION
## Summary

Adds logger-accepting 2-parameter constructors to `FixedWidthExtractor` and `FixedWidthLoader`, allowing diagnostic logging without also supplying custom settings:

- `FixedWidthExtractor(TextReader, ILogger<...>)`
- `FixedWidthExtractor(Stream, ILogger<...>)`
- `FixedWidthLoader(TextWriter, ILogger<...>)`
- `FixedWidthLoader(Stream, ILogger<...>)`

Null logger is rejected with `ArgumentNullException` at construction time.

## Test plan

- [x] `ArgumentNullException` tests for all 4 new constructors
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)