### PR TITLE
perf: reuse cached TypeConverter across nullable unwrap in ParseValue

### DIFF
--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthConverter.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthConverter.cs
@@ -314,7 +314,8 @@ public static class FixedWidthConverter
             (
                 text,
                 underlying,
-                format
+                format,
+                cachedConverter
             );
         }
 


### PR DESCRIPTION
Part 2 of 3 in the stacked code-review maintenance series (#94). **Base: `maint/cr-doc-accuracy` (#207)** — stacked; review/merge #207 first.

### The bug
`FixedWidthConverter.ParseValue` recurses into the underlying type for `Nullable<T>`, but the recursive call dropped the `cachedConverter` argument:

```csharp
return ParseValue(text, underlying, format);   // cachedConverter lost
```

The line parser passes `descriptor.TypeConverter` as the cache for the default-parser path (`FixedWidthLineParser` line ~491), but for a **nullable** TypeConverter-backed field the recursion threw that cache away and did a fresh `TypeDescriptor.GetConverter(targetType)` per value.

### The fix
Thread `cachedConverter` through the recursive call. Behavior is identical — same converter, same `TypeDescriptor.GetConverter` fallback when the cache is null — only the redundant per-value lookup for nullable fields is removed.

Verified: **289/289 tests pass** on net10.0; Release build clean.

**Stack:** #207 → **this** → `maint/cr-simplify`.