### PR TITLE
chore: prepare v0.4.0 release (version bump + CHANGELOG + PublicAPI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `FixedWidthLoader<TRecord>` now implements `ISupportDryRun`. Set `IsDryRun`
-  to `true` to run the full pipeline — enumerate the source, evaluate
-  `SkipItemCount` / `MaximumItemCount`, increment progress counters, fire the
-  progress-timer callback, and validate field widths — without writing anything
-  to the output fixed-width stream ([#197]).
-
 ### Changed
 
 ### Deprecated
@@ -24,6 +18,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Security
+
+## [0.4.0] - 2026-07-14
+
+### Added
+
+- `FixedWidthLoader<TRecord>` now implements `ISupportDryRun`. Set `IsDryRun`
+  to `true` to run the full pipeline — enumerate the source, evaluate
+  `SkipItemCount` / `MaximumItemCount`, increment progress counters, fire the
+  progress-timer callback, and validate field widths — without writing anything
+  to the output fixed-width stream ([#197]).
 
 ## [0.3.0] - 2026-07-13
 
@@ -128,7 +132,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   parsing for reduced allocations.
 - Nine runnable example console apps covering the major features.
 
-[Unreleased]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.2.3...v0.3.0
 [0.2.3]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.2.1...v0.2.2

--- a/src/Wolfgang.Etl.FixedWidth/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Etl.FixedWidth/PublicAPI.Shipped.txt
@@ -96,6 +96,8 @@ Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.FixedWidthLoader(System.IO.Tex
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.FixedWidthLoader(System.IO.TextWriter writer, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>> logger) -> void
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.HeaderConverter.get -> System.Func<string, Wolfgang.Etl.FixedWidth.FieldContext, string>
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.HeaderConverter.set -> void
+Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.IsDryRun.get -> bool
+Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.IsDryRun.set -> void
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.ValueConverter.get -> System.Func<object, Wolfgang.Etl.FixedWidth.FieldContext, string>
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.ValueConverter.set -> void
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.WriteHeader.get -> bool

--- a/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 #nullable enable
-Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.IsDryRun.get -> bool
-Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.IsDryRun.set -> void

--- a/src/Wolfgang.Etl.FixedWidth/Wolfgang.Etl.FixedWidth.csproj
+++ b/src/Wolfgang.Etl.FixedWidth/Wolfgang.Etl.FixedWidth.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net481;netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
     <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
          do not need to recompile / add binding redirects on every minor/patch
          bump. Bump only on a deliberate breaking API change. FileVersion +


### PR DESCRIPTION
Release-prep for **v0.4.0**. Base: `vNext`.

### Changes
- **Version** `<Version>` `0.3.0 → 0.4.0` (MINOR — adds `FixedWidthLoader.ISupportDryRun`, #215 / closes #197).
- **CHANGELOG** — promoted `[Unreleased] → [0.4.0]` (2026-07-14) with the dry-run entry + compare/reference links.
- **PublicAPI** — promoted the two `IsDryRun` entries from `Unshipped.txt` to `Shipped.txt` (now released); `Unshipped.txt` reset to `#nullable enable`.

### Verified (full local pr.yaml gate via dotnet)
- Release build: **0 warnings** (PublicAPI analyzer accepts the promotion)
- **Full 13-TFM test matrix: 294/294 pass** (net462→net10.0)
- Coverage: 95.2%

### Remaining release steps (after this merges to `vNext`)
1. Merge `vNext → main` (release PR).
2. **You** create the `v0.4.0` tag/release — `release.yaml` publishes to NuGet via OIDC.
3. Post-release: delete `vNext`.