### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `CompressedStreams` example demonstrating GZip and Brotli round trips
+  (load to and extract from a compressed stream), plus documentation in the
+  README and the DocFX examples guide. Documentation only — no public-API or
+  runtime-behavior change ([#32](https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/32)).
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `CompressedStreams` example demonstrating GZip and Brotli round trips
-  (load to and extract from a compressed stream), plus documentation in the
-  README and the DocFX examples guide. Documentation only — no public-API or
-  runtime-behavior change ([#32](https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/32)).
-
 ### Changed
 
 ### Deprecated
@@ -24,11 +19,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.3.0] - 2026-07-13
+
+### Added
+
+- `CompressedStreams` example demonstrating GZip and Brotli round trips
+  (load to and extract from a compressed stream), plus documentation in the
+  README and the DocFX examples guide ([#32]).
+
+### Changed
+
+- Reuse the cached `TypeConverter` across the nullable-unwrap recursion in the
+  value parser, avoiding a redundant per-value `TypeDescriptor.GetConverter`
+  lookup for nullable `TypeConverter`-backed fields. Behavior is unchanged
+  ([#208]).
+- Internal maintenance (no public-API or runtime-behavior change): corrected
+  stale and empty XML-doc comments, and applied small source simplifications —
+  shared buffered reader/writer construction helpers on the `Stream`
+  constructors and reuse of the precomputed header label ([#207], [#209]).
+
 ## [0.2.3] - 2026-07-06
 
 ### Changed
 
 - Dependabot bump: dotnet-dependencies group (7 packages).
+
 ## [0.2.2] - 2026-06-27
 
 ### Changed
@@ -107,15 +122,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   parsing for reduced allocations.
 - Nine runnable example console apps covering the major features.
 
-[Unreleased]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.2.3...HEAD
+[Unreleased]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.2.3...v0.3.0
 [0.2.3]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v.0.1.0...v0.2.0
 [0.1.0]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/releases/tag/v.0.1.0
+[#32]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/32
 [#49]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/49
 [#60]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/60
 [#62]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/62
 [#83]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/83
 [#84]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/84
 [#86]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/86
+[#207]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/207
+[#208]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/208
+[#209]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/209

--- a/ETL Fixed Width.slnx
+++ b/ETL Fixed Width.slnx
@@ -40,6 +40,7 @@
   <Folder Name="/examples/">
     <Project Path="examples/BasicExtraction/BasicExtraction.csproj" />
     <Project Path="examples/BasicLoading/BasicLoading.csproj" />
+    <Project Path="examples/CompressedStreams/CompressedStreams.csproj" />
     <Project Path="examples/CustomParsersConverters/CustomParsersConverters.csproj" />
     <Project Path="examples/ErrorHandling/ErrorHandling.csproj" />
     <Project Path="examples/FieldDelimiter/FieldDelimiter.csproj" />

--- a/README.md
+++ b/README.md
@@ -112,6 +112,22 @@ await using var writeStream = File.OpenWrite("output.dat");
 using var loader = new FixedWidthLoader<PersonRecord>(writeStream);
 ```
 
+Because the `Stream` constructors accept any `Stream`, compression works out of the box — wrap the file stream in a `GZipStream` or `BrotliStream` to read or write compressed fixed-width data (common for mainframe `.gz` exports) without a decompressed copy on disk:
+
+```csharp
+// Extraction from a GZip-compressed file
+await using var readStream = File.OpenRead("people.dat.gz");
+await using var gzip = new GZipStream(readStream, CompressionMode.Decompress);
+using var extractor = new FixedWidthExtractor<PersonRecord>(gzip);
+
+// Loading to a GZip-compressed file
+await using var writeStream = File.Create("output.dat.gz");
+await using var gzip = new GZipStream(writeStream, CompressionLevel.Optimal);
+using var loader = new FixedWidthLoader<PersonRecord>(gzip);
+```
+
+See the [CompressedStreams](examples/CompressedStreams) example for a complete GZip and Brotli round trip.
+
 ---
 
 ## ✨ Features
@@ -138,12 +154,13 @@ using var loader = new FixedWidthLoader<PersonRecord>(writeStream);
 
 **Examples:**
 
-The [examples/](examples/) folder contains 9 runnable console projects demonstrating each feature:
+The [examples/](examples/) folder contains 10 runnable console projects demonstrating each feature:
 
 | Example | Description |
 |---------|-------------|
 | [BasicExtraction](examples/BasicExtraction) | Read fixed-width data into strongly typed records |
 | [BasicLoading](examples/BasicLoading) | Write records to fixed-width output |
+| [CompressedStreams](examples/CompressedStreams) | Read and write GZip / Brotli compressed fixed-width data |
 | [RoundTrip](examples/RoundTrip) | Extract, transform, and reload records end-to-end |
 | [CustomParsersConverters](examples/CustomParsersConverters) | Custom `ValueParser` and `ValueConverter` delegates |
 | [ProgressReporting](examples/ProgressReporting) | Timer-based `IProgress<FixedWidthReport>` callbacks |

--- a/docfx_project/docs/examples.md
+++ b/docfx_project/docs/examples.md
@@ -14,6 +14,12 @@ Demonstrates the simplest loading workflow: writing strongly typed records to fi
 
 [View source](https://github.com/Chris-Wolfgang/ETL-FixedWidth/tree/main/examples/BasicLoading)
 
+## CompressedStreams
+
+Demonstrates loading to and extracting from compressed streams. Because the `Stream`-based constructors accept any `Stream`, GZip and Brotli compression work out of the box — you simply wrap the underlying stream in a `GZipStream` or `BrotliStream`. Highlights the disposal ordering required to flush the compressor before the compressed bytes are read back.
+
+[View source](https://github.com/Chris-Wolfgang/ETL-FixedWidth/tree/main/examples/CompressedStreams)
+
 ## RoundTrip
 
 Shows a full round-trip pipeline: extracting records from fixed-width text, then loading them back out to produce identical output. Validates that extraction and loading are symmetric.

--- a/examples/CompressedStreams/CompressedStreams.csproj
+++ b/examples/CompressedStreams/CompressedStreams.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.FixedWidth\Wolfgang.Etl.FixedWidth.csproj" />
+  </ItemGroup>
+
+  <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
+
+
+</Project>

--- a/examples/CompressedStreams/Program.cs
+++ b/examples/CompressedStreams/Program.cs
@@ -1,0 +1,226 @@
+// ---------------------------------------------------------------------------
+// CompressedStreams Example
+// ---------------------------------------------------------------------------
+//
+// This example demonstrates that FixedWidthLoader and FixedWidthExtractor work
+// with *any* Stream — including the compression streams in
+// System.IO.Compression. Because the Stream-based constructors accept an
+// arbitrary Stream, GZip and Brotli compression work out of the box: you simply
+// wrap the underlying stream in a GZipStream / BrotliStream before handing it to
+// the loader or extractor.
+//
+// Compressed mainframe exports are common — fixed-width files often arrive as
+// .gz archives — so reading and writing them without a temporary decompressed
+// copy on disk is a frequent requirement.
+//
+// Key concepts covered:
+//   - Loading records into a GZip-compressed stream
+//   - Extracting records back out of a GZip-compressed stream
+//   - The same pattern with Brotli
+//   - Why the compression stream must be disposed (flushed) before the
+//     compressed bytes can be read back
+//   - Using leaveOpen so the loader/compressor does not close the backing store
+//
+// This example is self-contained: it compresses into an in-memory MemoryStream
+// so it can be run with `dotnet run` without touching the file system. In
+// production you would swap the MemoryStream for a FileStream, e.g.:
+//
+//   await using var file = File.Create("people.dat.gz");
+//   await using var gzip = new GZipStream(file, CompressionLevel.Optimal);
+//   using var loader = new FixedWidthLoader<PersonRecord>(gzip);
+//
+//   await using var file = File.OpenRead("people.dat.gz");
+//   await using var gzip = new GZipStream(file, CompressionMode.Decompress);
+//   using var extractor = new FixedWidthExtractor<PersonRecord>(gzip);
+// ---------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.FixedWidth;
+using Wolfgang.Etl.FixedWidth.Attributes;
+using Wolfgang.Etl.FixedWidth.Enums;
+
+// ---------------------------------------------------------------------------
+// Step 1: The records we want to persist in compressed fixed-width form.
+// ---------------------------------------------------------------------------
+
+var people = new[]
+{
+    new PersonRecord { FirstName = "Alice",   LastName = "Anderson", Age = 25 },
+    new PersonRecord { FirstName = "Bob",     LastName = "Baker",    Age = 42 },
+    new PersonRecord { FirstName = "Charlie", LastName = "Clark",    Age = 33 },
+};
+
+var token = CancellationToken.None;
+
+// ---------------------------------------------------------------------------
+// Step 2: GZip round trip.
+//
+// Write (load) the records into a GZip-compressed stream, then read (extract)
+// them straight back out — no decompressed copy is ever materialized on disk.
+// ---------------------------------------------------------------------------
+
+Console.WriteLine("=== GZip ===");
+
+var gzipBytes = await CompressAsync
+(
+    people,
+    backing => new GZipStream(backing, CompressionLevel.Optimal, leaveOpen: true),
+    token
+);
+
+Console.WriteLine($"Compressed {people.Length} records into {gzipBytes.Length} bytes.");
+
+await ExtractAndPrintAsync
+(
+    gzipBytes,
+    backing => new GZipStream(backing, CompressionMode.Decompress),
+    token
+);
+
+// ---------------------------------------------------------------------------
+// Step 3: Brotli round trip.
+//
+// Identical pattern — only the compression stream type changes. This is the
+// whole point: the loader and extractor neither know nor care which Stream they
+// are wrapped around.
+// ---------------------------------------------------------------------------
+
+Console.WriteLine();
+Console.WriteLine("=== Brotli ===");
+
+var brotliBytes = await CompressAsync
+(
+    people,
+    backing => new BrotliStream(backing, CompressionLevel.Optimal, leaveOpen: true),
+    token
+);
+
+Console.WriteLine($"Compressed {people.Length} records into {brotliBytes.Length} bytes.");
+
+await ExtractAndPrintAsync
+(
+    brotliBytes,
+    backing => new BrotliStream(backing, CompressionMode.Decompress),
+    token
+);
+
+// ---------------------------------------------------------------------------
+// CompressAsync — load records through a compression stream and return the
+// compressed bytes.
+//
+// The compression stream MUST be disposed before the compressed bytes are
+// complete: GZip/Brotli buffer internally and write a trailing footer on
+// dispose. The nested `using` blocks guarantee that ordering — the loader is
+// disposed first (flushing its buffered writer), then the compression stream is
+// disposed (flushing the compressor and writing the footer) — all before we
+// read `backing.ToArray()`.
+//
+// `leaveOpen: true` on the compression stream keeps the backing MemoryStream
+// open after the compressor is disposed, so we can still read its bytes.
+// ---------------------------------------------------------------------------
+
+static async Task<byte[]> CompressAsync
+(
+    IReadOnlyCollection<PersonRecord> records,
+    Func<Stream, Stream> wrap,
+    CancellationToken token
+)
+{
+    using var backing = new MemoryStream();
+
+    // Scope the compressor + loader so both are disposed (and thus flushed)
+    // before we snapshot the backing stream's bytes below.
+    await using (var compressor = wrap(backing))
+    {
+        using var loader = new FixedWidthLoader<PersonRecord>(compressor);
+        await loader.LoadAsync(ToAsyncEnumerable(records, token), token);
+    }
+
+    return backing.ToArray();
+}
+
+// ---------------------------------------------------------------------------
+// ExtractAndPrintAsync — decompress the bytes and stream the records back out
+// through a FixedWidthExtractor, printing each one.
+// ---------------------------------------------------------------------------
+
+static async Task ExtractAndPrintAsync
+(
+    byte[] compressed,
+    Func<Stream, Stream> wrap,
+    CancellationToken token
+)
+{
+    using var backing = new MemoryStream(compressed);
+    await using var decompressor = wrap(backing);
+    using var extractor = new FixedWidthExtractor<PersonRecord>(decompressor);
+
+    Console.WriteLine("Extracted records:");
+
+    await foreach (var person in extractor.ExtractAsync(token))
+    {
+        Console.WriteLine
+        (
+            $"  {person.FirstName,-10} {person.LastName,-10} Age: {person.Age}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ToAsyncEnumerable — adapt an in-memory collection to the
+// IAsyncEnumerable<T> that LoadAsync consumes. In a real pipeline this would be
+// the output of a FixedWidthExtractor or a transformer, which is already async.
+//
+// The #pragma suppresses CS1998 ("async method lacks await") because this
+// adapter has no genuinely asynchronous work to await.
+// ---------------------------------------------------------------------------
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators
+static async IAsyncEnumerable<PersonRecord> ToAsyncEnumerable
+(
+    IEnumerable<PersonRecord> records,
+    [EnumeratorCancellation] CancellationToken token
+)
+{
+    foreach (var record in records)
+    {
+        token.ThrowIfCancellationRequested();
+        yield return record;
+    }
+}
+#pragma warning restore CS1998
+
+// ---------------------------------------------------------------------------
+// PersonRecord — the POCO mapped to a 23-character fixed-width line
+// (10 + 10 + 3). See the BasicExtraction example for a fuller walk-through of
+// the [FixedWidthField] attribute.
+// ---------------------------------------------------------------------------
+
+/// <summary>
+/// Represents a single person record in a fixed-width file.
+/// The total line width is 10 + 10 + 3 = 23 characters.
+/// </summary>
+public class PersonRecord
+{
+    // Column 0: 10-character first name, left-aligned, space-padded.
+    [FixedWidthField(0, 10)]
+    public string FirstName { get; set; } = string.Empty;
+
+
+
+    // Column 1: 10-character last name, left-aligned, space-padded.
+    [FixedWidthField(1, 10)]
+    public string LastName { get; set; } = string.Empty;
+
+
+
+    // Column 2: 3-character age, right-aligned, zero-padded.
+    [FixedWidthField(2, 3, Alignment = FieldAlignment.Right, Pad = '0')]
+    public int Age { get; set; }
+}

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthConverter.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthConverter.cs
@@ -78,7 +78,7 @@ public static class FixedWidthConverter
             {
                 throw new FieldOverflowException
                 (
-                    $"Value for property '{context.PropertyName}' has length {text.Length} which " + $"exceeds the defined field width of {context.FieldLength}.",
+                    $"Value for property '{context.PropertyName}' has length {text.Length} which exceeds the defined field width of {context.FieldLength}.",
                     context.PropertyName,
                     context.FieldLength,
                     text.Length

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthConverter.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthConverter.cs
@@ -314,7 +314,8 @@ public static class FixedWidthConverter
             (
                 text,
                 underlying,
-                format
+                format,
+                cachedConverter
             );
         }
 

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
@@ -888,7 +888,9 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
     /// Throws <see cref="LineTooShortException"/> when the policy is
     /// <see cref="BlankLineHandling.ThrowException"/>.
     /// </summary>
-    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <see cref="BlankLineHandling"/> holds an unrecognized value.
+    /// </exception>
     /// <exception cref="LineTooShortException">
     /// Thrown when <see cref="BlankLineHandling"/> is
     /// <see cref="BlankLineHandling.ThrowException"/> (the default).
@@ -944,11 +946,14 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
     /// Returns <see langword="true"/> and sets <paramref name="record"/> on success.
     /// Returns <see langword="false"/> when <see cref="MalformedLineHandling"/> is
     /// <see cref="MalformedLineHandling.Skip"/> and the line cannot be parsed.
-    /// Yields a default record and returns <see langword="false"/> when the policy
-    /// is <see cref="MalformedLineHandling.ReturnDefault"/>.
+    /// Sets a default record and returns <see langword="true"/> when the policy
+    /// is <see cref="MalformedLineHandling.ReturnDefault"/> (the caller performs
+    /// the yield).
     /// Re-throws on <see cref="MalformedLineHandling.ThrowException"/>.
     /// </summary>
-    /// <exception cref="InvalidOperationException"></exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <see cref="MalformedLineHandling"/> holds an unrecognized value.
+    /// </exception>
     private bool TryParseLine(string line, FieldMapResult fieldMap, out TRecord record)
     {
         record = default!;

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
@@ -163,8 +163,7 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
     /// <exception cref="ArgumentNullException"><paramref name="stream"/> is null.</exception>
     public FixedWidthExtractor(Stream stream)
     {
-        if (stream == null) throw new ArgumentNullException(nameof(stream));
-        _reader = new StreamReader(stream, encoding: System.Text.Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: DefaultBufferSize, leaveOpen: true);
+        _reader = CreateBufferedReader(stream);
         _ownsReader = true;
         _logger = NullLogger.Instance;
     }
@@ -191,8 +190,7 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
         ILogger<FixedWidthExtractor<TRecord>> logger
     )
     {
-        if (stream == null) throw new ArgumentNullException(nameof(stream));
-        _reader = new StreamReader(stream, encoding: System.Text.Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: DefaultBufferSize, leaveOpen: true);
+        _reader = CreateBufferedReader(stream);
         _ownsReader = true;
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -224,11 +222,24 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
         ILogger<FixedWidthExtractor<TRecord>>? logger = null
     )
     {
-        if (stream == null) throw new ArgumentNullException(nameof(stream));
-        _reader = new StreamReader(stream, encoding: System.Text.Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: DefaultBufferSize, leaveOpen: true);
+        _reader = CreateBufferedReader(stream);
         _ownsReader = true;
         _progressTimer = timer ?? throw new ArgumentNullException(nameof(timer));
         _logger = logger ?? (ILogger)NullLogger.Instance;
+    }
+
+
+
+    /// <summary>
+    /// Creates the internal <see cref="StreamReader"/> shared by the
+    /// <see cref="Stream"/>-based constructors: UTF-8, BOM detection, a 64 KB
+    /// buffer, and <c>leaveOpen: true</c> so the caller retains stream ownership.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="stream"/> is null.</exception>
+    private static StreamReader CreateBufferedReader(Stream stream)
+    {
+        if (stream == null) throw new ArgumentNullException(nameof(stream));
+        return new StreamReader(stream, encoding: System.Text.Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: DefaultBufferSize, leaveOpen: true);
     }
 
 
@@ -881,6 +892,15 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
 
 
     /// <summary>
+    /// Creates a default <typeparamref name="TRecord"/> instance via the field map's
+    /// compiled factory. Used by the <see cref="BlankLineHandling.ReturnDefault"/> and
+    /// <see cref="MalformedLineHandling.ReturnDefault"/> paths.
+    /// </summary>
+    private static TRecord CreateDefaultRecord(FieldMapResult fieldMap) => (TRecord)fieldMap.Factory();
+
+
+
+    /// <summary>
     /// Handles a blank line according to <see cref="BlankLineHandling"/>.
     /// Returns <see langword="true"/> when a default record should be yielded,
     /// passing it back via <paramref name="defaultRecord"/>.
@@ -905,7 +925,7 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
                 return false;
 
             case BlankLineHandling.ReturnDefault:
-                defaultRecord = (TRecord)fieldMap.Factory();
+                defaultRecord = CreateDefaultRecord(fieldMap);
                 return true;
 
             case BlankLineHandling.ThrowException:
@@ -981,7 +1001,7 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
 
                 case MalformedLineHandling.ReturnDefault:
                     // Cannot yield inside catch — caller handles the yield and increment.
-                    record = (TRecord)fieldMap.Factory();
+                    record = CreateDefaultRecord(fieldMap);
                     return true;
 
                 case MalformedLineHandling.ThrowException:

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthLoader.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthLoader.cs
@@ -243,8 +243,8 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>
     /// <remarks>
     /// The converter receives the raw boxed property value and a <see cref="FieldContext"/>
     /// describing the field. It must return a string no longer than
-    /// <see cref="FieldContext.FieldLength"/>; otherwise the safety-net inside
-    /// <c>FormatSegment</c> will throw a
+    /// <see cref="FieldContext.FieldLength"/>; otherwise the loader's field-width
+    /// safety-net will throw a
     /// <see cref="Exceptions.FieldOverflowException"/>.
     /// </remarks>
     /// <example>

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthLoader.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthLoader.cs
@@ -162,8 +162,7 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>
     /// <exception cref="ArgumentNullException"><paramref name="stream"/> is null.</exception>
     public FixedWidthLoader(Stream stream)
     {
-        if (stream == null) throw new ArgumentNullException(nameof(stream));
-        _writer = new StreamWriter(stream, encoding: System.Text.Encoding.UTF8, bufferSize: DefaultBufferSize, leaveOpen: true);
+        _writer = CreateBufferedWriter(stream);
         _ownsWriter = true;
         _logger = NullLogger.Instance;
     }
@@ -190,8 +189,7 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>
         ILogger<FixedWidthLoader<TRecord>> logger
     )
     {
-        if (stream == null) throw new ArgumentNullException(nameof(stream));
-        _writer = new StreamWriter(stream, encoding: System.Text.Encoding.UTF8, bufferSize: DefaultBufferSize, leaveOpen: true);
+        _writer = CreateBufferedWriter(stream);
         _ownsWriter = true;
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -223,11 +221,24 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>
         ILogger<FixedWidthLoader<TRecord>>? logger = null
     )
     {
-        if (stream == null) throw new ArgumentNullException(nameof(stream));
-        _writer = new StreamWriter(stream, encoding: System.Text.Encoding.UTF8, bufferSize: DefaultBufferSize, leaveOpen: true);
+        _writer = CreateBufferedWriter(stream);
         _ownsWriter = true;
         _progressTimer = timer ?? throw new ArgumentNullException(nameof(timer));
         _logger = logger ?? (ILogger)NullLogger.Instance;
+    }
+
+
+
+    /// <summary>
+    /// Creates the internal <see cref="StreamWriter"/> shared by the
+    /// <see cref="Stream"/>-based constructors: UTF-8, a 64 KB buffer, and
+    /// <c>leaveOpen: true</c> so the caller retains stream ownership.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="stream"/> is null.</exception>
+    private static StreamWriter CreateBufferedWriter(Stream stream)
+    {
+        if (stream == null) throw new ArgumentNullException(nameof(stream));
+        return new StreamWriter(stream, encoding: System.Text.Encoding.UTF8, bufferSize: DefaultBufferSize, leaveOpen: true);
     }
 
 
@@ -645,9 +656,8 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>
     {
         var ex = new InvalidOperationException
         (
-            $"A null record was encountered at item " +
-            $"{CurrentItemCount + CurrentSkippedItemCount + 1}. " +
-            $"The loader writes what it is given — null records are not permitted."
+            $"A null record was encountered at item {CurrentItemCount + CurrentSkippedItemCount + 1}. " +
+            "The loader writes what it is given — null records are not permitted."
         );
 
         _logger.LogError

--- a/src/Wolfgang.Etl.FixedWidth/Parsing/FixedWidthLineParser.cs
+++ b/src/Wolfgang.Etl.FixedWidth/Parsing/FixedWidthLineParser.cs
@@ -378,8 +378,8 @@ internal static class FixedWidthLineParser
     {
         var attr = descriptor.Attribute;
         var prop = descriptor.Property;
-        var headerLabel = attr.Header ?? prop.Name;
-        var text = headerConverter(headerLabel, descriptor.Context);
+        // Reuse the label precomputed on the context (attribute.Header ?? property.Name).
+        var text = headerConverter(descriptor.Context.HeaderLabel, descriptor.Context);
 
         if (text.Length > attr.Length)
         {

--- a/src/Wolfgang.Etl.FixedWidth/Parsing/FixedWidthLineParser.cs
+++ b/src/Wolfgang.Etl.FixedWidth/Parsing/FixedWidthLineParser.cs
@@ -15,7 +15,6 @@ namespace Wolfgang.Etl.FixedWidth.Parsing;
 internal static class FixedWidthLineParser
 {
     // ------------------------------------------------------------------
-    // ------------------------------------------------------------------
     // Direct-write formatting — writes segments directly to a TextWriter
     // to avoid intermediate List<string> and Join allocations.
     // ------------------------------------------------------------------
@@ -26,7 +25,9 @@ internal static class FixedWidthLineParser
     /// is inserted between adjacent logical columns (including skip columns) to match
     /// the parser's <see cref="FieldDescriptor.AbsoluteColumnIndex"/> semantics.
     /// </summary>
-    /// <exception cref="FieldOverflowException"></exception>
+    /// <exception cref="FieldOverflowException">
+    /// Thrown when a converted value is wider than its declared field length.
+    /// </exception>
     internal static void WriteRecord<T>
     (
         TextWriter writer,
@@ -64,7 +65,9 @@ internal static class FixedWidthLineParser
     /// <summary>
     /// Writes a header line directly to <paramref name="writer"/>.
     /// </summary>
-    /// <exception cref="FieldOverflowException"></exception>
+    /// <exception cref="FieldOverflowException">
+    /// Thrown when a converted header label is wider than its declared field length.
+    /// </exception>
     internal static void WriteHeader
     (
         TextWriter writer,
@@ -285,7 +288,9 @@ internal static class FixedWidthLineParser
     /// the intermediate <see cref="string.PadLeft(int,char)"/> /
     /// <see cref="string.PadRight(int,char)"/> allocation.
     /// </summary>
-    /// <exception cref="FieldOverflowException"></exception>
+    /// <exception cref="FieldOverflowException">
+    /// Thrown when the converted value is wider than its declared field length.
+    /// </exception>
     /// <exception cref="InvalidOperationException">
     /// Thrown when the property has no public getter.
     /// </exception>
@@ -322,7 +327,7 @@ internal static class FixedWidthLineParser
         var padCount = attr.Length - text.Length;
 #if NET8_0_OR_GREATER
         // Stack-allocate the full padded field so it can be written in a single
-        // call when small enough — typical fixed-width fields are ≤128 chars.
+        // call when small enough — fields up to 256 chars use the stack path.
         const int stackFieldLimit = 256;
         if (attr.Length <= stackFieldLimit)
         {
@@ -361,7 +366,9 @@ internal static class FixedWidthLineParser
     /// "label + space-padding", avoiding the intermediate
     /// <see cref="string.PadRight(int,char)"/> allocation.
     /// </summary>
-    /// <exception cref="FieldOverflowException"></exception>
+    /// <exception cref="FieldOverflowException">
+    /// Thrown when the converted header label is wider than its declared field length.
+    /// </exception>
     private static void WriteHeaderSegmentTo
     (
         TextWriter writer,
@@ -401,12 +408,16 @@ internal static class FixedWidthLineParser
     /// <typeparamref name="T"/>. Validates that the line is long enough to satisfy
     /// all field and skip definitions plus any delimiter contribution before parsing.
     /// </summary>
-    /// <param name="line"></param>
-    /// <param name="lineNumber"></param>
-    /// <param name="fieldMap"></param>
-    /// <param name="fieldDelimiter"></param>
-    /// <param name="valueParser"></param>
-    /// <exception cref="LineTooShortException"></exception>
+    /// <typeparam name="T">The record type to materialize.</typeparam>
+    /// <param name="line">The raw fixed-width line to parse.</param>
+    /// <param name="lineNumber">The 1-based line number, used for diagnostics.</param>
+    /// <param name="fieldMap">The resolved field map describing the columns.</param>
+    /// <param name="fieldDelimiter">Optional delimiter inserted between columns, or <see langword="null"/>.</param>
+    /// <param name="valueParser">Optional value parser; defaults to <see cref="FixedWidthConverter.DefaultParser"/>.</param>
+    /// <returns>A new <typeparamref name="T"/> populated from <paramref name="line"/>.</returns>
+    /// <exception cref="LineTooShortException">
+    /// Thrown when <paramref name="line"/> is shorter than the columns require.
+    /// </exception>
     internal static T ParseLine<T>
     (
         string line,

--- a/src/Wolfgang.Etl.FixedWidth/Wolfgang.Etl.FixedWidth.csproj
+++ b/src/Wolfgang.Etl.FixedWidth/Wolfgang.Etl.FixedWidth.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net481;netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Version>0.2.3</Version>
+    <Version>0.3.0</Version>
     <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
          do not need to recompile / add binding redirects on every minor/patch
          bump. Bump only on a deliberate breaking API change. FileVersion +


### PR DESCRIPTION
Release **v0.3.0** — folds the current `vNext` cycle into `main`.

### Contents (since v0.2.3)
- **Added:** `CompressedStreams` example — GZip/Brotli round trip + README & DocFX docs ([#206], closes #32)
- **Changed (perf):** reuse the cached `TypeConverter` across the nullable-unwrap recursion in the value parser — drops a redundant per-value `TypeDescriptor.GetConverter` lookup for nullable `TypeConverter`-backed fields; behavior unchanged ([#208])
- **Maintenance (no public-API / no behavior change):** XML-doc corrections + small source simplifications ([#207], [#209])
- **Release prep:** `<Version>` → 0.3.0, CHANGELOG promoted ([#210])

### Release hygiene
- **Protected files:** none in this release diff (all changes are `src`/examples/docs/CHANGELOG/csproj) — **no separate protected-file PR required**, no admin-bypass needed.
- **Public API:** surface unchanged; `PublicAPI.Shipped.txt`/`Unshipped.txt` untouched.
- Build clean across all 5 TFMs; 289/289 tests pass.

### ⚠️ Merge order
1. Merge **#210 into `vNext` first** (so the 0.3.0 version bump + CHANGELOG land in `vNext` — this PR will then include them).
2. Merge **this PR** (`vNext → main`).
3. Create the **`v0.3.0`** tag/release — `release.yaml` publishes to NuGet via OIDC trusted-publishing.
4. Post-release: delete `vNext` (per-cycle; recreate next cycle).

[#206]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/206
[#207]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/207
[#208]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/208
[#209]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/209
[#210]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/210