### PR TITLE
refactor: small simplifications in src (no behavior change)

### DIFF
--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthConverter.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthConverter.cs
@@ -78,7 +78,7 @@ public static class FixedWidthConverter
             {
                 throw new FieldOverflowException
                 (
-                    $"Value for property '{context.PropertyName}' has length {text.Length} which " + $"exceeds the defined field width of {context.FieldLength}.",
+                    $"Value for property '{context.PropertyName}' has length {text.Length} which exceeds the defined field width of {context.FieldLength}.",
                     context.PropertyName,
                     context.FieldLength,
                     text.Length

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
@@ -163,8 +163,7 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
     /// <exception cref="ArgumentNullException"><paramref name="stream"/> is null.</exception>
     public FixedWidthExtractor(Stream stream)
     {
-        if (stream == null) throw new ArgumentNullException(nameof(stream));
-        _reader = new StreamReader(stream, encoding: System.Text.Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: DefaultBufferSize, leaveOpen: true);
+        _reader = CreateBufferedReader(stream);
         _ownsReader = true;
         _logger = NullLogger.Instance;
     }
@@ -191,8 +190,7 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
         ILogger<FixedWidthExtractor<TRecord>> logger
     )
     {
-        if (stream == null) throw new ArgumentNullException(nameof(stream));
-        _reader = new StreamReader(stream, encoding: System.Text.Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: DefaultBufferSize, leaveOpen: true);
+        _reader = CreateBufferedReader(stream);
         _ownsReader = true;
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -224,11 +222,24 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
         ILogger<FixedWidthExtractor<TRecord>>? logger = null
     )
     {
-        if (stream == null) throw new ArgumentNullException(nameof(stream));
-        _reader = new StreamReader(stream, encoding: System.Text.Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: DefaultBufferSize, leaveOpen: true);
+        _reader = CreateBufferedReader(stream);
         _ownsReader = true;
         _progressTimer = timer ?? throw new ArgumentNullException(nameof(timer));
         _logger = logger ?? (ILogger)NullLogger.Instance;
+    }
+
+
+
+    /// <summary>
+    /// Creates the internal <see cref="StreamReader"/> shared by the
+    /// <see cref="Stream"/>-based constructors: UTF-8, BOM detection, a 64 KB
+    /// buffer, and <c>leaveOpen: true</c> so the caller retains stream ownership.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="stream"/> is null.</exception>
+    private static StreamReader CreateBufferedReader(Stream stream)
+    {
+        if (stream == null) throw new ArgumentNullException(nameof(stream));
+        return new StreamReader(stream, encoding: System.Text.Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: DefaultBufferSize, leaveOpen: true);
     }
 
 
@@ -881,6 +892,15 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
 
 
     /// <summary>
+    /// Creates a default <typeparamref name="TRecord"/> instance via the field map's
+    /// compiled factory. Used by the <see cref="BlankLineHandling.ReturnDefault"/> and
+    /// <see cref="MalformedLineHandling.ReturnDefault"/> paths.
+    /// </summary>
+    private static TRecord CreateDefaultRecord(FieldMapResult fieldMap) => (TRecord)fieldMap.Factory();
+
+
+
+    /// <summary>
     /// Handles a blank line according to <see cref="BlankLineHandling"/>.
     /// Returns <see langword="true"/> when a default record should be yielded,
     /// passing it back via <paramref name="defaultRecord"/>.
@@ -905,7 +925,7 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
                 return false;
 
             case BlankLineHandling.ReturnDefault:
-                defaultRecord = (TRecord)fieldMap.Factory();
+                defaultRecord = CreateDefaultRecord(fieldMap);
                 return true;
 
             case BlankLineHandling.ThrowException:
@@ -981,7 +1001,7 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
 
                 case MalformedLineHandling.ReturnDefault:
                     // Cannot yield inside catch — caller handles the yield and increment.
-                    record = (TRecord)fieldMap.Factory();
+                    record = CreateDefaultRecord(fieldMap);
                     return true;
 
                 case MalformedLineHandling.ThrowException:

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthLoader.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthLoader.cs
@@ -162,8 +162,7 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>
     /// <exception cref="ArgumentNullException"><paramref name="stream"/> is null.</exception>
     public FixedWidthLoader(Stream stream)
     {
-        if (stream == null) throw new ArgumentNullException(nameof(stream));
-        _writer = new StreamWriter(stream, encoding: System.Text.Encoding.UTF8, bufferSize: DefaultBufferSize, leaveOpen: true);
+        _writer = CreateBufferedWriter(stream);
         _ownsWriter = true;
         _logger = NullLogger.Instance;
     }
@@ -190,8 +189,7 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>
         ILogger<FixedWidthLoader<TRecord>> logger
     )
     {
-        if (stream == null) throw new ArgumentNullException(nameof(stream));
-        _writer = new StreamWriter(stream, encoding: System.Text.Encoding.UTF8, bufferSize: DefaultBufferSize, leaveOpen: true);
+        _writer = CreateBufferedWriter(stream);
         _ownsWriter = true;
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -223,11 +221,24 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>
         ILogger<FixedWidthLoader<TRecord>>? logger = null
     )
     {
-        if (stream == null) throw new ArgumentNullException(nameof(stream));
-        _writer = new StreamWriter(stream, encoding: System.Text.Encoding.UTF8, bufferSize: DefaultBufferSize, leaveOpen: true);
+        _writer = CreateBufferedWriter(stream);
         _ownsWriter = true;
         _progressTimer = timer ?? throw new ArgumentNullException(nameof(timer));
         _logger = logger ?? (ILogger)NullLogger.Instance;
+    }
+
+
+
+    /// <summary>
+    /// Creates the internal <see cref="StreamWriter"/> shared by the
+    /// <see cref="Stream"/>-based constructors: UTF-8, a 64 KB buffer, and
+    /// <c>leaveOpen: true</c> so the caller retains stream ownership.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="stream"/> is null.</exception>
+    private static StreamWriter CreateBufferedWriter(Stream stream)
+    {
+        if (stream == null) throw new ArgumentNullException(nameof(stream));
+        return new StreamWriter(stream, encoding: System.Text.Encoding.UTF8, bufferSize: DefaultBufferSize, leaveOpen: true);
     }
 
 
