### PR TITLE
docs: fix stale/empty XML-doc comments in src (no behavior change)

### DIFF
--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
@@ -888,7 +888,9 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
     /// Throws <see cref="LineTooShortException"/> when the policy is
     /// <see cref="BlankLineHandling.ThrowException"/>.
     /// </summary>
-    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <see cref="BlankLineHandling"/> holds an unrecognized value.
+    /// </exception>
     /// <exception cref="LineTooShortException">
     /// Thrown when <see cref="BlankLineHandling"/> is
     /// <see cref="BlankLineHandling.ThrowException"/> (the default).
@@ -944,11 +946,14 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
     /// Returns <see langword="true"/> and sets <paramref name="record"/> on success.
     /// Returns <see langword="false"/> when <see cref="MalformedLineHandling"/> is
     /// <see cref="MalformedLineHandling.Skip"/> and the line cannot be parsed.
-    /// Yields a default record and returns <see langword="false"/> when the policy
-    /// is <see cref="MalformedLineHandling.ReturnDefault"/>.
+    /// Sets a default record and returns <see langword="true"/> when the policy
+    /// is <see cref="MalformedLineHandling.ReturnDefault"/> (the caller performs
+    /// the yield).
     /// Re-throws on <see cref="MalformedLineHandling.ThrowException"/>.
     /// </summary>
