### PR TITLE
chore: bump Meziantou 3.0.115 + VS.Threading.Analyzers 18.7.23 (supersedes #185)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -41,7 +41,7 @@
     </PackageReference>
     
     <!-- Microsoft Threading Analyzers - Thread safety -->
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.14.15">
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="18.7.23">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -53,7 +53,7 @@
     </PackageReference>
     
     <!-- Meziantou - Comprehensive code quality -->
-    <PackageReference Include="Meziantou.Analyzer" Version="3.0.98">
+    <PackageReference Include="Meziantou.Analyzer" Version="3.0.115">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
## Summary

Retargets the Dependabot bump **#185** onto the **vNext** (v0.2.2) train, the correct destination during the release cycle.

#185 targets `main` and is **blocked**: it bumps `Wolfgang.Etl.Abstractions` 0.13.0→0.14.1 (whose base classes became `IDisposable`) without the code reconciliation that requires, so the extractor/loader fail to build (CA1063 / CS0108 / CS0114 / S3881 on every TFM). #185 couldn't be cleanly retargeted in place — its branch is cut from `main`, which has diverged from `vNext` by 16 files.

Decomposing #185's five bumps:
| Bump | Where it lands |
|------|----------------|
| Abstractions 0.13→**0.14.1** + reconciliation | already on vNext via **#177** |
| TestKit / TestKit.Xunit 0.8→**0.9.0** | already on vNext via **#177** |
| **Meziantou 3.0.98→3.0.115** | **this PR** |
| **VS.Threading.Analyzers 17.14.15→18.7.23** (major) | **this PR** |

Bumping here also lifts vNext's analyzer versions to/above `main`'s (main has Meziantou 3.0.105 / VS.Threading 17.14.15), which **avoids a `Directory.Build.props` downgrade conflict when vNext merges to main (#134)**.

**Verified locally:** src + test Release build clean (0 warnings) across all TFMs; **303/303 tests pass** — the major VS.Threading 17→18 bump introduced no new diagnostics.

Once merged, **#185 is fully superseded** and will be closed.