### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `FixedWidthLoader<TRecord>` now implements `ISupportDryRun`. Set `IsDryRun`
-  to `true` to run the full pipeline — enumerate the source, evaluate
-  `SkipItemCount` / `MaximumItemCount`, increment progress counters, fire the
-  progress-timer callback, and validate field widths — without writing anything
-  to the output fixed-width stream ([#197]).
-
 ### Changed
 
 ### Deprecated
@@ -24,6 +18,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Security
+
+## [0.4.0] - 2026-07-14
+
+### Added
+
+- `FixedWidthLoader<TRecord>` now implements `ISupportDryRun`. Set `IsDryRun`
+  to `true` to run the full pipeline — enumerate the source, evaluate
+  `SkipItemCount` / `MaximumItemCount`, increment progress counters, fire the
+  progress-timer callback, and validate field widths — without writing anything
+  to the output fixed-width stream ([#197]).
 
 ## [0.3.0] - 2026-07-13
 
@@ -128,7 +132,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   parsing for reduced allocations.
 - Nine runnable example console apps covering the major features.
 
-[Unreleased]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.2.3...v0.3.0
 [0.2.3]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.2.1...v0.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `FixedWidthLoader<TRecord>` now implements `ISupportDryRun`. Set `IsDryRun`
+  to `true` to run the full pipeline — enumerate the source, evaluate
+  `SkipItemCount` / `MaximumItemCount`, increment progress counters, fire the
+  progress-timer callback, and validate field widths — without writing anything
+  to the output fixed-width stream ([#197]).
+
 ### Changed
 
 ### Deprecated
@@ -136,6 +142,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#83]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/83
 [#84]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/84
 [#86]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/86
+[#197]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/197
 [#207]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/207
 [#208]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/208
 [#209]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/209

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthLoader.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthLoader.cs
@@ -45,7 +45,7 @@ namespace Wolfgang.Etl.FixedWidth;
 /// loader.FieldDelimiter = " | ";
 /// </code>
 /// </remarks>
-public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>
+public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, ISupportDryRun
     where TRecord : notnull
 {
     // ------------------------------------------------------------------
@@ -318,6 +318,21 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>
 
 
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// When <see langword="true"/>, the loader enumerates the source and evaluates
+    /// <see cref="Abstractions.LoaderBase{TDestination,TProgress}.SkipItemCount"/> /
+    /// <see cref="Abstractions.LoaderBase{TDestination,TProgress}.MaximumItemCount"/>,
+    /// increments progress counters, fires the progress-timer callback, and logs as
+    /// usual — but writes nothing to the output fixed-width stream. Field-width
+    /// validation still runs, so a dry run surfaces
+    /// <see cref="Exceptions.FieldOverflowException"/> the same way a real run would.
+    /// Defaults to <see langword="false"/>.
+    /// </remarks>
+    public bool IsDryRun { get; set; }
+
+
+
     /// <summary>
     /// When non-null, a separator line is written after the header, consisting of
     /// the specified character repeated to each field's width.
@@ -449,9 +464,15 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>
         var fieldMap = FieldMap.GetResult<TRecord>();
         LogLoadingStarted(fieldMap);
 
+        // In dry-run mode, route all formatting through a throwaway writer so the
+        // pipeline — including field-width validation — still runs, but nothing
+        // reaches the output stream. The real writer is left untouched and so
+        // flushes nothing below.
+        var target = IsDryRun ? TextWriter.Null : _writer;
+
         if (WriteHeader)
         {
-            await WriteHeaderAsync(fieldMap).ConfigureAwait(false);
+            await WriteHeaderAsync(fieldMap, target).ConfigureAwait(false);
         }
 
         await foreach (var item in items.WithCancellation(token).ConfigureAwait(false))
@@ -478,29 +499,47 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>
 
             FixedWidthLineParser.WriteRecord
             (
-                _writer,
+                target,
                 item,
                 fieldMap,
                 ValueConverter,
                 FieldDelimiter
             );
             Interlocked.Increment(ref _currentLineNumber);
-            await _writer.WriteLineAsync().ConfigureAwait(false);
+            await target.WriteLineAsync().ConfigureAwait(false);
             IncrementCurrentItemCount();
             LogDebugRecordWritten();
         }
 
-        if (_ownsWriter)
-        {
-#if NET8_0_OR_GREATER
-            await _writer.FlushAsync(token).ConfigureAwait(false);
-#else
-            token.ThrowIfCancellationRequested();
-            await _writer.FlushAsync().ConfigureAwait(false);
-#endif
-        }
+        await FlushIfOwnedAsync(token).ConfigureAwait(false);
 
         LogLoadingCompleted();
+    }
+
+
+
+    /// <summary>
+    /// Flushes the internal writer when the loader owns it (the <see cref="Stream"/>
+    /// constructors). No-op for caller-supplied writers, which the caller flushes.
+    /// In dry-run mode the writer received no writes, so this flushes nothing.
+    /// </summary>
+    private async Task FlushIfOwnedAsync(CancellationToken token)
+    {
+        // In dry-run mode nothing was written to the owned writer, so there is
+        // nothing to flush. Flushing anyway would emit the StreamWriter's UTF-8
+        // preamble (BOM) to the stream on .NET Framework, which the dry-run
+        // contract treats as a side effect.
+        if (!_ownsWriter || IsDryRun)
+        {
+            return;
+        }
+
+#if NET8_0_OR_GREATER
+        await _writer.FlushAsync(token).ConfigureAwait(false);
+#else
+        token.ThrowIfCancellationRequested();
+        await _writer.FlushAsync().ConfigureAwait(false);
+#endif
     }
 
 
@@ -509,17 +548,17 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>
     /// Writes the header line and, if <see cref="FieldSeparator"/> is set, the
     /// separator line that follows it.
     /// </summary>
-    private async Task WriteHeaderAsync(FieldMapResult fieldMap)
+    private async Task WriteHeaderAsync(FieldMapResult fieldMap, TextWriter target)
     {
         FixedWidthLineParser.WriteHeader
         (
-            _writer,
+            target,
             fieldMap,
             HeaderConverter,
             FieldDelimiter
         );
         Interlocked.Increment(ref _currentLineNumber);
-        await _writer.WriteLineAsync().ConfigureAwait(false);
+        await target.WriteLineAsync().ConfigureAwait(false);
 
         if (_logger.IsEnabled(LogLevel.Debug))
         {
@@ -530,13 +569,13 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>
         {
             FixedWidthLineParser.WriteSeparator
             (
-                _writer,
+                target,
                 fieldMap,
                 FieldSeparator.Value,
                 FieldDelimiter
             );
             Interlocked.Increment(ref _currentLineNumber);
-            await _writer.WriteLineAsync().ConfigureAwait(false);
+            await target.WriteLineAsync().ConfigureAwait(false);
 
             if (_logger.IsEnabled(LogLevel.Debug))
             {

--- a/src/Wolfgang.Etl.FixedWidth/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Etl.FixedWidth/PublicAPI.Shipped.txt
@@ -96,6 +96,8 @@ Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.FixedWidthLoader(System.IO.Tex
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.FixedWidthLoader(System.IO.TextWriter writer, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>> logger) -> void
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.HeaderConverter.get -> System.Func<string, Wolfgang.Etl.FixedWidth.FieldContext, string>
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.HeaderConverter.set -> void
+Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.IsDryRun.get -> bool
+Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.IsDryRun.set -> void
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.ValueConverter.get -> System.Func<object, Wolfgang.Etl.FixedWidth.FieldContext, string>
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.ValueConverter.set -> void
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.WriteHeader.get -> bool

--- a/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 #nullable enable
-Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.IsDryRun.get -> bool
-Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.IsDryRun.set -> void

--- a/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.IsDryRun.get -> bool
+Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.IsDryRun.set -> void

--- a/src/Wolfgang.Etl.FixedWidth/Wolfgang.Etl.FixedWidth.csproj
+++ b/src/Wolfgang.Etl.FixedWidth/Wolfgang.Etl.FixedWidth.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net481;netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Version>0.3.0</Version>
+    <Version>0.4.0</Version>
     <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
          do not need to recompile / add binding redirects on every minor/patch
          bump. Bump only on a deliberate breaking API change. FileVersion +

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthLoaderDryRunContractTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthLoaderDryRunContractTests.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Wolfgang.Etl.TestKit.Xunit;
+
+namespace Wolfgang.Etl.FixedWidth.Tests.Unit;
+
+/// <summary>
+/// Verifies <see cref="FixedWidthLoader{TRecord}"/> honors the
+/// <c>ISupportDryRun</c> contract: a dry run enumerates the source but writes
+/// nothing to the output stream, while a normal run does write.
+/// </summary>
+public class FixedWidthLoaderDryRunContractTests
+    : SupportsDryRunContractTests<FixedWidthLoader<PersonRecord>>
+{
+    private static readonly IReadOnlyList<PersonRecord> SourceItems = new List<PersonRecord>
+    {
+        new() { FirstName = "Alice", LastName = "Anderson", Age = 25 },
+        new() { FirstName = "Bob", LastName = "Brown", Age = 30 },
+    };
+
+
+
+    protected override FixedWidthLoader<PersonRecord> CreateSut() =>
+        new(new MemoryStream());
+
+
+
+    protected override async Task<bool> RunAndReportSideEffectAsync(bool isDryRun)
+    {
+        var stream = new MemoryStream();
+        var sut = new FixedWidthLoader<PersonRecord>(stream) { IsDryRun = isDryRun };
+
+        await sut.LoadAsync(SourceItems.ToAsyncEnumerable());
+
+        // The Stream constructor owns (and flushes) the writer, so any bytes
+        // written show up here. A dry run must leave the stream empty.
+        return stream.Length > 0;
+    }
+}


### PR DESCRIPTION
Release **v0.4.0** — folds the current `vNext` cycle into `main`.

### Contents (since v0.3.0)
- **Added:** `FixedWidthLoader<TRecord>` implements `ISupportDryRun` — `IsDryRun = true` runs the full pipeline (enumerate, skip/max, counters, progress, logging, field-width validation) without writing to the output stream ([#215], closes #197)
- **Release prep:** `<Version>` → 0.4.0, CHANGELOG promoted, `IsDryRun` promoted to `PublicAPI.Shipped.txt` ([#216])

### Release hygiene
- **Protected files:** none in this release diff (src/tests/CHANGELOG/csproj/PublicAPI) — **no protected-file PR / admin-bypass needed**.
- **Public API:** one additive member (`FixedWidthLoader.IsDryRun`) — MINOR bump.
- Full local gate green: 294/294 across all 13 TFMs, 95.2% coverage.

### ⚠️ Merge order
1. Merge **#216 into `vNext` first** (lands the 0.4.0 bump + CHANGELOG + PublicAPI promotion — this PR then includes them).
2. Merge **this PR** (`vNext → main`).
3. Create the **`v0.4.0`** tag/release — `release.yaml` publishes to NuGet via OIDC.
4. Post-release: delete `vNext`.

[#215]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/215
[#216]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/216