### PR TITLE
ci: add benchmarks workflow with gh-pages chart

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -19,6 +19,13 @@ on:
 permissions:
   contents: read
 
+# Serialize benchmark publishes so two pushes to main close together can't race
+# on the gh-pages branch. cancel-in-progress: false — every merge represents a
+# meaningful data point, so we queue rather than discard.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   benchmark:
     name: Run BenchmarkDotNet & publish chart
@@ -59,11 +66,16 @@ jobs:
         run: |
           # BDN writes a timestamped joined report when running multiple classes.
           # Pick the newest *-report-full-compact.json — the action consumes one file.
-          report=$(ls -t BenchmarkDotNet.Artifacts/results/*-report-full-compact.json | head -n 1)
-          if [ -z "$report" ]; then
+          # nullglob: when no files match, the glob expands to nothing instead of
+          # the literal pattern. Without it, set -e + pipefail would abort before
+          # our explicit "no report found" error message could run.
+          shopt -s nullglob
+          reports=(BenchmarkDotNet.Artifacts/results/*-report-full-compact.json)
+          if [ ${#reports[@]} -eq 0 ]; then
             echo "::error::No BenchmarkDotNet JSON report found"
             exit 1
           fi
+          report=$(ls -t "${reports[@]}" | head -n 1)
           cp "$report" benchmarks-result.json
           echo "report=benchmarks/Wolfgang.Etl.FixedWidth.Benchmarks/benchmarks-result.json" >> "$GITHUB_OUTPUT"
           echo "Found: $report"

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -1,0 +1,84 @@
+name: Benchmarks
+
+# Runs BenchmarkDotNet after a merge to main, then publishes the results to
+# the gh-pages branch under /dev/bench/ where benchmark-action/github-action-benchmark
+# renders an interactive line chart.
+#
+# This workflow is decoupled from PR validation and release: it does NOT gate
+# merging or publishing — it just adds one data point per qualifying push.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'benchmarks/**'
+      - '.github/workflows/benchmarks.yaml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    name: Run BenchmarkDotNet & publish chart
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Required to push the rendered chart + history to the gh-pages branch.
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            10.0.x
+
+      - name: Restore
+        run: dotnet restore benchmarks/Wolfgang.Etl.FixedWidth.Benchmarks/Wolfgang.Etl.FixedWidth.Benchmarks.csproj
+
+      - name: Build (Release)
+        run: dotnet build -c Release --no-restore benchmarks/Wolfgang.Etl.FixedWidth.Benchmarks/Wolfgang.Etl.FixedWidth.Benchmarks.csproj
+
+      - name: Run benchmarks
+        working-directory: benchmarks/Wolfgang.Etl.FixedWidth.Benchmarks
+        # ShortRun keeps total runtime small (~3-5 min). GitHub-hosted runners
+        # are noisy, so chart trends are reliable for allocations and double-digit
+        # time changes; smaller deltas are not.
+        run: dotnet run -c Release --no-build -- --filter "*" --job short --memory --exporters json
+
+      - name: Locate BDN combined report
+        id: locate
+        working-directory: benchmarks/Wolfgang.Etl.FixedWidth.Benchmarks
+        run: |
+          # BDN writes a timestamped joined report when running multiple classes.
+          # Pick the newest *-report-full-compact.json — the action consumes one file.
+          report=$(ls -t BenchmarkDotNet.Artifacts/results/*-report-full-compact.json | head -n 1)
+          if [ -z "$report" ]; then
+            echo "::error::No BenchmarkDotNet JSON report found"
+            exit 1
+          fi
+          cp "$report" benchmarks-result.json
+          echo "report=benchmarks/Wolfgang.Etl.FixedWidth.Benchmarks/benchmarks-result.json" >> "$GITHUB_OUTPUT"
+          echo "Found: $report"
+
+      - name: Publish chart to gh-pages
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: BenchmarkDotNet
+          tool: 'benchmarkdotnet'
+          output-file-path: ${{ steps.locate.outputs.report }}
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench
+          auto-push: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Don't fail the workflow if a metric regresses — this is a tracker,
+          # not a gate. Tighten later if the noise floor settles.
+          alert-threshold: '200%'
+          fail-on-alert: false

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -60,28 +60,35 @@ jobs:
         # time changes; smaller deltas are not.
         run: dotnet run -c Release --no-build -- --filter "*" --job short --memory --exporters json
 
-      - name: Locate BDN combined report
+      - name: Merge per-class BDN reports
         id: locate
         working-directory: benchmarks/Wolfgang.Etl.FixedWidth.Benchmarks
         run: |
-          # BDN writes a timestamped joined report when running multiple classes.
-          # Pick the newest *-report-full-compact.json — the action consumes one file.
-          # nullglob: when no files match, the glob expands to nothing instead of
-          # the literal pattern. Without it, set -e + pipefail would abort before
-          # our explicit "no report found" error message could run.
+          # BDN's --exporters json writes one *-report-full-compressed.json per
+          # benchmark class. github-action-benchmark consumes a single file, so
+          # we combine the .Benchmarks arrays into one synthetic report.
+          # nullglob: empty match expands to nothing (instead of the literal
+          # pattern), so the explicit "no report found" branch can run before
+          # set -e + pipefail aborts the step.
           shopt -s nullglob
-          reports=(BenchmarkDotNet.Artifacts/results/*-report-full-compact.json)
+          reports=(BenchmarkDotNet.Artifacts/results/*-report-full-compressed.json)
           if [ ${#reports[@]} -eq 0 ]; then
             echo "::error::No BenchmarkDotNet JSON report found"
             exit 1
           fi
-          report=$(ls -t "${reports[@]}" | head -n 1)
-          cp "$report" benchmarks-result.json
+          echo "Merging ${#reports[@]} report(s):"
+          printf '  %s\n' "${reports[@]}"
+          jq -s '{
+            Title: "BenchmarkDotNet combined report",
+            HostEnvironmentInfo: .[0].HostEnvironmentInfo,
+            Benchmarks: [.[].Benchmarks[]]
+          }' "${reports[@]}" > benchmarks-result.json
           echo "report=benchmarks/Wolfgang.Etl.FixedWidth.Benchmarks/benchmarks-result.json" >> "$GITHUB_OUTPUT"
-          echo "Found: $report"
 
       - name: Publish chart to gh-pages
-        uses: benchmark-action/github-action-benchmark@v1
+        # Pinned to v1.22.1 commit per repo convention (third-party actions
+        # publishing to gh-pages are pinned by SHA, not mutable tag).
+        uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba  # v1.22.1
         with:
           name: BenchmarkDotNet
           tool: 'benchmarkdotnet'


### PR DESCRIPTION
## Summary
- New \`.github/workflows/benchmarks.yaml\` runs BenchmarkDotNet on \`push: main\` (src/** and benchmarks/** paths only) and on \`workflow_dispatch\`
- Publishes the BDN JSON report to \`gh-pages\` under \`/dev/bench/\` via [benchmark-action/github-action-benchmark](https://github.com/benchmark-action/github-action-benchmark) — renders an interactive line chart
- Decoupled from \`pr.yaml\` and \`release.yaml\`: this workflow does NOT gate merges or publishing

## Why
Track allocation/time trends over time so regressions and improvements are visible. Once merged, the chart will be at \`https://chris-wolfgang.github.io/ETL-FixedWidth/dev/bench/\`.

This first merge to main establishes the baseline data point. Subsequent merges (e.g. an upcoming perf PR) appear as new points on the chart.

## Notes
- Uses \`--job short\` to keep runtime ~3-5 min
- \`alert-threshold: 200%\` and \`fail-on-alert: false\` — purely a tracker, not a gate. Can be tightened once the noise floor settles
- Dependabot bumps to \`src/**.csproj\` will trigger this workflow (intentional — package bumps can shift perf)

## Test plan
- [ ] Workflow runs successfully on merge to main
- [ ] Chart appears at https://chris-wolfgang.github.io/ETL-FixedWidth/dev/bench/
- [ ] gh-pages branch contains \`dev/bench/data.js\` updated by the action