### PR TITLE
docfx: preserve dev/ on gh-pages so benchmark chart survives releases

### DIFF
--- a/.github/workflows/docfx.yaml
+++ b/.github/workflows/docfx.yaml
@@ -322,9 +322,11 @@ jobs:
               git -C $WORK_DIR remote add origin "https://github.com/$($env:GITHUB_REPOSITORY).git"
             }
 
-            # Remove stale root files; preserve versions/, .git, .nojekyll, CNAME
+            # Remove stale root files; preserve versions/, .git, .nojekyll, CNAME, dev
+            # ('dev' is where benchmark-action/github-action-benchmark stores its
+            # chart + accumulated data.js — wiping it loses chart history on every release.)
             Get-ChildItem -Path $WORK_DIR -Force | Where-Object {
-              $_.Name -notin @('.git', 'CNAME', '.nojekyll', 'versions')
+              $_.Name -notin @('.git', 'CNAME', '.nojekyll', 'versions', 'dev')
             } | Remove-Item -Recurse -Force
 
             # Ensure .nojekyll exists so GitHub Pages does not run Jekyll


### PR DESCRIPTION
## Summary
The DocFX deploy step's stale-file cleanup at the gh-pages root keeps only \`.git\`, \`CNAME\`, \`.nojekyll\`, and \`versions/\`. Everything else is deleted — including \`dev/\`, which is where [\`benchmark-action/github-action-benchmark\`](https://github.com/benchmark-action/github-action-benchmark) stores \`data.js\` (the accumulated chart history) and its rendered chart at \`/dev/bench/\`.

So every release silently wipes the benchmark chart. The next benchmark workflow run after the release re-seeds it with a single data point. Yesterday's \`v0.2.1\` release reduced this repo's chart from 5 entries to 1.

Add \`'dev'\` to the preserve list.

## Why local first, canonical separately
A matching PR will land in \`repo-template\` so every Wolfgang.* repo with a benchmarks workflow benefits. Patching here too means this repo's next release does not wipe the chart again before the canonical fix syncs back.

## Test plan
- [x] One-line preserve-list change verified locally.
- [ ] CI green (maintainer override expected for the workflow-touch guard).
- [ ] On next release, confirm \`gh-pages:/dev/bench/data.js\` retains its entries.