-    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <see cref="MalformedLineHandling"/> holds an unrecognized value.
+    /// </exception>
     private bool TryParseLine(string line, FieldMapResult fieldMap, out TRecord record)
     {
         record = default!;

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthLoader.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthLoader.cs
@@ -243,8 +243,8 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>
     /// <remarks>
     /// The converter receives the raw boxed property value and a <see cref="FieldContext"/>
     /// describing the field. It must return a string no longer than
-    /// <see cref="FieldContext.FieldLength"/>; otherwise the safety-net inside
-    /// <c>FormatSegment</c> will throw a
+    /// <see cref="FieldContext.FieldLength"/>; otherwise the loader's field-width
+    /// safety-net will throw a
     /// <see cref="Exceptions.FieldOverflowException"/>.
     /// </remarks>
     /// <example>

--- a/src/Wolfgang.Etl.FixedWidth/Parsing/FixedWidthLineParser.cs
+++ b/src/Wolfgang.Etl.FixedWidth/Parsing/FixedWidthLineParser.cs
@@ -15,7 +15,6 @@ namespace Wolfgang.Etl.FixedWidth.Parsing;
 internal static class FixedWidthLineParser
 {
     // ------------------------------------------------------------------
-    // ------------------------------------------------------------------
     // Direct-write formatting — writes segments directly to a TextWriter
     // to avoid intermediate List<string> and Join allocations.
     // ------------------------------------------------------------------
@@ -26,7 +25,9 @@ internal static class FixedWidthLineParser
     /// is inserted between adjacent logical columns (including skip columns) to match
     /// the parser's <see cref="FieldDescriptor.AbsoluteColumnIndex"/> semantics.
     /// </summary>
-    /// <exception cref="FieldOverflowException"></exception>
+    /// <exception cref="FieldOverflowException">
+    /// Thrown when a converted value is wider than its declared field length.
+    /// </exception>
     internal static void WriteRecord<T>
     (
         TextWriter writer,
@@ -64,7 +65,9 @@ internal static class FixedWidthLineParser
     /// <summary>
     /// Writes a header line directly to <paramref name="writer"/>.
     /// </summary>
-    /// <exception cref="FieldOverflowException"></exception>
+    /// <exception cref="FieldOverflowException">
+    /// Thrown when a converted header label is wider than its declared field length.
+    /// </exception>
     internal static void WriteHeader
     (
         TextWriter writer,
@@ -285,7 +288,9 @@ internal static class FixedWidthLineParser
     /// the intermediate <see cref="string.PadLeft(int,char)"/> /
     /// <see cref="string.PadRight(int,char)"/> allocation.
     /// </summary>
-    /// <exception cref="FieldOverflowException"></exception>
+    /// <exception cref="FieldOverflowException">
+    /// Thrown when the converted value is wider than its declared field length.
+    /// </exception>
     /// <exception cref="InvalidOperationException">
     /// Thrown when the property has no public getter.
     /// </exception>
@@ -322,7 +327,7 @@ internal static class FixedWidthLineParser
         var padCount = attr.Length - text.Length;
 #if NET8_0_OR_GREATER
         // Stack-allocate the full padded field so it can be written in a single
-        // call when small enough — typical fixed-width fields are ≤128 chars.
+        // call when small enough — fields up to 256 chars use the stack path.
         const int stackFieldLimit = 256;
         if (attr.Length <= stackFieldLimit)
         {
@@ -361,7 +366,9 @@ internal static class FixedWidthLineParser
     /// "label + space-padding", avoiding the intermediate
     /// <see cref="string.PadRight(int,char)"/> allocation.
     /// </summary>
-    /// <exception cref="FieldOverflowException"></exception>
+    /// <exception cref="FieldOverflowException">
+    /// Thrown when the converted header label is wider than its declared field length.
+    /// </exception>
     private static void WriteHeaderSegmentTo
     (
         TextWriter writer,
@@ -401,12 +408,16 @@ internal static class FixedWidthLineParser
     /// <typeparamref name="T"/>. Validates that the line is long enough to satisfy
     /// all field and skip definitions plus any delimiter contribution before parsing.
     /// </summary>
-    /// <param name="line"></param>
-    /// <param name="lineNumber"></param>
-    /// <param name="fieldMap"></param>
-    /// <param name="fieldDelimiter"></param>
-    /// <param name="valueParser"></param>
-    /// <exception cref="LineTooShortException"></exception>
+    /// <typeparam name="T">The record type to materialize.</typeparam>
+    /// <param name="line">The raw fixed-width line to parse.</param>
+    /// <param name="lineNumber">The 1-based line number, used for diagnostics.</param>
+    /// <param name="fieldMap">The resolved field map describing the columns.</param>
+    /// <param name="fieldDelimiter">Optional delimiter inserted between columns, or <see langword="null"/>.</param>
+    /// <param name="valueParser">Optional value parser; defaults to <see cref="FixedWidthConverter.DefaultParser"/>.</param>
+    /// <returns>A new <typeparamref name="T"/> populated from <paramref name="line"/>.</returns>
+    /// <exception cref="LineTooShortException">
+    /// Thrown when <paramref name="line"/> is shorter than the columns require.
+    /// </exception>
     internal static T ParseLine<T>
     (
         string line,


### PR DESCRIPTION
Part 1 of 3 in a stacked code-review maintenance series (#94). **Base: `vNext`.**

Doc-accuracy batch — documentation only, **no public-API or runtime-behavior change**:

- **`FixedWidthExtractor.TryParseLine`** summary claimed it *"yields a default record and returns `false`"* for `ReturnDefault`; the code sets the record and returns `true` (the caller yields). Corrected.
- Filled empty `<exception>` / `<param>` XML-doc tags on `ParseLine`, `WriteRecord`, `WriteHeader`, `WriteFieldSegment`, `WriteHeaderSegmentTo`, `HandleBlankLine`, `TryParseLine`.
- Fixed a stale `"typical fields are ≤128 chars"` comment sitting above the `256` `stackFieldLimit` constant.
- `FixedWidthLoader.ValueConverter` remark referenced a non-existent `<c>FormatSegment</c>` method → reworded.
- Removed a duplicated divider comment in `FixedWidthLineParser`.

Verified: `dotnet build -c Release` clean across all 5 TFMs, 0 warnings (XML-doc validation passes under TreatWarningsAsErrors).

**Stack:** #206 (docs example, independent) · **this** → `maint/cr-perf-converter-cache` → `maint/cr-simplify`.