### PR TITLE
test: cover new write paths added in #84

### DIFF
--- a/benchmarks/Wolfgang.Etl.FixedWidth.Benchmarks/DateTimeBenchmarks.cs
+++ b/benchmarks/Wolfgang.Etl.FixedWidth.Benchmarks/DateTimeBenchmarks.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
@@ -36,13 +37,13 @@ public class DateTimeBenchmarks
             {
                 FirstName = "John",
                 LastName = "Smith",
-                BirthDate = new DateTime(1980, 1, 1).AddDays(i % 10000),
+                BirthDate = new DateTime(1980, 1, 1, 0, 0, 0, DateTimeKind.Utc).AddDays(i % 10000),
                 ZipCode = 98101,
             };
 
-            sb.Append("John                ");                                         // 20
-            sb.Append("Smith               ");                                         // 20
-            sb.Append(_records[i].BirthDate.ToString("yyyyMMdd"));                     //  8
+            sb.Append("John                ");                                                            // 20
+            sb.Append("Smith               ");                                                            // 20
+            sb.Append(_records[i].BirthDate.ToString("yyyyMMdd", CultureInfo.InvariantCulture));          //  8
             sb.Append("98101");                                                        //  5
             sb.AppendLine();
         }

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthConverter.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthConverter.cs
@@ -380,10 +380,12 @@ public static class FixedWidthConverter
 
 
 
+#if !NET8_0_OR_GREATER
     /// <summary>
     /// Parses a <see cref="DateTime"/>, <see cref="DateTimeOffset"/>, or
     /// <see cref="TimeSpan"/> value from <paramref name="text"/> using the
-    /// required <paramref name="format"/> string.
+    /// required <paramref name="format"/> string. On net8+ this is replaced
+    /// by <c>ParseDateTimeValueSpan</c> which avoids the string allocation.
     /// </summary>
     /// <exception cref="InvalidOperationException">
     /// Thrown when <paramref name="format"/> is null or empty.
@@ -425,13 +427,15 @@ public static class FixedWidthConverter
             CultureInfo.InvariantCulture
         );
     }
+#endif
 
 
 
 #if NET8_0_OR_GREATER
     /// <summary>
-    /// Span-based equivalent of <see cref="ParseDateTimeValue"/> that avoids the
-    /// <see cref="string"/> allocation by parsing directly from the source span.
+    /// Span-based replacement for the older-TFM <c>ParseDateTimeValue</c> that
+    /// avoids the <see cref="string"/> allocation by parsing directly from the
+    /// source span.
     /// </summary>
     /// <exception cref="InvalidOperationException">
     /// Thrown when <paramref name="format"/> is null or empty.

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthLineParserTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthLineParserTests.cs
@@ -1460,6 +1460,96 @@ public class FixedWidthConverterTests
             result
         );
     }
