### PR TITLE
docs: correct stale NuGet + target-framework claims (#101)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Extractor and Loader for reading and writing fixed width files and text streams
 dotnet add package Wolfgang.Etl.FixedWidth
 ```
 
-**NuGet Package:** Coming soon to NuGet.org
+**NuGet Package:** [Wolfgang.Etl.FixedWidth on NuGet.org](https://www.nuget.org/packages/Wolfgang.Etl.FixedWidth/)
 
 ---
 

--- a/docfx_project/docs/getting-started.md
+++ b/docfx_project/docs/getting-started.md
@@ -4,7 +4,7 @@ This guide will help you quickly get up and running with Wolfgang.Etl.FixedWidth
 
 ## Prerequisites
 
-- .NET 8.0 SDK or later (netstandard2.0 and netstandard2.1 packages are also available for older runtimes)
+- .NET 8.0 SDK or later to follow this guide (the package also targets net462, net481, and netstandard2.0 for older runtimes)
 
 ## Installation
 


### PR DESCRIPTION
## Summary

Code-review (#101) doc-accuracy findings:

- **README.md** — "**NuGet Package:** Coming soon to NuGet.org" was stale; the package is **published** (0.1.0 / 0.2.0 / 0.2.1 on nuget.org, verified via the flat-container API). Now links to the package page.
- **docfx getting-started.md** — claimed a **netstandard2.1** package is available; the package never targeted netstandard2.1. Corrected to the real older-runtime targets (net462, net481, netstandard2.0).

Docs-only. Stacked on #189.

> Remaining XML-doc nits from the review (empty `<exception>`/`<param>` tags on a few internal methods; the loader `<remarks>` using `<code>` outside `<example>`; the `DefaultParser` exception-doc listing only `FormatException`) are cosmetic — render fine, no analyzer pressure — and deferred unless you want them.