### PR TITLE
docs: fix duplicate gzip variable in README compression snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,13 +117,13 @@ Because the `Stream` constructors accept any `Stream`, compression works out of 
 ```csharp
 // Extraction from a GZip-compressed file
 await using var readStream = File.OpenRead("people.dat.gz");
-await using var gzip = new GZipStream(readStream, CompressionMode.Decompress);
-using var extractor = new FixedWidthExtractor<PersonRecord>(gzip);
+await using var readGzip = new GZipStream(readStream, CompressionMode.Decompress);
+using var extractor = new FixedWidthExtractor<PersonRecord>(readGzip);
 
 // Loading to a GZip-compressed file
 await using var writeStream = File.Create("output.dat.gz");
-await using var gzip = new GZipStream(writeStream, CompressionLevel.Optimal);
-using var loader = new FixedWidthLoader<PersonRecord>(gzip);
+await using var writeGzip = new GZipStream(writeStream, CompressionLevel.Optimal);
+using var loader = new FixedWidthLoader<PersonRecord>(writeGzip);
 ```
 
 See the [CompressedStreams](examples/CompressedStreams) example for a complete GZip and Brotli round trip.


### PR DESCRIPTION
Addresses the Copilot review comment on the v0.3.0 release PR (#211).

The compressed-streams snippet in the README declared `gzip` twice in the same code block (once for decompression, once for compression), so it would not compile as written. Renamed to `readGzip` / `writeGzip`.

Docs only. Targets `vNext` so it flows into the v0.3.0 release via #211.