+
+
+
+    // ------------------------------------------------------------------
+    // ParseValue — span-based numeric fast path (net8+)
+    //
+    // Each branch of ParseNumericSpan was previously only exercised for int.
+    // These cases hit the remaining branches so the per-class coverage gate
+    // for FixedWidthConverter stays above the 90% threshold and so a future
+    // refactor of the fast path is caught by tests, not just by chart drift.
+    // ------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(typeof(long),    "9000000000",   9000000000L)]
+    [InlineData(typeof(short),   "12345",        (short)12345)]
+    [InlineData(typeof(byte),    "200",          (byte)200)]
+    [InlineData(typeof(uint),    "4000000000",   4000000000u)]
+    [InlineData(typeof(ulong),   "18000000000",  18000000000ul)]
+    [InlineData(typeof(ushort),  "60000",        (ushort)60000)]
+    [InlineData(typeof(sbyte),   "-100",         (sbyte)-100)]
+    [InlineData(typeof(bool),    "true",         true)]
+    public void ParseValue_when_targetType_is_integer_or_bool_uses_span_fast_path
+    (
+        Type targetType,
+        string text,
+        object expected
+    )
+    {
+        var result = FixedWidthConverter.ParseValue(text.AsMemory(), targetType, format: null);
+
+        Assert.Equal(expected, result);
+        Assert.Equal(targetType, result.GetType());
+    }
+
+
+
+    [Fact]
+    public void ParseValue_when_targetType_is_decimal_uses_span_fast_path()
+    {
+        var result = FixedWidthConverter.ParseValue("123.45".AsMemory(), typeof(decimal), format: null);
+
+        Assert.Equal(123.45m, result);
+        Assert.IsType<decimal>(result);
+    }
+
+
+
+    [Fact]
+    public void ParseValue_when_targetType_is_double_uses_span_fast_path()
+    {
+        var result = FixedWidthConverter.ParseValue("3.14159".AsMemory(), typeof(double), format: null);
+
+        Assert.Equal(3.14159, (double)result, precision: 5);
+    }
+
+
+
+    [Fact]
+    public void ParseValue_when_targetType_is_float_uses_span_fast_path()
+    {
+        var result = FixedWidthConverter.ParseValue("2.5".AsMemory(), typeof(float), format: null);
+
+        Assert.Equal(2.5f, (float)result);
+    }
+
+
+
+    [Fact]
+    public void ParseValue_when_value_type_text_is_empty_returns_default()
+    {
+        // Covers the empty-span branch for non-nullable value types — should
+        // return Activator.CreateInstance(targetType), i.e. default(int) == 0.
+        var result = FixedWidthConverter.ParseValue("".AsMemory(), typeof(int), format: null);
+
+        Assert.Equal(0, result);
+    }
+
+
+
+    [Fact]
+    public void ConvertToString_when_value_is_not_IFormattable_uses_object_ToString()
+    {
+        // Covers the non-IFormattable fallback at the bottom of ConvertToString.
+        // System.Version is not IFormattable but has a sensible ToString().
+        var version = new Version(1, 2, 3);
+
+        var result = FixedWidthConverter.ConvertToString(version, MakeContext("Version", 10));
+
+        Assert.Equal("1.2.3", result);
+    }
 }
 
 

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthLineParserTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthLineParserTests.cs
@@ -685,9 +685,11 @@ public class FixedWidthLineParserTests
     [ExcludeFromCodeCoverage]
     private class WideFieldRecord
     {
-        // Exceeds the 256-char stackalloc threshold in WriteFieldSegment so the
-        // pooled-buffer / per-WritePadding fallback path is exercised.
-        [FixedWidthField(0, 300)]
+        // Exceeds the (currently 256-char) stackalloc threshold in
+        // WriteFieldSegment so the pooled-buffer / per-WritePadding fallback
+        // path is exercised. 1024 leaves comfortable headroom; if the
+        // stackalloc limit is ever raised above 1024, this width must grow too.
+        [FixedWidthField(0, 1024)]
         public string Wide { get; set; } = string.Empty;
     }
 
