### PR TITLE
chore: bump Abstractions to 0.14.1 and TestKit/Xunit to 0.9.0

### DIFF
--- a/examples/BasicExtraction/BasicExtraction.csproj
+++ b/examples/BasicExtraction/BasicExtraction.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.8.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.9.0" />
   </ItemGroup>
 
   <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->

--- a/examples/BasicLoading/BasicLoading.csproj
+++ b/examples/BasicLoading/BasicLoading.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.8.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.9.0" />
   </ItemGroup>
 
   <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
@@ -27,12 +27,12 @@ namespace Wolfgang.Etl.FixedWidth;
 /// </para>
 /// <list type="bullet">
 ///   <item><b>TextReader constructor</b> — the caller owns the <see cref="TextReader"/>
-///   lifetime. The extractor does not dispose it. Calling <see cref="Dispose()"/> is
+///   lifetime. The extractor does not dispose it. Calling <see cref="System.IDisposable.Dispose"/> is
 ///   optional and has no effect.</item>
 ///   <item><b>Stream constructor</b> — the extractor creates an internal
 ///   <see cref="StreamReader"/> with a 64 KB buffer for improved throughput on large files.
 ///   The caller retains ownership of the <see cref="Stream"/> (it is not closed), but
-///   <see cref="Dispose()"/> must be called to release the internal reader.</item>
+///   <see cref="System.IDisposable.Dispose"/> must be called to release the internal reader.</item>
 /// </list>
 /// </remarks>
 /// <example>
@@ -45,7 +45,7 @@ namespace Wolfgang.Etl.FixedWidth;
 /// var extractor = new FixedWidthExtractor&lt;CustomerRecord&gt;(reader);
 /// </code>
 /// </example>
