### PR TITLE
ci: add ReSharper InspectCode parallel job to pr.yaml (#178)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1460,3 +1460,117 @@ jobs:
           name: devskim-results
           path: devskim-results.txt
           if-no-files-found: warn
+
+  # ReSharper InspectCode — a non-Roslyn static-analysis pass (data-flow,
+  # dead-code, structural rules) that runs in PARALLEL with the test stages
+  # (no `needs:` on them). Findings upload to GitHub Code Scanning and annotate
+  # the PR diff. Runs on windows-latest because the src/test projects target
+  # net462/net481, which a Linux runner cannot build. The `.DotSettings`
+  # noise-floor profile is fetched from main alongside the other protected
+  # configs so a PR cannot silence rules via its own copy.
+  inspectcode:
+    name: "ReSharper InspectCode"
+    runs-on: windows-latest
+    needs: detect-projects
+    if: github.repository != 'Chris-Wolfgang/repo-template' && needs.detect-projects.outputs.has-projects == 'true'
+    permissions:
+      contents: read
+      security-events: write   # required for github/codeql-action/upload-sarif
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/head
+          persist-credentials: false
+
+      - name: Fetch trusted configuration files from main branch
+        # Skip for Dependabot — its package-version bumps to protected files are
+        # legitimate and should not be overwritten by main's older versions.
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
+        shell: bash
+        run: |
+          echo "Fetching configuration files from main branch to prevent malicious overrides..."
+          git fetch origin main:main-branch
+
+          # Includes *.DotSettings so a PR cannot weaken the InspectCode profile.
+          config_files=(
+            ".editorconfig"
+            "Directory.Build.props"
+            "Directory.Build.targets"
+            "BannedSymbols.txt"
+            "*.globalconfig"
+            "*.ruleset"
+            "*.DotSettings"
+            ".github/workflows/*.yml"
+            ".github/workflows/*.yaml"
+          )
+
+          for config_file in "${config_files[@]}"; do
+            if [[ "$config_file" == *"*"* ]]; then
+              while read -r file; do
+                if [ -n "$file" ]; then
+                  echo "  ✓ Copying $file from main branch"
+                  mkdir -p "$(dirname "$file")"
+                  if ! git show "main-branch:$file" > "$file"; then
+                    echo "::error::Failed to copy $file from main-branch — aborting to prevent silent fall-back to PR-supplied protected config."
+                    exit 1
+                  fi
+                fi
+              done < <(git ls-tree -r --name-only main-branch | { grep -E "${config_file//\*/.*}" || true; })
+            else
+              if git cat-file -e "main-branch:$config_file" 2>/dev/null; then
+                echo "  ✓ Copying $config_file from main branch"
+                if ! git show "main-branch:$config_file" > "$config_file"; then
+                  echo "::error::Failed to copy $config_file from main-branch — aborting to prevent silent fall-back to PR-supplied protected config."
+                  exit 1
+                fi
+              else
+                echo "  ℹ️  $config_file not found in main branch, skipping"
+              fi
+            fi
+          done
+          echo "✅ Configuration files secured - using versions from main branch"
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore + Build (Release)
+        shell: bash
+        run: |
+          dotnet restore
+          dotnet build -c Release --no-restore
+
+      - name: Install JetBrains.ReSharper.GlobalTools
+        run: dotnet tool install -g JetBrains.ReSharper.GlobalTools
+
+      - name: Run InspectCode
+        shell: bash
+        run: |
+          SLN=$(ls *.slnx 2>/dev/null | head -1)
+          echo "Inspecting $SLN"
+          jb inspectcode "$SLN" \
+            --output=inspect.sarif \
+            --format=sarif \
+            --severity=WARNING \
+            --no-build
+
+      - name: Upload SARIF to Code Scanning
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: inspect.sarif
+
+      - name: Gate on error-severity findings
+        shell: bash
+        run: |
+          # Only `error`-severity findings fail the job; warnings surface in
+          # Code Scanning but do not block (tune up to error once the noise
+          # floor settles).
+          count=$(jq '[.runs[].results[] | select(.level=="error")] | length' inspect.sarif)
+          echo "InspectCode error-severity findings: $count"
+          if [ "$count" -gt 0 ]; then
+            echo "::error::$count InspectCode error(s) — see Security → Code scanning alerts"
+            exit 1
+          fi

--- a/ETL Fixed Width.slnx.DotSettings
+++ b/ETL Fixed Width.slnx.DotSettings
@@ -1,0 +1,38 @@
+<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+
+	<!--
+	  ReSharper InspectCode noise-floor profile.
+
+	  Goal: 0 noise findings on a clean main, so the first finding after the
+	  inspectcode job lands is always actionable. Rules below are silenced
+	  because the existing Roslyn analyzer stack (.editorconfig + Roslynator +
+	  Meziantou + SonarAnalyzer + AsyncFixer + VS.Threading + BannedApiAnalyzers
+	  + PublicApiAnalyzers) already governs them; reporting them again is
+	  duplicate noise.
+
+	  This is a STARTER profile. After the first CI run, review the Code
+	  Scanning alerts and tune (silence remaining duplicates, or promote a
+	  genuinely valuable InspectCode-only rule to WARNING/ERROR).
+	-->
+
+	<!-- Naming — owned by IDE1006 + .editorconfig naming rules -->
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=InconsistentNaming/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+
+	<!-- Formatting / style — owned by .editorconfig + Roslynator -->
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantUsingDirective/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeThisQualifier/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeRedundantParentheses/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=BuiltInTypeReferenceStyle/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=RedundantNameQualifier/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+
+	<!-- Public-surface "unused" noise — a library's public API is unused within
+	     its own assembly by definition; the public surface is governed by
+	     PublicApiAnalyzers (PublicAPI.*.txt), not by InspectCode. -->
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedMember_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedType_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedAutoPropertyAccessor_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MemberCanBePrivate_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ClassNeverInstantiated_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=AutoPropertyCanBeMadeGetOnly_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+
+</wpf:ResourceDictionary>


### PR DESCRIPTION
## Summary

Closes #178.

Adds an `inspectcode` job to `pr.yaml` that runs JetBrains ReSharper InspectCode (a non-Roslyn static-analysis pass — data-flow, dead-code, structural rules) **in parallel** with the test stages. Findings upload to GitHub Code Scanning as SARIF and inline-annotate the PR diff.

### Design choices (repo-specific)
- **`runs-on: windows-latest`** — the src/test projects target `net462`/`net481`, which a Linux runner can't build. (Same reason `codeql.yaml` runs on Windows.) The issue's Linux sketch would fail the `dotnet build` step here.
- **Mirrors the `pull_request_target` trusted-checkout model** used by the test/security jobs: checks out the PR head, then overwrites protected configs from `main`. **`*.DotSettings` is added to that trusted list** so a malicious PR can't silence InspectCode rules via its own copy.
- **Gates only on `error`-severity findings**; warnings surface in Code Scanning but don't block (per the issue: tune up to `error` once the noise floor settles).
- **`ETL Fixed Width.slnx.DotSettings`** — starter noise-floor profile (named to match the `.slnx` so InspectCode auto-loads it). Silences rules already owned by the Roslyn stack (`.editorconfig` formatting, IDE1006 naming, `RedundantUsingDirective`, and the public-surface "unused" rules — a library's public API is governed by PublicApiAnalyzers, not InspectCode).

### ⚠️ Validation gaps to close after merge
- `pr.yaml` only runs under `pull_request_target` on PRs **to `main`**, so this job is **first exercised when `vNext` → `main` (PR #134) runs** — it cannot be CI-validated on a PR to `vNext`. Expect to tune the `.DotSettings` noise floor and confirm `--format=sarif` / `jb` behavior after that first real run.
- Acceptance item **"add 'ReSharper InspectCode' as a required status check on `main`"** is a branch-ruleset admin action — **not** done here (needs maintainer).
- The canonical-first plan (repo-template, then fan-out) is bypassed per your instruction to implement repo-locally now; consider feeding this back to `repo-template`.

### Stacking
Based on `chore/bump-testkit-0.9.0` (#177). Touches the protected `pr.yaml`; the `Detect .NET Projects` guard fires only on PRs to `main`, so it rides the existing v0.2.2 maintainer-bypass merge.

> `Closes #178` auto-fires when the change reaches `main`.