@@ -645,9 +656,8 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>
     {
         var ex = new InvalidOperationException
         (
-            $"A null record was encountered at item " +
-            $"{CurrentItemCount + CurrentSkippedItemCount + 1}. " +
-            $"The loader writes what it is given — null records are not permitted."
+            $"A null record was encountered at item {CurrentItemCount + CurrentSkippedItemCount + 1}. " +
+            "The loader writes what it is given — null records are not permitted."
         );
 
         _logger.LogError

--- a/src/Wolfgang.Etl.FixedWidth/Parsing/FixedWidthLineParser.cs
+++ b/src/Wolfgang.Etl.FixedWidth/Parsing/FixedWidthLineParser.cs
@@ -378,8 +378,8 @@ internal static class FixedWidthLineParser
     {
         var attr = descriptor.Attribute;
         var prop = descriptor.Property;
-        var headerLabel = attr.Header ?? prop.Name;
-        var text = headerConverter(headerLabel, descriptor.Context);
+        // Reuse the label precomputed on the context (attribute.Header ?? property.Name).
+        var text = headerConverter(descriptor.Context.HeaderLabel, descriptor.Context);
 
         if (text.Length > attr.Length)
         {


### PR DESCRIPTION
Part 3 of 3 in the stacked code-review maintenance series (#94). **Base: `maint/cr-perf-converter-cache` (#208)** — stacked; review/merge #207 then #208 first.

### Applied
- **Ctor dedup** — extracted `CreateBufferedReader` / `CreateBufferedWriter` so the three `Stream` constructors on the extractor and loader stop repeating the `StreamReader`/`StreamWriter` construction + null check.
- **Reuse precomputed label** — `WriteHeaderSegmentTo` now reads `descriptor.Context.HeaderLabel` (precomputed as `attribute.Header ?? property.Name`) instead of recomputing it per row.
- **`CreateDefaultRecord` helper** — centralizes the two `ReturnDefault` paths that cast `fieldMap.Factory()` to `TRecord`.
- **String collapse** — two pointless `$"..." + $"..."` concatenations → single interpolated strings (converter overflow message, loader null-record message).

### Deliberately skipped (net-negative — flagging rather than forcing)
- **Unify the three `WriteRecord`/`WriteHeader`/`WriteSeparator` loops** — the shared parts are already extracted into helpers; unifying the remaining skeleton needs a per-call delegate/closure, a heap allocation on the deliberately **allocation-free** direct-write hot path. Not worth it.
- **Dedup the extractor skip/max budget blocks** — they live inside a `yield`-based iterator (can't `yield break`/`continue` from an extracted helper), and the one differing line is a source-generated log call that would allocate if passed as a delegate.
- **Merge `FieldMap` empty-map early-out with `BuildResult`** — they look similar but encode different rules: the early-out forces a zeroed result (`width:0, count:0`) for empty/all-skip types, whereas `BuildResult` computes non-zero width/count. Merging would obscure that intent.

Verified: Release build clean across all 5 TFMs, 0 warnings; **289/289 tests pass** on net10.0.

**Stack:** #207 → #208 → **this**.