### PR TITLE
feat: implement ISupportDryRun on FixedWidthLoader (#197)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `FixedWidthLoader<TRecord>` now implements `ISupportDryRun`. Set `IsDryRun`
+  to `true` to run the full pipeline — enumerate the source, evaluate
+  `SkipItemCount` / `MaximumItemCount`, increment progress counters, fire the
+  progress-timer callback, and validate field widths — without writing anything
+  to the output fixed-width stream ([#197]).
+
 ### Changed
 
 ### Deprecated
@@ -136,6 +142,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#83]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/83
 [#84]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/84
 [#86]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/86
+[#197]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/197
 [#207]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/207
 [#208]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/208
 [#209]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/209

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthLoader.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthLoader.cs
@@ -45,7 +45,7 @@ namespace Wolfgang.Etl.FixedWidth;
 /// loader.FieldDelimiter = " | ";
 /// </code>
 /// </remarks>
-public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>
+public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, ISupportDryRun
     where TRecord : notnull
 {
     // ------------------------------------------------------------------
@@ -318,6 +318,21 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>
 
 
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// When <see langword="true"/>, the loader enumerates the source and evaluates
+    /// <see cref="Abstractions.LoaderBase{TDestination,TProgress}.SkipItemCount"/> /
+    /// <see cref="Abstractions.LoaderBase{TDestination,TProgress}.MaximumItemCount"/>,
+    /// increments progress counters, fires the progress-timer callback, and logs as
+    /// usual — but writes nothing to the output fixed-width stream. Field-width
+    /// validation still runs, so a dry run surfaces
+    /// <see cref="Exceptions.FieldOverflowException"/> the same way a real run would.
+    /// Defaults to <see langword="false"/>.
+    /// </remarks>
+    public bool IsDryRun { get; set; }
+
+
+
     /// <summary>
     /// When non-null, a separator line is written after the header, consisting of
     /// the specified character repeated to each field's width.
@@ -449,9 +464,15 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>
         var fieldMap = FieldMap.GetResult<TRecord>();
         LogLoadingStarted(fieldMap);
 
+        // In dry-run mode, route all formatting through a throwaway writer so the
+        // pipeline — including field-width validation — still runs, but nothing
+        // reaches the output stream. The real writer is left untouched and so
+        // flushes nothing below.
+        var target = IsDryRun ? TextWriter.Null : _writer;
+
         if (WriteHeader)
         {
-            await WriteHeaderAsync(fieldMap).ConfigureAwait(false);
+            await WriteHeaderAsync(fieldMap, target).ConfigureAwait(false);
         }
 
         await foreach (var item in items.WithCancellation(token).ConfigureAwait(false))
@@ -478,29 +499,47 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>
 
             FixedWidthLineParser.WriteRecord
             (
-                _writer,
+                target,
                 item,
                 fieldMap,
                 ValueConverter,
                 FieldDelimiter
             );
             Interlocked.Increment(ref _currentLineNumber);
-            await _writer.WriteLineAsync().ConfigureAwait(false);
+            await target.WriteLineAsync().ConfigureAwait(false);
             IncrementCurrentItemCount();
             LogDebugRecordWritten();
         }
 
-        if (_ownsWriter)
-        {
-#if NET8_0_OR_GREATER
-            await _writer.FlushAsync(token).ConfigureAwait(false);
-#else
-            token.ThrowIfCancellationRequested();
-            await _writer.FlushAsync().ConfigureAwait(false);
-#endif
-        }
+        await FlushIfOwnedAsync(token).ConfigureAwait(false);
 
         LogLoadingCompleted();
+    }
+
+
+
+    /// <summary>
+    /// Flushes the internal writer when the loader owns it (the <see cref="Stream"/>
+    /// constructors). No-op for caller-supplied writers, which the caller flushes.
+    /// In dry-run mode the writer received no writes, so this flushes nothing.
+    /// </summary>
+    private async Task FlushIfOwnedAsync(CancellationToken token)
+    {
+        // In dry-run mode nothing was written to the owned writer, so there is
+        // nothing to flush. Flushing anyway would emit the StreamWriter's UTF-8
+        // preamble (BOM) to the stream on .NET Framework, which the dry-run
+        // contract treats as a side effect.
+        if (!_ownsWriter || IsDryRun)
+        {
+            return;
+        }
+
+#if NET8_0_OR_GREATER
+        await _writer.FlushAsync(token).ConfigureAwait(false);
+#else
+        token.ThrowIfCancellationRequested();
+        await _writer.FlushAsync().ConfigureAwait(false);
+#endif
     }
 
 
@@ -509,17 +548,17 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>
     /// Writes the header line and, if <see cref="FieldSeparator"/> is set, the
     /// separator line that follows it.
     /// </summary>
-    private async Task WriteHeaderAsync(FieldMapResult fieldMap)
+    private async Task WriteHeaderAsync(FieldMapResult fieldMap, TextWriter target)
     {
         FixedWidthLineParser.WriteHeader
         (
-            _writer,
+            target,
             fieldMap,
             HeaderConverter,
             FieldDelimiter
         );
         Interlocked.Increment(ref _currentLineNumber);
-        await _writer.WriteLineAsync().ConfigureAwait(false);
+        await target.WriteLineAsync().ConfigureAwait(false);
 
         if (_logger.IsEnabled(LogLevel.Debug))
         {
@@ -530,13 +569,13 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>
         {
             FixedWidthLineParser.WriteSeparator
             (
-                _writer,
+                target,
                 fieldMap,
                 FieldSeparator.Value,
                 FieldDelimiter
             );
             Interlocked.Increment(ref _currentLineNumber);
-            await _writer.WriteLineAsync().ConfigureAwait(false);
+            await target.WriteLineAsync().ConfigureAwait(false);
 
             if (_logger.IsEnabled(LogLevel.Debug))
             {

--- a/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.IsDryRun.get -> bool
+Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.IsDryRun.set -> void

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthLoaderDryRunContractTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthLoaderDryRunContractTests.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Wolfgang.Etl.TestKit.Xunit;
+
+namespace Wolfgang.Etl.FixedWidth.Tests.Unit;
+
+/// <summary>
+/// Verifies <see cref="FixedWidthLoader{TRecord}"/> honors the
+/// <c>ISupportDryRun</c> contract: a dry run enumerates the source but writes
+/// nothing to the output stream, while a normal run does write.
+/// </summary>
+public class FixedWidthLoaderDryRunContractTests
+    : SupportsDryRunContractTests<FixedWidthLoader<PersonRecord>>
+{
+    private static readonly IReadOnlyList<PersonRecord> SourceItems = new List<PersonRecord>
+    {
+        new() { FirstName = "Alice", LastName = "Anderson", Age = 25 },
+        new() { FirstName = "Bob", LastName = "Brown", Age = 30 },
+    };
+
+
+
+    protected override FixedWidthLoader<PersonRecord> CreateSut() =>
+        new(new MemoryStream());
+
+
+
+    protected override async Task<bool> RunAndReportSideEffectAsync(bool isDryRun)
+    {
+        var stream = new MemoryStream();
+        var sut = new FixedWidthLoader<PersonRecord>(stream) { IsDryRun = isDryRun };
+
+        await sut.LoadAsync(SourceItems.ToAsyncEnumerable());
+
+        // The Stream constructor owns (and flushes) the writer, so any bytes
+        // written show up here. A dry run must leave the stream empty.
+        return stream.Length > 0;
+    }
+}


### PR DESCRIPTION
Implements `ISupportDryRun` on `FixedWidthLoader<TRecord>` — part of the fleet-wide dry-run rollout (Abstractions 0.15.0, already referenced).

## Behavior
When `IsDryRun` is `true`, the loader runs the **full** pipeline — enumerate the source, evaluate `SkipItemCount` / `MaximumItemCount`, increment progress counters, fire the progress-timer callback, log, **and validate field widths** — but writes nothing to the output stream. Defaults to `false`.

## Implementation
- Formatting is routed through `TextWriter.Null` in dry-run, so field-width validation still runs (a dry run surfaces `FieldOverflowException` exactly like a real run) while the real writer is left untouched.
- The owned-writer flush is skipped in dry-run — otherwise the `StreamWriter` emits its UTF-8 **BOM** on .NET Framework even with no content, which the contract treats as a side effect (the same quirk ETL-Json #200 hit). *Caught locally by the full-matrix gate before pushing.*

## Tests / surface
- New `FixedWidthLoaderDryRunContractTests : SupportsDryRunContractTests<FixedWidthLoader<PersonRecord>>` (TestKit.Xunit 0.10.0, already referenced).
- `IsDryRun` added to `PublicAPI.Unshipped.txt`; CHANGELOG `[Unreleased]` entry. Additive surface → **MINOR** (version bump deferred to release prep, per the vNext flow).

## Local verification (full pr.yaml gate via dotnet)
- Release build: 0 warnings, all TFMs
- **Full 13-TFM test matrix: 294/294 pass** (net462→net10.0)
- Coverage: 95.2% assembly / 93.7% loader (above the 90% gate)

Closes #197