### PR TITLE
docs: add CompressedStreams example (GZip/Brotli round trip)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `CompressedStreams` example demonstrating GZip and Brotli round trips
+  (load to and extract from a compressed stream), plus documentation in the
+  README and the DocFX examples guide. Documentation only — no public-API or
+  runtime-behavior change ([#32](https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/32)).
+
 ### Changed
 
 ### Deprecated

--- a/ETL Fixed Width.slnx
+++ b/ETL Fixed Width.slnx
@@ -40,6 +40,7 @@
   <Folder Name="/examples/">
     <Project Path="examples/BasicExtraction/BasicExtraction.csproj" />
     <Project Path="examples/BasicLoading/BasicLoading.csproj" />
+    <Project Path="examples/CompressedStreams/CompressedStreams.csproj" />
     <Project Path="examples/CustomParsersConverters/CustomParsersConverters.csproj" />
     <Project Path="examples/ErrorHandling/ErrorHandling.csproj" />
     <Project Path="examples/FieldDelimiter/FieldDelimiter.csproj" />

--- a/README.md
+++ b/README.md
@@ -112,6 +112,22 @@ await using var writeStream = File.OpenWrite("output.dat");
 using var loader = new FixedWidthLoader<PersonRecord>(writeStream);
 ```
 
+Because the `Stream` constructors accept any `Stream`, compression works out of the box — wrap the file stream in a `GZipStream` or `BrotliStream` to read or write compressed fixed-width data (common for mainframe `.gz` exports) without a decompressed copy on disk:
+
+```csharp
+// Extraction from a GZip-compressed file
+await using var readStream = File.OpenRead("people.dat.gz");
+await using var gzip = new GZipStream(readStream, CompressionMode.Decompress);
+using var extractor = new FixedWidthExtractor<PersonRecord>(gzip);
+
+// Loading to a GZip-compressed file
+await using var writeStream = File.Create("output.dat.gz");
+await using var gzip = new GZipStream(writeStream, CompressionLevel.Optimal);
+using var loader = new FixedWidthLoader<PersonRecord>(gzip);
+```
+
+See the [CompressedStreams](examples/CompressedStreams) example for a complete GZip and Brotli round trip.
+
 ---
 
 ## ✨ Features
@@ -138,12 +154,13 @@ using var loader = new FixedWidthLoader<PersonRecord>(writeStream);
 
 **Examples:**
 
-The [examples/](examples/) folder contains 9 runnable console projects demonstrating each feature:
+The [examples/](examples/) folder contains 10 runnable console projects demonstrating each feature:
 
 | Example | Description |
 |---------|-------------|
 | [BasicExtraction](examples/BasicExtraction) | Read fixed-width data into strongly typed records |
 | [BasicLoading](examples/BasicLoading) | Write records to fixed-width output |
+| [CompressedStreams](examples/CompressedStreams) | Read and write GZip / Brotli compressed fixed-width data |
 | [RoundTrip](examples/RoundTrip) | Extract, transform, and reload records end-to-end |
 | [CustomParsersConverters](examples/CustomParsersConverters) | Custom `ValueParser` and `ValueConverter` delegates |
 | [ProgressReporting](examples/ProgressReporting) | Timer-based `IProgress<FixedWidthReport>` callbacks |

--- a/docfx_project/docs/examples.md
+++ b/docfx_project/docs/examples.md
@@ -14,6 +14,12 @@ Demonstrates the simplest loading workflow: writing strongly typed records to fi
 
 [View source](https://github.com/Chris-Wolfgang/ETL-FixedWidth/tree/main/examples/BasicLoading)
 
+## CompressedStreams
+
+Demonstrates loading to and extracting from compressed streams. Because the `Stream`-based constructors accept any `Stream`, GZip and Brotli compression work out of the box — you simply wrap the underlying stream in a `GZipStream` or `BrotliStream`. Highlights the disposal ordering required to flush the compressor before the compressed bytes are read back.
+
+[View source](https://github.com/Chris-Wolfgang/ETL-FixedWidth/tree/main/examples/CompressedStreams)
+
 ## RoundTrip
 
 Shows a full round-trip pipeline: extracting records from fixed-width text, then loading them back out to produce identical output. Validates that extraction and loading are symmetric.

--- a/examples/CompressedStreams/CompressedStreams.csproj
+++ b/examples/CompressedStreams/CompressedStreams.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.FixedWidth\Wolfgang.Etl.FixedWidth.csproj" />
+  </ItemGroup>
+
+  <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
+
+
+</Project>

--- a/examples/CompressedStreams/Program.cs
+++ b/examples/CompressedStreams/Program.cs
@@ -1,0 +1,226 @@
+// ---------------------------------------------------------------------------
+// CompressedStreams Example
+// ---------------------------------------------------------------------------
+//
+// This example demonstrates that FixedWidthLoader and FixedWidthExtractor work
+// with *any* Stream — including the compression streams in
+// System.IO.Compression. Because the Stream-based constructors accept an
+// arbitrary Stream, GZip and Brotli compression work out of the box: you simply
+// wrap the underlying stream in a GZipStream / BrotliStream before handing it to
+// the loader or extractor.
+//
+// Compressed mainframe exports are common — fixed-width files often arrive as
+// .gz archives — so reading and writing them without a temporary decompressed
+// copy on disk is a frequent requirement.
+//
+// Key concepts covered:
+//   - Loading records into a GZip-compressed stream
+//   - Extracting records back out of a GZip-compressed stream
+//   - The same pattern with Brotli
+//   - Why the compression stream must be disposed (flushed) before the
+//     compressed bytes can be read back
+//   - Using leaveOpen so the loader/compressor does not close the backing store
+//
+// This example is self-contained: it compresses into an in-memory MemoryStream
+// so it can be run with `dotnet run` without touching the file system. In
+// production you would swap the MemoryStream for a FileStream, e.g.:
+//
+//   await using var file = File.Create("people.dat.gz");
+//   await using var gzip = new GZipStream(file, CompressionLevel.Optimal);
+//   using var loader = new FixedWidthLoader<PersonRecord>(gzip);
+//
+//   await using var file = File.OpenRead("people.dat.gz");
+//   await using var gzip = new GZipStream(file, CompressionMode.Decompress);
+//   using var extractor = new FixedWidthExtractor<PersonRecord>(gzip);
+// ---------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.FixedWidth;
+using Wolfgang.Etl.FixedWidth.Attributes;
+using Wolfgang.Etl.FixedWidth.Enums;
+
+// ---------------------------------------------------------------------------
+// Step 1: The records we want to persist in compressed fixed-width form.
+// ---------------------------------------------------------------------------
+
+var people = new[]
+{
+    new PersonRecord { FirstName = "Alice",   LastName = "Anderson", Age = 25 },
+    new PersonRecord { FirstName = "Bob",     LastName = "Baker",    Age = 42 },
+    new PersonRecord { FirstName = "Charlie", LastName = "Clark",    Age = 33 },
+};
+
+var token = CancellationToken.None;
+
+// ---------------------------------------------------------------------------
+// Step 2: GZip round trip.
+//
+// Write (load) the records into a GZip-compressed stream, then read (extract)
+// them straight back out — no decompressed copy is ever materialized on disk.
+// ---------------------------------------------------------------------------
+
+Console.WriteLine("=== GZip ===");
+
+var gzipBytes = await CompressAsync
+(
+    people,
+    backing => new GZipStream(backing, CompressionLevel.Optimal, leaveOpen: true),
+    token
+);
+
+Console.WriteLine($"Compressed {people.Length} records into {gzipBytes.Length} bytes.");
+
+await ExtractAndPrintAsync
+(
+    gzipBytes,
+    backing => new GZipStream(backing, CompressionMode.Decompress),
+    token
+);
+
+// ---------------------------------------------------------------------------
+// Step 3: Brotli round trip.
+//
+// Identical pattern — only the compression stream type changes. This is the
+// whole point: the loader and extractor neither know nor care which Stream they
+// are wrapped around.
+// ---------------------------------------------------------------------------
+
+Console.WriteLine();
+Console.WriteLine("=== Brotli ===");
+
+var brotliBytes = await CompressAsync
+(
+    people,
+    backing => new BrotliStream(backing, CompressionLevel.Optimal, leaveOpen: true),
+    token
+);
+
+Console.WriteLine($"Compressed {people.Length} records into {brotliBytes.Length} bytes.");
+
+await ExtractAndPrintAsync
+(
+    brotliBytes,
+    backing => new BrotliStream(backing, CompressionMode.Decompress),
+    token
+);
+
+// ---------------------------------------------------------------------------
+// CompressAsync — load records through a compression stream and return the
+// compressed bytes.
+//
+// The compression stream MUST be disposed before the compressed bytes are
+// complete: GZip/Brotli buffer internally and write a trailing footer on
+// dispose. The nested `using` blocks guarantee that ordering — the loader is
+// disposed first (flushing its buffered writer), then the compression stream is
+// disposed (flushing the compressor and writing the footer) — all before we
+// read `backing.ToArray()`.
+//
+// `leaveOpen: true` on the compression stream keeps the backing MemoryStream
+// open after the compressor is disposed, so we can still read its bytes.
+// ---------------------------------------------------------------------------
+
+static async Task<byte[]> CompressAsync
+(
+    IReadOnlyCollection<PersonRecord> records,
+    Func<Stream, Stream> wrap,
+    CancellationToken token
+)
+{
+    using var backing = new MemoryStream();
+
+    // Scope the compressor + loader so both are disposed (and thus flushed)
+    // before we snapshot the backing stream's bytes below.
+    await using (var compressor = wrap(backing))
+    {
+        using var loader = new FixedWidthLoader<PersonRecord>(compressor);
+        await loader.LoadAsync(ToAsyncEnumerable(records, token), token);
+    }
+
+    return backing.ToArray();
+}
+
+// ---------------------------------------------------------------------------
+// ExtractAndPrintAsync — decompress the bytes and stream the records back out
+// through a FixedWidthExtractor, printing each one.
+// ---------------------------------------------------------------------------
+
+static async Task ExtractAndPrintAsync
+(
+    byte[] compressed,
+    Func<Stream, Stream> wrap,
+    CancellationToken token
+)
+{
+    using var backing = new MemoryStream(compressed);
+    await using var decompressor = wrap(backing);
+    using var extractor = new FixedWidthExtractor<PersonRecord>(decompressor);
+
+    Console.WriteLine("Extracted records:");
+
+    await foreach (var person in extractor.ExtractAsync(token))
+    {
+        Console.WriteLine
+        (
+            $"  {person.FirstName,-10} {person.LastName,-10} Age: {person.Age}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ToAsyncEnumerable — adapt an in-memory collection to the
+// IAsyncEnumerable<T> that LoadAsync consumes. In a real pipeline this would be
+// the output of a FixedWidthExtractor or a transformer, which is already async.
+//
+// The #pragma suppresses CS1998 ("async method lacks await") because this
+// adapter has no genuinely asynchronous work to await.
+// ---------------------------------------------------------------------------
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators
+static async IAsyncEnumerable<PersonRecord> ToAsyncEnumerable
+(
+    IEnumerable<PersonRecord> records,
+    [EnumeratorCancellation] CancellationToken token
+)
+{
+    foreach (var record in records)
+    {
+        token.ThrowIfCancellationRequested();
+        yield return record;
+    }
+}
+#pragma warning restore CS1998
+
+// ---------------------------------------------------------------------------
+// PersonRecord — the POCO mapped to a 23-character fixed-width line
+// (10 + 10 + 3). See the BasicExtraction example for a fuller walk-through of
+// the [FixedWidthField] attribute.
+// ---------------------------------------------------------------------------
+
+/// <summary>
+/// Represents a single person record in a fixed-width file.
+/// The total line width is 10 + 10 + 3 = 23 characters.
+/// </summary>
+public class PersonRecord
+{
+    // Column 0: 10-character first name, left-aligned, space-padded.
+    [FixedWidthField(0, 10)]
+    public string FirstName { get; set; } = string.Empty;
+
+
+
+    // Column 1: 10-character last name, left-aligned, space-padded.
+    [FixedWidthField(1, 10)]
+    public string LastName { get; set; } = string.Empty;
+
+
+
+    // Column 2: 3-character age, right-aligned, zero-padded.
+    [FixedWidthField(2, 3, Alignment = FieldAlignment.Right, Pad = '0')]
+    public int Age { get; set; }
+}


### PR DESCRIPTION
## Summary

Resolves #32 — adds documentation and a runnable example for reading/writing compressed fixed-width streams.

The `Stream`-based constructors already accept any `Stream`, so compression works out of the box. This makes that discoverable:

- **New `examples/CompressedStreams`** — self-contained console app doing a full GZip **and** Brotli round trip (load → compressed stream → extract), wired into the solution. Verified with `dotnet run -c Release`.
- **README** — new snippet after the file-I/O section + a row in the examples table (9 → 10 examples).
- **DocFX examples guide** — new `CompressedStreams` section.
- **CHANGELOG** — noted under `[Unreleased] / Added`.

Documentation only — **no public-API or runtime-behavior change**.

## Notes

- New example = MINOR surface, so this targets `vNext` for the next 0.3.0 cycle rather than a patch on v0.2.3.
- The example uses an in-memory `MemoryStream` to stay self-contained; the comments show the production `FileStream` (`.gz`) form.

Closes #32