### PR TITLE
test: tighten weak separator-line assertion (#101)

### DIFF
--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthLoaderTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthLoaderTests.cs
@@ -442,7 +442,11 @@ public class FixedWidthLoaderTests
             3,
             lines.Length
         );
-        Assert.True(lines[1].Replace('-', ' ').Trim().Length == 0 || lines[1].All(c => c == '-'));
+        Assert.Equal
+        (
+            new string('-', 23),
+            lines[1]
+        );
         Assert.Equal
         (
             "John      Smith     042",


### PR DESCRIPTION
## Summary

Code-review (#101) test-quality finding.

`LoadAsync_when_FieldSeparator_is_set_writes_separator_line_after_the_header` asserted the separator line with:

```csharp
Assert.True(lines[1].Replace('-', ' ').Trim().Length == 0 || lines[1].All(c => c == '-'));
```

— a message-less `Assert.True` whose two disjuncts both pass for an all-spaces line, so it wouldn't catch a wrong/missing separator. Replaced with the exact expectation matching the 23-char record width (and the style of the sibling `WriteSeparator` tests):

```csharp
Assert.Equal(new string('-', 23), lines[1]);
```

Verified: passes (the separator is exactly 23 dashes). Stacked on #190.

> The other Phase-1.7 finding — `Microsoft.Bcl.AsyncInterfaces` / `Microsoft.Extensions.Logging.Abstractions` referenced in both src and test — is **won't-fix**: both are legitimate *direct* deps of the test project (it uses `ILogger` directly and needs `Bcl.AsyncInterfaces` for `IAsyncEnumerable` on its net4x/netstandard2.0 TFMs), and the NU1605 risk is already mitigated by the Dependabot `dotnet-dependencies` group bumping them in lockstep.