### PR TITLE
docs: fix README + introduction inaccuracies (D4/D5, #111 #112)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This project is licensed under the **MIT License**. See the [LICENSE](LICENSE) f
 
 - **GitHub Repository:** [https://github.com/Chris-Wolfgang/ETL-FixedWidth](https://github.com/Chris-Wolfgang/ETL-FixedWidth)
 - **API Documentation:** https://Chris-Wolfgang.github.io/ETL-FixedWidth/
-- **Formatting Guide:** [README-FORMATTING.md](README-FORMATTING.md)
+- **Formatting Guide:** [README-FORMATTING.md](docs/README-FORMATTING.md)
 - **Contributing Guide:** [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ---
@@ -89,6 +89,8 @@ await foreach (var person in extractor.ExtractAsync(CancellationToken.None))
 var writer = new StringWriter();
 var loader = new FixedWidthLoader<PersonRecord>(writer);
 
+// LoadAsync accepts an IAsyncEnumerable<PersonRecord>; `sourceItems` is any
+// async sequence of records (for example, the output of a FixedWidthExtractor).
 await loader.LoadAsync(sourceItems, CancellationToken.None);
 
 Console.WriteLine(writer.ToString());
@@ -154,11 +156,15 @@ The [examples/](examples/) folder contains 9 runnable console projects demonstra
 
 ## 🎯 Target Frameworks
 
+The package targets the following frameworks (see the project file for the authoritative list):
+
 | Framework | Versions |
 |-----------|----------|
-| .Net Framework | .net 4.6.2, .net 4.7.0, .net 4.7.1, .net 4.7.2, .net 4.8, .net 4.8.1 |
-| .Net Core | |
-| .Net | .net 5.0, .net 6.0, .net 7.0, .net 8.0, .net 9.0, .net 10.0 |
+| .NET Framework | .NET 4.6.2, .NET 4.8.1 |
+| .NET Standard | .NET Standard 2.0 |
+| .NET | .NET 8.0, .NET 10.0 |
+
+> The CI test matrix additionally exercises the library on .NET Framework 4.7.x/4.8 and .NET 5.0–9.0 via the netstandard2.0 facade; those are tested-against runtimes, not package target frameworks.
 
 ---
 
@@ -195,7 +201,7 @@ This library uses **`BannedSymbols.txt`** to prohibit synchronous APIs and enfor
 ## 🛠️ Building from Source
 
 ### Prerequisites
-- [.NET 8.0 SDK](https://dotnet.microsoft.com/download) or later
+- [.NET 10.0 SDK](https://dotnet.microsoft.com/download) or later (required for the `net10.0` target framework)
 - Optional: [PowerShell Core](https://github.com/PowerShell/PowerShell) for formatting scripts
 
 ### Build Steps
@@ -215,7 +221,7 @@ dotnet build --configuration Release
 dotnet test --configuration Release
 
 # Run code formatting (PowerShell Core)
-pwsh ./format.ps1
+pwsh ./scripts/format.ps1
 ```
 
 ### Code Formatting
@@ -230,7 +236,7 @@ dotnet format
 dotnet format --verify-no-changes
 ```
 
-See [README-FORMATTING.md](README-FORMATTING.md) for detailed formatting guidelines.
+See [README-FORMATTING.md](docs/README-FORMATTING.md) for detailed formatting guidelines.
 
 ### Building Documentation
 

--- a/docfx_project/docs/introduction.md
+++ b/docfx_project/docs/introduction.md
@@ -19,7 +19,7 @@ Wolfgang.Etl.FixedWidth provides an extractor and loader for reading and writing
 - **Zero-copy parsing with ReadOnlyMemory&lt;char&gt;** — slices line data without allocating intermediate strings where possible
 - **Span-based numeric parsing on net8.0+** — uses `ISpanParsable<T>` for allocation-free numeric conversion on modern runtimes
 - **Compiled delegates for reflection-free field access** — property getters and setters are compiled once and cached for fast field access
-- **Multi-TFM support** — targets netstandard2.0, netstandard2.1, net8.0, net9.0, and net10.0
+- **Multi-TFM support** — targets net462, net481, netstandard2.0, net8.0, and net10.0
 
 ## Getting Help
 


### PR DESCRIPTION
## Summary

Closes #111 (D4: Audit README for accuracy) and #112 (D5: Audit other Markdown for accuracy).

Audited README.md and the non-README markdown (docs/*.md, CONTRIBUTING/SECURITY/CODE_OF_CONDUCT, docfx articles) against the **current** public API, csproj, and package metadata. The Quick Start code samples, feature table, and most docs verified accurate against `PublicAPI.Shipped.txt` and the runnable `examples/`. Substantive errors fixed:

| File | Was | Now |
|------|-----|-----|
| README.md (×2) | `[…](README-FORMATTING.md)` (root, broken) | `docs/README-FORMATTING.md` |
| README.md | `pwsh ./format.ps1` | `pwsh ./scripts/format.ps1` |
| README.md | "Target Frameworks" table = CI test matrix (net47x/48, net5–9) | actual package TFMs `net462;net481;netstandard2.0;net8.0;net10.0` + a note on tested-against runtimes |
| README.md | Build prereq ".NET 8.0 SDK" | ".NET 10.0 SDK" (net10.0 target) |
| README.md | `LoadAsync(sourceItems, …)` with undeclared list | comment clarifying it takes `IAsyncEnumerable<T>` |
| docfx introduction.md | "targets netstandard2.0, **netstandard2.1**, net8.0, **net9.0**, net10.0" | actual TFMs `net462, net481, netstandard2.0, net8.0, net10.0` |

Docs-only; no code change. Targets `vNext` to ride the v0.2.2 release.

> `Closes #111`/`#112` auto-fire when `vNext` merges to `main`.