@@ -743,10 +745,13 @@ public class FixedWidthLineParserTests
     public void WriteRecord_when_field_width_exceeds_stackalloc_threshold_uses_writepadding_fallback_left_aligned()
     {
         // Covers the non-stackalloc branch of WriteFieldSegment: when attr.Length
-        // is greater than the 256-char stackalloc cap, the writer falls back to
-        // direct value + WritePadding writes. The counting writer asserts the
-        // fallback branch executed (multiple Write* calls vs the single Write of
-        // the stackalloc path) so the test stays robust if the threshold changes.
+        // is greater than the stackalloc cap, the writer falls back to a direct
+        // value Write + WritePadding writes. The counting writer asserts the
+        // fallback branch executed (>=2 Write calls vs the single Write of the
+        // stackalloc path). The 1024 field width is well above the current
+        // 256-char threshold; if that threshold ever moves above 1024, the
+        // record's FixedWidthField length must be raised to keep this assertion
+        // meaningful.
         var fieldMap = FieldMap.GetResult<WideFieldRecord>();
         var record = new WideFieldRecord { Wide = "value" };
         var writer = new CountingTextWriter();
@@ -754,10 +759,9 @@ public class FixedWidthLineParserTests
         FixedWidthLineParser.WriteRecord(writer, record, fieldMap, FixedWidthConverter.Strict, fieldDelimiter: null);
 
         var output = writer.ToString();
-        Assert.Equal(300, output.Length);
+        Assert.Equal(1024, output.Length);
         Assert.StartsWith("value", output);
-        Assert.Equal(new string(' ', 295), output.Substring(5));
-        // Stackalloc path: 1 Write. Fallback: value Write + WritePadding Write(s) >= 2.
+        Assert.Equal(new string(' ', 1019), output.Substring(5));
         Assert.True
         (
             writer.WriteCallCount >= 2,
@@ -770,7 +774,8 @@ public class FixedWidthLineParserTests
     [ExcludeFromCodeCoverage]
     private class WideRightAlignedRecord
     {
-        [FixedWidthField(0, 300, Alignment = FieldAlignment.Right, Pad = '0')]
+        // See WideFieldRecord for the rationale on the 1024 width.
+        [FixedWidthField(0, 1024, Alignment = FieldAlignment.Right, Pad = '0')]
         public string Wide { get; set; } = string.Empty;
     }
 
@@ -779,10 +784,10 @@ public class FixedWidthLineParserTests
     [Fact]
     public void WriteRecord_when_field_width_exceeds_stackalloc_threshold_uses_writepadding_fallback_right_aligned()
     {
-        // Companion to the left-aligned variant — verifies the right-aligned
-        // branch of the non-stackalloc fallback (WritePadding fires before the
-        // value is written). The counting writer asserts the fallback branch
-        // executed regardless of any future change to the stackalloc threshold.
+        // Right-aligned companion to the left-aligned variant. WritePadding fires
+        // before the value is written; the counting writer asserts the fallback
+        // branch executed (>=2 Write calls). Same threshold caveat as the
+        // left-aligned test — keep the field width above the stackalloc cap.
         var fieldMap = FieldMap.GetResult<WideRightAlignedRecord>();
         var record = new WideRightAlignedRecord { Wide = "42" };
         var writer = new CountingTextWriter();
@@ -790,10 +795,9 @@ public class FixedWidthLineParserTests
         FixedWidthLineParser.WriteRecord(writer, record, fieldMap, FixedWidthConverter.Strict, fieldDelimiter: null);
 
         var output = writer.ToString();
-        Assert.Equal(300, output.Length);
+        Assert.Equal(1024, output.Length);
         Assert.EndsWith("42", output);
-        Assert.Equal(new string('0', 298), output.Substring(0, 298));
-        // Stackalloc path: 1 Write. Fallback: WritePadding Write(s) + value Write >= 2.
+        Assert.Equal(new string('0', 1022), output.Substring(0, 1022));
         Assert.True
         (
             writer.WriteCallCount >= 2,
@@ -1464,12 +1468,12 @@ public class FixedWidthConverterTests
 
 
     // ------------------------------------------------------------------
-    // ParseValue — span-based numeric fast path (net8+)
+    // ParseValue — numeric and bool round-trip
     //
-    // Each branch of ParseNumericSpan was previously only exercised for int.
-    // These cases hit the remaining branches so the per-class coverage gate
-    // for FixedWidthConverter stays above the 90% threshold and so a future
-    // refactor of the fast path is caught by tests, not just by chart drift.
+    // On net8+ these cases exercise the span-based fast path in
+    // ParseNumericSpan; on older TFMs they exercise the TypeDescriptor
+    // fallback. Either way, the observable behavior is the same and the
+    // tests describe parsing behavior rather than which internal branch ran.
     // ------------------------------------------------------------------
 
     [Theory]
@@ -1481,7 +1485,7 @@ public class FixedWidthConverterTests
     [InlineData(typeof(ushort),  "60000",        (ushort)60000)]
     [InlineData(typeof(sbyte),   "-100",         (sbyte)-100)]
     [InlineData(typeof(bool),    "true",         true)]
-    public void ParseValue_when_targetType_is_integer_or_bool_uses_span_fast_path
+    public void ParseValue_when_targetType_is_integer_or_bool_returns_parsed_value
     (
         Type targetType,
         string text,
@@ -1497,7 +1501,7 @@ public class FixedWidthConverterTests
 
 
     [Fact]
-    public void ParseValue_when_targetType_is_decimal_uses_span_fast_path()
+    public void ParseValue_when_targetType_is_decimal_returns_parsed_decimal()
     {
         var result = FixedWidthConverter.ParseValue("123.45".AsMemory(), typeof(decimal), format: null);
 
@@ -1508,7 +1512,7 @@ public class FixedWidthConverterTests
 
 
     [Fact]
-    public void ParseValue_when_targetType_is_double_uses_span_fast_path()
+    public void ParseValue_when_targetType_is_double_returns_parsed_double()
     {
         var result = FixedWidthConverter.ParseValue("3.14159".AsMemory(), typeof(double), format: null);
 
@@ -1518,7 +1522,7 @@ public class FixedWidthConverterTests
 
 
     [Fact]
-    public void ParseValue_when_targetType_is_float_uses_span_fast_path()
+    public void ParseValue_when_targetType_is_float_returns_parsed_float()
     {
         var result = FixedWidthConverter.ParseValue("2.5".AsMemory(), typeof(float), format: null);
 

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthLineParserTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthLineParserTests.cs
@@ -621,6 +621,129 @@ public class FixedWidthLineParserTests
 
 
     [Fact]
+    public void WriteRecord_when_custom_converter_returns_string_longer_than_field_width_throws_FieldOverflowException()
+    {
+        // Covers the safety-net throw inside WriteFieldSegment — fires when a
+        // custom value converter bypasses length validation and returns an
+        // overlong string on the direct-write path.
+        var fieldMap = FieldMap.GetResult<SimpleRecord>();
+        var record = new SimpleRecord { FirstName = "John", LastName = "Smith", Age = 1 };
+        var writer = new System.IO.StringWriter();
+
+        Func<object, FieldContext, string> badConverter = (_, _) => "This string is far too long";
+
+        var ex = Assert.Throws<FieldOverflowException>
+        (
+            () => FixedWidthLineParser.WriteRecord(writer, record, fieldMap, badConverter, fieldDelimiter: null)
+        );
+
+        Assert.Equal
+        (
+            "FirstName",
+            ex.PropertyName
+        );
+        Assert.Equal
+        (
+            10,
+            ex.FieldLength
+        );
+        Assert.True(ex.ActualLength > 10);
+    }
+
+
+
+    [Fact]
+    public void WriteHeader_when_custom_header_converter_returns_string_longer_than_field_width_throws_FieldOverflowException()
+    {
+        // Covers the overflow throw inside WriteHeaderSegmentTo — fires when a
+        // custom header converter returns an overlong label on the direct-write path.
+        var fieldMap = FieldMap.GetResult<SimpleRecord>();
+        var writer = new System.IO.StringWriter();
+
+        Func<string, FieldContext, string> badConverter = (_, _) => "This header is way too long for the field";
+
+        var ex = Assert.Throws<FieldOverflowException>
+        (
+            () => FixedWidthLineParser.WriteHeader(writer, fieldMap, badConverter, fieldDelimiter: null)
+        );
+
+        Assert.Equal
+        (
+            "FirstName",
+            ex.PropertyName
+        );
+        Assert.Equal
+        (
+            10,
+            ex.FieldLength
+        );
+        Assert.True(ex.ActualLength > 10);
+    }
+
+
+
+    [ExcludeFromCodeCoverage]
+    private class WideFieldRecord
+    {
+        // Exceeds the 256-char stackalloc threshold in WriteFieldSegment so the
+        // pooled-buffer / per-WritePadding fallback path is exercised.
+        [FixedWidthField(0, 300)]
+        public string Wide { get; set; } = string.Empty;
+    }
+
+
+
+    [Fact]
+    public void WriteRecord_when_field_width_exceeds_stackalloc_threshold_uses_writepadding_fallback_left_aligned()
+    {
+        // Covers the non-stackalloc branch of WriteFieldSegment: when attr.Length
+        // is greater than the 256-char stackalloc cap, the writer falls back to
+        // direct value + WritePadding writes. This test verifies the left-aligned
+        // (default) path; pad is space, value is on the left.
+        var fieldMap = FieldMap.GetResult<WideFieldRecord>();
+        var record = new WideFieldRecord { Wide = "value" };
+        var writer = new System.IO.StringWriter();
+
+        FixedWidthLineParser.WriteRecord(writer, record, fieldMap, FixedWidthConverter.Strict, fieldDelimiter: null);
+
+        var output = writer.ToString();
+        Assert.Equal(300, output.Length);
+        Assert.StartsWith("value", output);
+        Assert.Equal(new string(' ', 295), output.Substring(5));
+    }
+
+
+
+    [ExcludeFromCodeCoverage]
+    private class WideRightAlignedRecord
+    {
+        [FixedWidthField(0, 300, Alignment = FieldAlignment.Right, Pad = '0')]
+        public string Wide { get; set; } = string.Empty;
+    }
+
+
+
+    [Fact]
+    public void WriteRecord_when_field_width_exceeds_stackalloc_threshold_uses_writepadding_fallback_right_aligned()
+    {
+        // Companion to the left-aligned variant — verifies the right-aligned
+        // branch of the non-stackalloc fallback (WritePadding fires before the
+        // value is written).
+        var fieldMap = FieldMap.GetResult<WideRightAlignedRecord>();
+        var record = new WideRightAlignedRecord { Wide = "42" };
+        var writer = new System.IO.StringWriter();
+
+        FixedWidthLineParser.WriteRecord(writer, record, fieldMap, FixedWidthConverter.Strict, fieldDelimiter: null);
+
+        var output = writer.ToString();
+        Assert.Equal(300, output.Length);
+        Assert.EndsWith("42", output);
+        Assert.Equal(new string('0', 298), output.Substring(0, 298));
+    }
+
+
+
+    [Fact]
     public void WriteSeparator_when_field_delimiter_is_set_inserts_delimiter_between_separators()
     {
         var fieldMap = FieldMap.GetResult<SimpleRecord>();

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthLineParserTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthLineParserTests.cs
@@ -693,16 +693,63 @@ public class FixedWidthLineParserTests
 
 
 
+    /// <summary>
+    /// Minimal <see cref="System.IO.TextWriter"/> that counts Write* invocations
+    /// while delegating to an inner writer. Used to distinguish the
+    /// single-call stackalloc path of <c>WriteFieldSegment</c> from its
+    /// multi-call fallback (one Write for the value + one or more for padding).
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    private sealed class CountingTextWriter : System.IO.TextWriter
+    {
+        private readonly System.IO.TextWriter _inner = new System.IO.StringWriter();
+
+        public int WriteCallCount { get; private set; }
+
+        public override System.Text.Encoding Encoding => _inner.Encoding;
+
+        public override string ToString() => _inner.ToString()!;
+
+        public override void Write(char value)
+        {
+            WriteCallCount++;
+            _inner.Write(value);
+        }
+
+        public override void Write(string? value)
+        {
+            WriteCallCount++;
+            _inner.Write(value);
+        }
+
+        public override void Write(char[] buffer, int index, int count)
+        {
+            WriteCallCount++;
+            _inner.Write(buffer, index, count);
+        }
+
+#if NET6_0_OR_GREATER
+        public override void Write(ReadOnlySpan<char> buffer)
+        {
+            WriteCallCount++;
+            _inner.Write(buffer);
+        }
+#endif
+    }
+
+
+
     [Fact]
     public void WriteRecord_when_field_width_exceeds_stackalloc_threshold_uses_writepadding_fallback_left_aligned()
     {
         // Covers the non-stackalloc branch of WriteFieldSegment: when attr.Length
         // is greater than the 256-char stackalloc cap, the writer falls back to
-        // direct value + WritePadding writes. This test verifies the left-aligned
-        // (default) path; pad is space, value is on the left.
+        // direct value + WritePadding writes. The counting writer asserts the
+        // fallback branch executed (multiple Write* calls vs the single Write of
+        // the stackalloc path) so the test stays robust if the threshold changes.
         var fieldMap = FieldMap.GetResult<WideFieldRecord>();
         var record = new WideFieldRecord { Wide = "value" };
-        var writer = new System.IO.StringWriter();
+        var writer = new CountingTextWriter();
 
         FixedWidthLineParser.WriteRecord(writer, record, fieldMap, FixedWidthConverter.Strict, fieldDelimiter: null);
 
@@ -710,6 +757,12 @@ public class FixedWidthLineParserTests
         Assert.Equal(300, output.Length);
         Assert.StartsWith("value", output);
         Assert.Equal(new string(' ', 295), output.Substring(5));
+        // Stackalloc path: 1 Write. Fallback: value Write + WritePadding Write(s) >= 2.
+        Assert.True
+        (
+            writer.WriteCallCount >= 2,
+            $"Expected fallback path (>=2 Write calls); observed {writer.WriteCallCount}."
+        );
     }
 
 
@@ -728,10 +781,11 @@ public class FixedWidthLineParserTests
     {
         // Companion to the left-aligned variant — verifies the right-aligned
         // branch of the non-stackalloc fallback (WritePadding fires before the
-        // value is written).
+        // value is written). The counting writer asserts the fallback branch
+        // executed regardless of any future change to the stackalloc threshold.
         var fieldMap = FieldMap.GetResult<WideRightAlignedRecord>();
         var record = new WideRightAlignedRecord { Wide = "42" };
-        var writer = new System.IO.StringWriter();
+        var writer = new CountingTextWriter();
 
         FixedWidthLineParser.WriteRecord(writer, record, fieldMap, FixedWidthConverter.Strict, fieldDelimiter: null);
 
@@ -739,6 +793,12 @@ public class FixedWidthLineParserTests
         Assert.Equal(300, output.Length);
         Assert.EndsWith("42", output);
         Assert.Equal(new string('0', 298), output.Substring(0, 298));
+        // Stackalloc path: 1 Write. Fallback: WritePadding Write(s) + value Write >= 2.
+        Assert.True
+        (
+            writer.WriteCallCount >= 2,
+            $"Expected fallback path (>=2 Write calls); observed {writer.WriteCallCount}."
+        );
     }
 
 


### PR DESCRIPTION
## Summary
Tests + small follow-up source fixes for the perf code that landed in [#84](https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/84). PR scope grew while addressing the per-class coverage gate and the analyzer errors that surfaced once Stage 1 stopped failing.

### Tests added
- \`WriteRecord\` overflow exception via a custom value converter that returns an over-long string — covers the \`WriteFieldSegment\` safety net.
- \`WriteHeader\` overflow exception via a custom header converter — covers the \`WriteHeaderSegmentTo\` safety net.
- Two \`WriteRecord\` cases with a 1024-char field, exercising the \`WritePadding\` fallback for both left- and right-aligned fields. A private \`CountingTextWriter\` asserts the fallback branch ran (\`>= 2\` Write calls vs the single Write of the stackalloc path).
- \`ParseValue\` numeric/bool round-trip for \`long\`, \`short\`, \`byte\`, \`uint\`, \`ulong\`, \`ushort\`, \`sbyte\`, \`bool\`, \`decimal\`, \`double\`, \`float\` (previously only \`int\` was covered).
- \`ParseValue\` empty-span branch for non-nullable value types.
- \`ConvertToString\` non-IFormattable fallback (using \`System.Version\`).

### Source fixes (necessary to land the tests through CI)
- Gate \`ParseDateTimeValue\` behind \`#if !NET8_0_OR_GREATER\` — Windows S1144 was failing on net8.0/net10.0 because \`ParseDateTimeValueSpan\` made it dead code there. Linux Stage 1 didn't catch this when [#84](https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/84) merged because Stage 1 was failing the coverage gate, which skipped Stage 2 (Windows) entirely.
- \`DateTimeBenchmarks.cs\` analyzer fixes: pass \`DateTimeKind.Utc\` to the \`DateTime\` ctor (S6562) and \`CultureInfo.InvariantCulture\` to \`DateTime.ToString\` (MA0011).

## Coverage delta (net10.0, local)
| Scope                  | Before          | After           |
|------------------------|-----------------|-----------------|
| Overall line           | 90.54%          | **93.16%**      |
| Overall branch         | 83.90%          | **87.80%**      |
| FixedWidthLineParser   | 87.2% / 86.1%   | **96.5% / 92.6%** |
| FixedWidthConverter    | 79.0%           | **83.5%**       |

CI's multi-TFM combined coverage lifts \`FixedWidthConverter\` past the 90% per-class gate via the older-TFM \`ParseDateTimeValue\` being live on net5.0–net7.0 runs.

## Test plan
- [x] \`dotnet test\` — 301 / 301 pass on net10.0 (was 284)
- [x] \`dotnet build -c Release\` clean across net462, net481, netstandard2.0, net8.0, net10.0
- [ ] Stage 1 (Linux + Coverage Gate) green
- [ ] Stage 2 (Windows) green