### PR TITLE
fix(docs): restore canonical version-picker bootstrap in docfx.json _appFooter

### DIFF
--- a/docfx_project/docfx.json
+++ b/docfx_project/docfx.json
@@ -53,7 +53,7 @@
       "_appLogoPath": "logo.svg",
       "_appFaviconPath": "favicon.svg",
       "_enableSearch": true,
-      "_appFooter": "Made with DocFX",
+      "_appFooter": "Made with DocFX <script>(function(){var r='/';if(window.location.hostname.endsWith('.github.io')){var s=window.location.pathname.split('/').filter(Boolean);if(s.length)r='/'+s[0]+'/';}var t=document.createElement('script');t.src=r+'public/version-picker.js';t.async=true;document.head.appendChild(t);})();</script>",
       "_disableSidebar": false,
       "_disableTocFilter": false,
       "_enableDarkMode": true,


### PR DESCRIPTION
## Summary

The `_appFooter` field in `docfx_project/docfx.json` got reverted to a bare `"Made with DocFX"` string at some point. Per [reference_docfx_version_picker](https://github.com/Chris-Wolfgang/claude-sessions) and the canonical [repo-template](https://github.com/Chris-Wolfgang/repo-template/blob/main/docfx_project/docfx.json), the version-picker dropdown is wired **only** via an inline `<script>` bootstrap inside `_appFooter` (DocFX's `main.js` slot is always an empty `export default {}` stub). Without the bootstrap, `docfx_project/public/version-picker.js` never loads, and the deployed docs site has no version-picker UI even though the JS, `versions.json`, and `docs/DOCFX-VERSION-PICKER.md` all describe it as wired.

This PR restores the canonical `_appFooter` string. Identical change going out to 13 affected Wolfgang.* repos as a fleet sweep.

## Verification

- `curl -s https://chris-wolfgang.github.io/<repo>/versions/latest/ | grep version-picker` returns 0 hits today (broken).
- After release deploy: should return at least 1 hit (the lazy-loaded `<script src=".../public/version-picker.js">` tag injected into `<head>`).
- For a local check before release: `cd docfx_project && docfx build && grep -l version-picker _site/**/*.html`.

## Origin

Discovered during Try-Pattern's v0.3.3 Tier-1 maintenance pilot, docs-accuracy audit ([PR #217](https://github.com/Chris-Wolfgang/Try-Pattern/pull/217) / sub-issue #128). `template-drift-scan` on `docfx.json` across all 30 Wolfgang.* repos showed 13 affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)