### PR TITLE
test: add Stryker config + record baseline mutation score (T3, #107)

### DIFF
--- a/stryker-config.json
+++ b/stryker-config.json
@@ -1,0 +1,20 @@
+{
+  "stryker-config": {
+    "project": "Wolfgang.Etl.FixedWidth.csproj",
+    "test-projects": [
+      "tests/Wolfgang.Etl.FixedWidth.Tests.Unit/Wolfgang.Etl.FixedWidth.Tests.Unit.csproj"
+    ],
+    "target-framework": "net10.0",
+    "reporters": [
+      "html",
+      "json",
+      "progress"
+    ],
+    "thresholds": {
+      "high": 80,
+      "low": 60,
+      "break": 0
+    },
+    "mutation-level": "Standard"
+  }
+}


### PR DESCRIPTION
## Summary

Closes #107 (T3: Add Stryker mutation testing).

The canonical `stryker.yaml` workflow was already present (and is brought fully up to date in #181), but it never actually ran a mutation analysis for this repo — there was no config and no recorded score. This adds a root **umbrella `stryker-config.json`** so the workflow's umbrella mode and local `dotnet stryker` runs are reproducible, and records the first baseline.

### Baseline (dotnet-stryker 4.15.0 · net10.0 · Standard level)

**Mutation score: 72.87%**

| Status | Count |
|--------|------:|
| Killed | 491 |
| Survived | 153 |
| Timeout | 22 |
| NoCoverage | 38 |
| CompileError | 21 |
| Ignored | 186 |

Score = (Killed + Timeout) / (Killed + Survived + Timeout + NoCoverage) = 513 / 704.

### Triage — surviving / uncovered mutants by file

| File | Survived | NoCoverage | Timeout |
|------|---------:|-----------:|--------:|
| `FixedWidthLineParser.cs` | 57 | 19 | 8 |
| `FixedWidthExtractor.cs` | 35 | 12 | 0 |
| `FixedWidthLoader.cs` | 30 | 6 | 0 |
| `FixedWidthConverter.cs` | 15 | 1 | 10 |
| `FieldDescriptor` / `FieldMap` / attributes / `MemoryExtensions` | ≤6 each | — | — |

The **38 NoCoverage** mutants point at statement/branch paths the unit tests never execute (despite high line coverage) — the cheapest wins. The parser and the two pipeline classes hold the bulk of the survivors.

Driving the score up (writing tests to kill these survivors and setting a `break` threshold as a release gate) is the deeper follow-up tracked by **#145** (Stryker score as a release-gate quality bar); this issue's acceptance — *Stryker runs; score recorded; survivors triaged* — is satisfied here.

### Stacking
Based on `chore/bump-testkit-0.9.0` (#177). Config-only; no build impact.

> `Closes #107` auto-fires when the change reaches `main`.