### PR TITLE
docs: add compressed-stream (GZip/Brotli) examples (#32)

### DIFF
--- a/ETL Fixed Width.slnx
+++ b/ETL Fixed Width.slnx
@@ -40,6 +40,7 @@
   <Folder Name="/examples/">
     <Project Path="examples/BasicExtraction/BasicExtraction.csproj" />
     <Project Path="examples/BasicLoading/BasicLoading.csproj" />
+    <Project Path="examples/CompressedStreams/CompressedStreams.csproj" />
     <Project Path="examples/CustomParsersConverters/CustomParsersConverters.csproj" />
     <Project Path="examples/ErrorHandling/ErrorHandling.csproj" />
     <Project Path="examples/FieldDelimiter/FieldDelimiter.csproj" />

--- a/README.md
+++ b/README.md
@@ -138,12 +138,13 @@ using var loader = new FixedWidthLoader<PersonRecord>(writeStream);
 
 **Examples:**
 
-The [examples/](examples/) folder contains 9 runnable console projects demonstrating each feature:
+The [examples/](examples/) folder contains 10 runnable console projects demonstrating each feature:
 
 | Example | Description |
 |---------|-------------|
 | [BasicExtraction](examples/BasicExtraction) | Read fixed-width data into strongly typed records |
 | [BasicLoading](examples/BasicLoading) | Write records to fixed-width output |
+| [CompressedStreams](examples/CompressedStreams) | Extract from / load to GZip and Brotli compressed streams |
 | [RoundTrip](examples/RoundTrip) | Extract, transform, and reload records end-to-end |
 | [CustomParsersConverters](examples/CustomParsersConverters) | Custom `ValueParser` and `ValueConverter` delegates |
 | [ProgressReporting](examples/ProgressReporting) | Timer-based `IProgress<FixedWidthReport>` callbacks |
@@ -151,6 +152,26 @@ The [examples/](examples/) folder contains 9 runnable console projects demonstra
 | [FieldDelimiter](examples/FieldDelimiter) | Delimited output (e.g. `" \| "`) for human-readable tables |
 | [SkipAndMax](examples/SkipAndMax) | `SkipItemCount` and `MaximumItemCount` for pagination |
 | [HeadersAndSeparators](examples/HeadersAndSeparators) | `WriteHeader`, `HasHeader`, and `FieldSeparator` |
+
+### Advanced: compressed streams
+
+The extractor and loader accept any `Stream`, so they work transparently over `GZipStream` / `BrotliStream` — no special support needed:
+
+```csharp
+// Load to a GZip-compressed file
+await using var file = File.Create("output.dat.gz");
+using var gzip = new GZipStream(file, CompressionMode.Compress);
+using var loader = new FixedWidthLoader<PersonRecord>(gzip);
+await loader.LoadAsync(records, token);
+
+// Extract from a GZip-compressed file
+await using var input = File.OpenRead("output.dat.gz");
+using var gunzip = new GZipStream(input, CompressionMode.Decompress);
+using var extractor = new FixedWidthExtractor<PersonRecord>(gunzip);
+await foreach (var record in extractor.ExtractAsync(token)) { /* ... */ }
+```
+
+See the [CompressedStreams](examples/CompressedStreams) example for a runnable GZip + Brotli round-trip.
 
 ---
 

--- a/docfx_project/docs/examples.md
+++ b/docfx_project/docs/examples.md
@@ -14,6 +14,12 @@ Demonstrates the simplest loading workflow: writing strongly typed records to fi
 
 [View source](https://github.com/Chris-Wolfgang/ETL-FixedWidth/tree/main/examples/BasicLoading)
 
+## CompressedStreams
+
+Demonstrates that the extractor and loader work transparently over compressed streams — a full GZip and Brotli round-trip (load records through a compression stream, then extract them back) using only the `Stream` constructors. Shows the dispose ordering that finalizes the compressed container.
+
+[View source](https://github.com/Chris-Wolfgang/ETL-FixedWidth/tree/main/examples/CompressedStreams)
+
 ## RoundTrip
 
 Shows a full round-trip pipeline: extracting records from fixed-width text, then loading them back out to produce identical output. Validates that extraction and loading are symmetric.

--- a/docfx_project/docs/getting-started.md
+++ b/docfx_project/docs/getting-started.md
@@ -90,6 +90,31 @@ Console.WriteLine($"Total loaded: {loader.CurrentItemCount}");
 
 In production, replace `StringReader` / `StringWriter` with a `FileStream` or `StreamReader` — the extractor and loader accept any `TextReader` / `TextWriter`, or a raw `Stream` directly.
 
+### Working with compressed streams
+
+Because the extractor and loader accept any `Stream`, compression works out of the box — just wrap the file stream in a `GZipStream` or `BrotliStream` (compressed mainframe exports often arrive as `.dat.gz`):
+
+```csharp
+using System.IO.Compression;
+
+// Load to a GZip-compressed file
+await using var output = File.Create("people.dat.gz");
+using var gzip = new GZipStream(output, CompressionMode.Compress);
+using var loader = new FixedWidthLoader<PersonRecord>(gzip);
+await loader.LoadAsync(records, CancellationToken.None);
+
+// Extract from a GZip-compressed file
+await using var input = File.OpenRead("people.dat.gz");
+using var gunzip = new GZipStream(input, CompressionMode.Decompress);
+using var extractor = new FixedWidthExtractor<PersonRecord>(gunzip);
+await foreach (var person in extractor.ExtractAsync(CancellationToken.None))
+{
+    // ...
+}
+```
+
+`BrotliStream` works identically — only the wrapper type changes. See the [CompressedStreams](https://github.com/Chris-Wolfgang/ETL-FixedWidth/tree/main/examples/CompressedStreams) example for a runnable GZip + Brotli round-trip.
+
 ## Next Steps
 
 - Browse the [Examples](examples.md) for more detailed scenarios

--- a/examples/CompressedStreams/CompressedStreams.csproj
+++ b/examples/CompressedStreams/CompressedStreams.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.FixedWidth\Wolfgang.Etl.FixedWidth.csproj" />
+  </ItemGroup>
+
+  <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
+
+
+</Project>

--- a/examples/CompressedStreams/Program.cs
+++ b/examples/CompressedStreams/Program.cs
@@ -1,0 +1,140 @@
+// ---------------------------------------------------------------------------
+// CompressedStreams Example
+// ---------------------------------------------------------------------------
+//
+// This example demonstrates that Wolfgang.Etl.FixedWidth works transparently
+// over compressed streams. Because the extractor and loader accept any
+// System.IO.Stream, you can wrap a GZipStream / BrotliStream around a file or
+// network stream and the library neither knows nor cares — compression is
+// purely a property of the underlying stream.
+//
+// Compressed fixed-width exports are common: EBCDIC / ASCII mainframe extracts
+// frequently arrive as `.dat.gz` archives.
+//
+// Key concepts covered:
+//   - Loading records THROUGH a compression stream into a destination stream
+//   - Extracting records BACK from the decompressed stream (a full round-trip)
+//   - The dispose ordering that matters for compression:
+//       * the loader's Stream constructor wraps the stream with leaveOpen:true,
+//         so disposing the loader flushes its 64 KB buffer but does NOT close
+//         the compression stream;
+//       * the compression stream must therefore be disposed AFTER the loader so
+//         it writes its trailer (footer) and produces a valid archive.
+//     The nested `using` blocks below get this ordering right automatically
+//     (inner `using` disposes first).
+//   - GZip and Brotli are interchangeable — only the wrapper type changes.
+//
+// In production the inner MemoryStream would be a FileStream:
+//
+//   await using var file = File.Create("output.dat.gz");
+//   using var gzip = new GZipStream(file, CompressionMode.Compress);
+//   using var loader = new FixedWidthLoader<Person>(gzip);
+//   await loader.LoadAsync(records, token);
+//
+// ...and on the read side:
+//
+//   await using var file = File.OpenRead("output.dat.gz");
+//   using var gzip = new GZipStream(file, CompressionMode.Decompress);
+//   using var extractor = new FixedWidthExtractor<Person>(gzip);
+//   await foreach (var record in extractor.ExtractAsync(token)) { ... }
+// ---------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.FixedWidth;
+using Wolfgang.Etl.FixedWidth.Attributes;
+using Wolfgang.Etl.FixedWidth.Enums;
+
+var people = new List<Person>
+{
+    new() { FirstName = "Alice", LastName = "Anderson", Age = 30 },
+    new() { FirstName = "Bob", LastName = "Baker", Age = 42 },
+    new() { FirstName = "Charlie", LastName = "Clark", Age = 25 },
+};
+
+// ---------------------------------------------------------------------------
+// GZip round-trip
+// ---------------------------------------------------------------------------
+Console.WriteLine("=== GZip ===");
+var gzip = await CompressAsync(people, raw => new GZipStream(raw, CompressionMode.Compress, leaveOpen: true));
+Console.WriteLine($"Loaded {people.Count} records into {gzip.Length} GZip-compressed bytes.");
+Console.WriteLine("Extracted back from the compressed bytes:");
+await ExtractAndPrintAsync(gzip, raw => new GZipStream(raw, CompressionMode.Decompress, leaveOpen: true));
+
+Console.WriteLine();
+
+// ---------------------------------------------------------------------------
+// Brotli round-trip — identical code, only the wrapper type differs
+// ---------------------------------------------------------------------------
+Console.WriteLine("=== Brotli ===");
+var brotli = await CompressAsync(people, raw => new BrotliStream(raw, CompressionMode.Compress, leaveOpen: true));
+Console.WriteLine($"Loaded {people.Count} records into {brotli.Length} Brotli-compressed bytes.");
+Console.WriteLine("Extracted back from the compressed bytes:");
+await ExtractAndPrintAsync(brotli, raw => new BrotliStream(raw, CompressionMode.Decompress, leaveOpen: true));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Loads the records through the compression stream and returns the compressed
+// bytes. The nested using blocks dispose the loader first (flushing its buffer
+// into the compression stream), then the compression stream (writing the
+// trailer) — both leave the underlying MemoryStream open so we can read it.
+static async Task<byte[]> CompressAsync(IEnumerable<Person> source, Func<Stream, Stream> wrapForCompression)
+{
+    using var raw = new MemoryStream();
+
+    using (var compression = wrapForCompression(raw))
+    using (var loader = new FixedWidthLoader<Person>(compression))
+    {
+        await loader.LoadAsync(ToAsyncEnumerable(source), CancellationToken.None);
+    }
+
+    return raw.ToArray();
+}
+
+// Decompresses the bytes and extracts the records back out.
+static async Task ExtractAndPrintAsync(byte[] compressed, Func<Stream, Stream> wrapForDecompression)
+{
+    using var raw = new MemoryStream(compressed);
+    using var decompression = wrapForDecompression(raw);
+    using var extractor = new FixedWidthExtractor<Person>(decompression);
+
+    await foreach (var person in extractor.ExtractAsync(CancellationToken.None))
+    {
+        Console.WriteLine($"  {person.FirstName.Trim()} {person.LastName.Trim()}, age {person.Age}");
+    }
+}
+
+// Wraps an in-memory sequence as an IAsyncEnumerable<T> for LoadAsync. In
+// production the source would already be async (a database reader, another
+// extractor, etc.).
+static async IAsyncEnumerable<T> ToAsyncEnumerable<T>(IEnumerable<T> source)
+{
+    foreach (var item in source)
+    {
+        yield return item;
+    }
+
+    await Task.CompletedTask;
+}
+
+public class Person
+{
+    [FixedWidthField(0, 10)]
+    public string FirstName { get; set; } = string.Empty;
+
+
+
+    [FixedWidthField(1, 10)]
+    public string LastName { get; set; } = string.Empty;
+
+
+
+    [FixedWidthField(2, 3, Alignment = FieldAlignment.Right, Pad = '0')]
+    public int Age { get; set; }
+}


### PR DESCRIPTION
## Summary

Closes #32. Re-opens the compressed-stream examples work for the **0.3.0** cycle — it was briefly merged as #193 then rolled back out of the v0.2.2 `vNext` to keep that release a patch. This is the same verified commit, rebased onto the fresh `vNext` (cut from `main` after v0.2.2).

The extractor/loader already work over compressed streams (the `Stream` constructors accept any `Stream`), so this is **documentation only** — no code or API change, hence the 0.3.0 minor (new example/surface, no behavior change).

- **`examples/CompressedStreams`** — runnable GZip + Brotli round-trip (load through a compression stream, extract back). Verified on this base: GZip 89 bytes / Brotli 75 bytes, records round-trip correctly. Documents the dispose ordering (the loader's `Stream` ctor uses `leaveOpen: true`, so the compression stream is disposed after the loader to write its trailer).
- README examples table 9 → 10 + an "Advanced: compressed streams" snippet.
- docfx getting-started "Working with compressed streams" subsection + examples.md entry.

First PR of the 0.3.0 `vNext` train. (No CI here — `pr.yaml` runs only on PRs to `main`; full validation happens at the eventual `vNext → main`.)