### PR TITLE
build: harden build-pr.ps1 gitleaks install (macOS arch + tar-from-stdin)

### DIFF
--- a/scripts/build-pr.ps1
+++ b/scripts/build-pr.ps1
@@ -295,18 +295,13 @@ if (-not $SkipSecurity) {
             $env:PATH = "$dest;$env:PATH"
         }
         else {
-            # gitleaks ships separate darwin / linux builds, and on macOS we
-            # also have to pick between x64 (Intel) and arm64 (Apple Silicon).
-            # Without this branch the macOS path would download the Linux
-            # tarball and either fail to install or install an incompatible
-            # binary.
-            if ($IsMacOS) {
-                $arch = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq 'Arm64') { 'arm64' } else { 'x64' }
-                $archive = "gitleaks_${version}_darwin_${arch}.tar.gz"
-            }
-            else {
-                $archive = "gitleaks_${version}_linux_x64.tar.gz"
-            }
+            # gitleaks ships per-OS, per-arch builds. Pick the matching archive
+            # for the current platform (linux/darwin x64/arm64) — hard-coding
+            # x64 would install an incompatible binary on ARM64 Linux (e.g.
+            # Graviton) or Apple Silicon.
+            $arch = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq 'Arm64') { 'arm64' } else { 'x64' }
+            $os = if ($IsMacOS) { 'darwin' } else { 'linux' }
+            $archive = "gitleaks_${version}_${os}_${arch}.tar.gz"
             $url = "https://github.com/gitleaks/gitleaks/releases/download/v${version}/$archive"
             # Install to a user-writable location instead of /usr/local/bin
             # (which would require sudo for most local dev shells). $HOME/.local/bin

--- a/scripts/build-pr.ps1
+++ b/scripts/build-pr.ps1
@@ -295,14 +295,29 @@ if (-not $SkipSecurity) {
             $env:PATH = "$dest;$env:PATH"
         }
         else {
-            $archive = "gitleaks_${version}_linux_x64.tar.gz"
+            # gitleaks ships separate darwin / linux builds, and on macOS we
+            # also have to pick between x64 (Intel) and arm64 (Apple Silicon).
+            # Without this branch the macOS path would download the Linux
+            # tarball and either fail to install or install an incompatible
+            # binary.
+            if ($IsMacOS) {
+                $arch = if ([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture -eq 'Arm64') { 'arm64' } else { 'x64' }
+                $archive = "gitleaks_${version}_darwin_${arch}.tar.gz"
+            }
+            else {
+                $archive = "gitleaks_${version}_linux_x64.tar.gz"
+            }
             $url = "https://github.com/gitleaks/gitleaks/releases/download/v${version}/$archive"
             # Install to a user-writable location instead of /usr/local/bin
             # (which would require sudo for most local dev shells). $HOME/.local/bin
             # is on PATH by default on most Linux distros and macOS; if not, prepend it.
             $localBin = Join-Path $HOME ".local/bin"
             New-Item -ItemType Directory -Force -Path $localBin | Out-Null
-            curl -sSfL $url | tar xz -C $localBin gitleaks
+            # Use 'tar -f -' so extraction reads the gitleaks archive from
+            # stdin. GNU tar without '-f' defaults to /dev/tape (or another
+            # default depending on the TAPE env var), which can hang silently
+            # in CI / fresh shells.
+            curl -sSfL $url | tar -xz -f - -C $localBin gitleaks
             if (-not ($env:PATH -split [IO.Path]::PathSeparator | Where-Object { $_ -eq $localBin })) {
                 $env:PATH = "$localBin$([IO.Path]::PathSeparator)$env:PATH"
             }


### PR DESCRIPTION
Feeds two downstream improvements **up** into the canonical local pr.yaml mirror (`scripts/build-pr.ps1`), found during a fleet audit of the ETL repos' local gates.

- **macOS darwin/arm64 branch** (from ETL-Xml) — the non-Windows path always downloaded the Linux tarball, which fails / installs an incompatible binary on macOS (esp. Apple Silicon).
- **`tar -xz -f -`** (from ETL-Json) — read the archive from stdin explicitly; GNU tar without `-f` defaults to `/dev/tape` and can hang silently in CI / fresh shells.

Dev-tooling script only — `build-pr.ps1` is not compiled or exercised by `pr.yaml`'s build/test/coverage gate, so there's no build/test surface here. PowerShell hand-verified (agent can't invoke `pwsh`).

Part of feeding these to canonical + repo-template so the whole fleet's local gate inherits them on the next template sync.