### PR TITLE
chore: bump Wolfgang.Etl.FixedWidth to 0.2.1

### DIFF
--- a/src/Wolfgang.Etl.FixedWidth/Wolfgang.Etl.FixedWidth.csproj
+++ b/src/Wolfgang.Etl.FixedWidth/Wolfgang.Etl.FixedWidth.csproj
@@ -5,7 +5,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Version>0.2.0</Version>
+    <Version>0.2.1</Version>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <FileVersion>1.0.0</FileVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>


### PR DESCRIPTION
## Summary
- Bump \`<Version>\` in \`src/Wolfgang.Etl.FixedWidth.csproj\` from 0.2.0 to 0.2.1.

## Why
Patch release for the perf-only changes landed in [#84](https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/84):
- Writer allocations cut ~45% across record sizes (LoaderBenchmarks.Memory_TextWriter at 1k/10k/100k records).
- DateTime parse path on net8+ no longer allocates an intermediate string.

No public API change, no behavior change — output is byte-for-byte identical to 0.2.0. Hence patch, not minor.

## Test plan
- [x] CI green
- [ ] After merge: tag \`v0.2.1\` to trigger \`release.yaml\` and publish the package