-public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthReport>, IDisposable
+public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthReport>
     where TRecord : notnull, new()
 {
     // ------------------------------------------------------------------
@@ -506,32 +506,22 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
 
 
     /// <summary>
-    /// Disposes the internal <see cref="StreamReader"/> when this instance was
-    /// constructed from a <see cref="Stream"/>. Has no effect when constructed
-    /// from a caller-owned <see cref="TextReader"/>.
-    /// </summary>
-    public void Dispose()
-    {
-        Dispose(disposing: true);
-        GC.SuppressFinalize(this);
-    }
-
-
-
-    /// <summary>
-    /// Releases managed resources when <paramref name="disposing"/> is
-    /// <see langword="true"/>. Override in a derived class to add cleanup logic.
+    /// Releases the internal <see cref="StreamReader"/> when this instance was
+    /// constructed from a <see cref="Stream"/>, then defers to the base class.
+    /// Has no effect on a caller-owned <see cref="TextReader"/>.
     /// </summary>
     /// <param name="disposing">
-    /// <see langword="true"/> when called from <see cref="Dispose()"/>;
+    /// <see langword="true"/> when called from <see cref="System.IDisposable"/>;
     /// <see langword="false"/> when called from a finalizer.
     /// </param>
-    protected virtual void Dispose(bool disposing)
+    protected override void Dispose(bool disposing)
     {
         if (disposing && _ownsReader)
         {
             _reader.Dispose();
         }
+
+        base.Dispose(disposing);
     }
 
 

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthLoader.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthLoader.cs
@@ -20,13 +20,13 @@ namespace Wolfgang.Etl.FixedWidth;
 /// </para>
 /// <list type="bullet">
 ///   <item><b>TextWriter constructor</b> — the caller owns the <see cref="TextWriter"/>
-///   lifetime. The loader does not dispose it, and calling <see cref="Dispose()"/> is
+///   lifetime. The loader does not dispose it, and calling <see cref="System.IDisposable.Dispose"/> is
 ///   optional (no-op). The caller is responsible for flushing the writer.</item>
 ///   <item><b>Stream constructor</b> — the loader creates an internal
 ///   <see cref="StreamWriter"/> with a 64 KB buffer for improved throughput.
 ///   The caller retains ownership of the <see cref="Stream"/> (it is not closed).
 ///   The internal writer is flushed automatically at the end of
-///   <c>LoadWorkerAsync</c>, and <see cref="Dispose()"/> must be called to release it.</item>
+///   <c>LoadWorkerAsync</c>, and <see cref="System.IDisposable.Dispose"/> must be called to release it.</item>
 /// </list>
 /// <code>
 /// // Stream-based (preferred for files — 64 KB buffer reduces syscall overhead):
@@ -45,7 +45,7 @@ namespace Wolfgang.Etl.FixedWidth;
 /// loader.FieldDelimiter = " | ";
 /// </code>
 /// </remarks>
-public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, IDisposable
+public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>
     where TRecord : notnull
 {
     // ------------------------------------------------------------------
@@ -408,32 +408,22 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
 
 
     /// <summary>
-    /// Disposes the internal <see cref="StreamWriter"/> when this instance was
-    /// constructed from a <see cref="Stream"/>. Has no effect when constructed
-    /// from a caller-owned <see cref="TextWriter"/>.
-    /// </summary>
-    public void Dispose()
-    {
-        Dispose(disposing: true);
-        GC.SuppressFinalize(this);
-    }
-
-
-
-    /// <summary>
-    /// Releases managed resources when <paramref name="disposing"/> is
-    /// <see langword="true"/>. Override in a derived class to add cleanup logic.
+    /// Releases the internal <see cref="StreamWriter"/> when this instance was
+    /// constructed from a <see cref="Stream"/>, then defers to the base class.
+    /// Has no effect on a caller-owned <see cref="TextWriter"/>.
     /// </summary>
     /// <param name="disposing">
-    /// <see langword="true"/> when called from <see cref="Dispose()"/>;
+    /// <see langword="true"/> when called from <see cref="System.IDisposable"/>;
     /// <see langword="false"/> when called from a finalizer.
     /// </param>
-    protected virtual void Dispose(bool disposing)
+    protected override void Dispose(bool disposing)
     {
         if (disposing && _ownsWriter)
         {
             _writer.Dispose();
         }
+
+        base.Dispose(disposing);
     }
 
 

--- a/src/Wolfgang.Etl.FixedWidth/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Etl.FixedWidth/PublicAPI.Shipped.txt
@@ -20,20 +20,20 @@ Wolfgang.Etl.FixedWidth.Attributes.FixedWidthSkipAttribute.Length.get -> int
 Wolfgang.Etl.FixedWidth.Attributes.FixedWidthSkipAttribute.Message.get -> string?
 Wolfgang.Etl.FixedWidth.Attributes.FixedWidthSkipAttribute.Message.set -> void
 Wolfgang.Etl.FixedWidth.Enums.BlankLineHandling
-Wolfgang.Etl.FixedWidth.Enums.BlankLineHandling.ReturnDefault -> Wolfgang.Etl.FixedWidth.Enums.BlankLineHandling
-Wolfgang.Etl.FixedWidth.Enums.BlankLineHandling.Skip -> Wolfgang.Etl.FixedWidth.Enums.BlankLineHandling
-Wolfgang.Etl.FixedWidth.Enums.BlankLineHandling.ThrowException -> Wolfgang.Etl.FixedWidth.Enums.BlankLineHandling
+Wolfgang.Etl.FixedWidth.Enums.BlankLineHandling.ReturnDefault = 2 -> Wolfgang.Etl.FixedWidth.Enums.BlankLineHandling
+Wolfgang.Etl.FixedWidth.Enums.BlankLineHandling.Skip = 1 -> Wolfgang.Etl.FixedWidth.Enums.BlankLineHandling
+Wolfgang.Etl.FixedWidth.Enums.BlankLineHandling.ThrowException = 0 -> Wolfgang.Etl.FixedWidth.Enums.BlankLineHandling
 Wolfgang.Etl.FixedWidth.Enums.FieldAlignment
-Wolfgang.Etl.FixedWidth.Enums.FieldAlignment.Left -> Wolfgang.Etl.FixedWidth.Enums.FieldAlignment
-Wolfgang.Etl.FixedWidth.Enums.FieldAlignment.Right -> Wolfgang.Etl.FixedWidth.Enums.FieldAlignment
+Wolfgang.Etl.FixedWidth.Enums.FieldAlignment.Left = 0 -> Wolfgang.Etl.FixedWidth.Enums.FieldAlignment
+Wolfgang.Etl.FixedWidth.Enums.FieldAlignment.Right = 1 -> Wolfgang.Etl.FixedWidth.Enums.FieldAlignment
 Wolfgang.Etl.FixedWidth.Enums.LineAction
-Wolfgang.Etl.FixedWidth.Enums.LineAction.Process -> Wolfgang.Etl.FixedWidth.Enums.LineAction
-Wolfgang.Etl.FixedWidth.Enums.LineAction.Skip -> Wolfgang.Etl.FixedWidth.Enums.LineAction
-Wolfgang.Etl.FixedWidth.Enums.LineAction.Stop -> Wolfgang.Etl.FixedWidth.Enums.LineAction
+Wolfgang.Etl.FixedWidth.Enums.LineAction.Process = 0 -> Wolfgang.Etl.FixedWidth.Enums.LineAction
+Wolfgang.Etl.FixedWidth.Enums.LineAction.Skip = 1 -> Wolfgang.Etl.FixedWidth.Enums.LineAction
+Wolfgang.Etl.FixedWidth.Enums.LineAction.Stop = 2 -> Wolfgang.Etl.FixedWidth.Enums.LineAction
 Wolfgang.Etl.FixedWidth.Enums.MalformedLineHandling
-Wolfgang.Etl.FixedWidth.Enums.MalformedLineHandling.ReturnDefault -> Wolfgang.Etl.FixedWidth.Enums.MalformedLineHandling
-Wolfgang.Etl.FixedWidth.Enums.MalformedLineHandling.Skip -> Wolfgang.Etl.FixedWidth.Enums.MalformedLineHandling
-Wolfgang.Etl.FixedWidth.Enums.MalformedLineHandling.ThrowException -> Wolfgang.Etl.FixedWidth.Enums.MalformedLineHandling
+Wolfgang.Etl.FixedWidth.Enums.MalformedLineHandling.ReturnDefault = 2 -> Wolfgang.Etl.FixedWidth.Enums.MalformedLineHandling
+Wolfgang.Etl.FixedWidth.Enums.MalformedLineHandling.Skip = 1 -> Wolfgang.Etl.FixedWidth.Enums.MalformedLineHandling
+Wolfgang.Etl.FixedWidth.Enums.MalformedLineHandling.ThrowException = 0 -> Wolfgang.Etl.FixedWidth.Enums.MalformedLineHandling
 Wolfgang.Etl.FixedWidth.Exceptions.FieldConversionException
 Wolfgang.Etl.FixedWidth.Exceptions.FieldConversionException.ExpectedType.get -> System.Type
 Wolfgang.Etl.FixedWidth.Exceptions.FieldConversionException.FieldConversionException(string message, long lineNumber, string lineContent, string fieldName, System.Type expectedType, string rawValue, System.Exception innerException) -> void
@@ -66,7 +66,6 @@ Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.BlankLineHandling.get -> Wolfgang.Etl.FixedWidth.Enums.BlankLineHandling
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.BlankLineHandling.set -> void
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.CurrentLineNumber.get -> long
-Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.Dispose() -> void
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.FieldDelimiter.get -> string?
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.FieldDelimiter.set -> void
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.FieldSeparator.get -> char?
@@ -87,7 +86,6 @@ Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.ValueParser.get -> Wolfgang
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.ValueParser.set -> void
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.CurrentLineNumber.get -> long
-Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.Dispose() -> void
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.FieldDelimiter.get -> string?
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.FieldDelimiter.set -> void
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.FieldSeparator.get -> char?
@@ -113,19 +111,8 @@ override Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.ExtractWorkerAsync
 override Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.CreateProgressReport() -> Wolfgang.Etl.FixedWidth.FixedWidthReport
 override Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.CreateProgressTimer(System.IProgress<Wolfgang.Etl.FixedWidth.FixedWidthReport> progress) -> Wolfgang.Etl.Abstractions.IProgressTimer
 override Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.LoadWorkerAsync(System.Collections.Generic.IAsyncEnumerable<TRecord> items, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task
-override Wolfgang.Etl.FixedWidth.FixedWidthReport.<Clone>$() -> Wolfgang.Etl.Abstractions.Report
-override Wolfgang.Etl.FixedWidth.FixedWidthReport.Equals(object? obj) -> bool
-override Wolfgang.Etl.FixedWidth.FixedWidthReport.GetHashCode() -> int
-override Wolfgang.Etl.FixedWidth.FixedWidthReport.PrintMembers(System.Text.StringBuilder builder) -> bool
-override Wolfgang.Etl.FixedWidth.FixedWidthReport.ToString() -> string
-override sealed Wolfgang.Etl.FixedWidth.FixedWidthReport.Equals(Wolfgang.Etl.Abstractions.Report? other) -> bool
-static Wolfgang.Etl.FixedWidth.FixedWidthReport.operator !=(Wolfgang.Etl.FixedWidth.FixedWidthReport? left, Wolfgang.Etl.FixedWidth.FixedWidthReport? right) -> bool
-static Wolfgang.Etl.FixedWidth.FixedWidthReport.operator ==(Wolfgang.Etl.FixedWidth.FixedWidthReport? left, Wolfgang.Etl.FixedWidth.FixedWidthReport? right) -> bool
 static readonly Wolfgang.Etl.FixedWidth.FixedWidthConverter.DefaultParser -> Wolfgang.Etl.FixedWidth.FixedWidthValueParser
 static readonly Wolfgang.Etl.FixedWidth.FixedWidthConverter.Strict -> System.Func<object, Wolfgang.Etl.FixedWidth.FieldContext, string>
 static readonly Wolfgang.Etl.FixedWidth.FixedWidthConverter.StrictHeader -> System.Func<string, Wolfgang.Etl.FixedWidth.FieldContext, string>
 static readonly Wolfgang.Etl.FixedWidth.FixedWidthConverter.Truncate -> System.Func<object, Wolfgang.Etl.FixedWidth.FieldContext, string>
 static readonly Wolfgang.Etl.FixedWidth.FixedWidthConverter.TruncateHeader -> System.Func<string, Wolfgang.Etl.FixedWidth.FieldContext, string>
-virtual Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.Dispose(bool disposing) -> void
-virtual Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.Dispose(bool disposing) -> void
-virtual Wolfgang.Etl.FixedWidth.FixedWidthReport.Equals(Wolfgang.Etl.FixedWidth.FixedWidthReport? other) -> bool

--- a/src/Wolfgang.Etl.FixedWidth/Wolfgang.Etl.FixedWidth.csproj
+++ b/src/Wolfgang.Etl.FixedWidth/Wolfgang.Etl.FixedWidth.csproj
@@ -46,8 +46,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
     <PackageReference Include="System.Memory" Version="4.6.3" />
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.13.0" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.8" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.14.1" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
   </ItemGroup>
 
   <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/Wolfgang.Etl.FixedWidth.Tests.Unit.csproj
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/Wolfgang.Etl.FixedWidth.Tests.Unit.csproj
@@ -14,14 +14,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0'" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')) And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
-    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.8.0" />
-    <PackageReference Include="Wolfgang.Etl.TestKit.Xunit" Version="0.8.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.9.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit.Xunit" Version="0.9.0" />
     <PackageReference Include="coverlet.collector" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Bumps to the latest published packages. **Abstractions 0.14.0 made the extractor/loader base classes `IDisposable`/`IAsyncDisposable`**, so this is more than a version bump — the hand-rolled dispose pattern had to be reconciled.

### Package bumps
- `Wolfgang.Etl.Abstractions` 0.13.0 → **0.14.1** (src)
- `Wolfgang.Etl.TestKit` / `.Xunit` 0.8.0 → **0.9.0** (tests) and examples
- `Microsoft.Bcl.AsyncInterfaces` 10.0.8 → **10.0.9** (TestKit 0.9.0's floor; NU1605 otherwise)

### Code changes required by the new IDisposable base
- `FixedWidthExtractor`/`FixedWidthLoader`: drop redundant `IDisposable` interface + own `Dispose()`; change `Dispose(bool)` from `virtual` → `override` and chain `base.Dispose(disposing)` (CA1063/CS0108/CS0114).
- Fixed XML doc `cref`s that pointed at the now-inherited `Dispose()`.

### PublicAPI baseline regeneration
- Dropped stale record-synthesized + `Dispose()`/`Dispose(bool)` entries.
- Added `= value` to enum members (newer analyzer format; RS0016 is disabled here so only RS0017 surfaced).

Verified locally: **303/303** tests pass; multi-TFM Release build clean (net462/netstandard2.0/net481/net8.0/net10.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)