### PR TITLE
feat: add optional Encoding parameter to Stream constructors (#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Optional `Encoding` parameter on the `Stream`-based constructors of
+  `FixedWidthExtractor` and `FixedWidthLoader`. Defaults to `Encoding.UTF8`
+  (non-breaking); pass e.g. `new UTF8Encoding(false)` to write without a BOM,
+  or a code-page encoding for EBCDIC/mainframe data ([#16]).
+
 ### Changed
 
 ### Deprecated
@@ -146,6 +151,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#62]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/62
 [#83]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/83
 [#84]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/84
+[#16]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/16
 [#86]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/86
 [#197]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/197
 [#207]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/207

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Threading;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -160,10 +161,14 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
     /// The <see cref="Stream"/> to read fixed-width records from. The stream must be
     /// readable. The caller retains ownership — the extractor does not dispose the stream.
     /// </param>
+    /// <param name="encoding">
+    /// The <see cref="Encoding"/> used to decode the stream. Pass <see langword="null"/>
+    /// (the default) to use <see cref="Encoding.UTF8"/>.
+    /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="stream"/> is null.</exception>
-    public FixedWidthExtractor(Stream stream)
+    public FixedWidthExtractor(Stream stream, Encoding? encoding = null)
     {
-        _reader = CreateBufferedReader(stream);
+        _reader = CreateBufferedReader(stream, encoding);
         _ownsReader = true;
         _logger = NullLogger.Instance;
     }
@@ -181,16 +186,21 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
     /// readable. The caller retains ownership — the extractor does not dispose the stream.
     /// </param>
     /// <param name="logger">The logger instance for diagnostic output.</param>
+    /// <param name="encoding">
+    /// The <see cref="Encoding"/> used to decode the stream. Pass <see langword="null"/>
+    /// (the default) to use <see cref="Encoding.UTF8"/>.
+    /// </param>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="stream"/> or <paramref name="logger"/> is null.
     /// </exception>
     public FixedWidthExtractor
     (
         Stream stream,
-        ILogger<FixedWidthExtractor<TRecord>> logger
+        ILogger<FixedWidthExtractor<TRecord>> logger,
+        Encoding? encoding = null
     )
     {
-        _reader = CreateBufferedReader(stream);
+        _reader = CreateBufferedReader(stream, encoding);
         _ownsReader = true;
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -222,7 +232,7 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
         ILogger<FixedWidthExtractor<TRecord>>? logger = null
     )
     {
-        _reader = CreateBufferedReader(stream);
+        _reader = CreateBufferedReader(stream, encoding: null);
         _ownsReader = true;
         _progressTimer = timer ?? throw new ArgumentNullException(nameof(timer));
         _logger = logger ?? (ILogger)NullLogger.Instance;
@@ -232,14 +242,15 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
 
     /// <summary>
     /// Creates the internal <see cref="StreamReader"/> shared by the
-    /// <see cref="Stream"/>-based constructors: UTF-8, BOM detection, a 64 KB
-    /// buffer, and <c>leaveOpen: true</c> so the caller retains stream ownership.
+    /// <see cref="Stream"/>-based constructors: the requested encoding (or
+    /// <see cref="Encoding.UTF8"/>), BOM detection, a 64 KB buffer, and
+    /// <c>leaveOpen: true</c> so the caller retains stream ownership.
     /// </summary>
     /// <exception cref="ArgumentNullException"><paramref name="stream"/> is null.</exception>
-    private static StreamReader CreateBufferedReader(Stream stream)
+    private static StreamReader CreateBufferedReader(Stream stream, Encoding? encoding)
     {
         if (stream == null) throw new ArgumentNullException(nameof(stream));
-        return new StreamReader(stream, encoding: System.Text.Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: DefaultBufferSize, leaveOpen: true);
+        return new StreamReader(stream, encoding: encoding ?? Encoding.UTF8, detectEncodingFromByteOrderMarks: true, bufferSize: DefaultBufferSize, leaveOpen: true);
     }
 
 

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthLoader.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthLoader.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -159,10 +160,15 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
     /// The <see cref="Stream"/> to write fixed-width records to. The stream must be
     /// writable. The caller retains ownership — the loader does not dispose the stream.
     /// </param>
+    /// <param name="encoding">
+    /// The <see cref="Encoding"/> used to encode the output. Pass <see langword="null"/>
+    /// (the default) to use <see cref="Encoding.UTF8"/>. Use <c>new UTF8Encoding(false)</c>
+    /// to write UTF-8 without a byte-order mark.
+    /// </param>
     /// <exception cref="ArgumentNullException"><paramref name="stream"/> is null.</exception>
-    public FixedWidthLoader(Stream stream)
+    public FixedWidthLoader(Stream stream, Encoding? encoding = null)
     {
-        _writer = CreateBufferedWriter(stream);
+        _writer = CreateBufferedWriter(stream, encoding);
         _ownsWriter = true;
         _logger = NullLogger.Instance;
     }
@@ -180,16 +186,22 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
     /// writable. The caller retains ownership — the loader does not dispose the stream.
     /// </param>
     /// <param name="logger">The logger instance for diagnostic output.</param>
+    /// <param name="encoding">
+    /// The <see cref="Encoding"/> used to encode the output. Pass <see langword="null"/>
+    /// (the default) to use <see cref="Encoding.UTF8"/>. Use <c>new UTF8Encoding(false)</c>
+    /// to write UTF-8 without a byte-order mark.
+    /// </param>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="stream"/> or <paramref name="logger"/> is null.
     /// </exception>
     public FixedWidthLoader
     (
         Stream stream,
-        ILogger<FixedWidthLoader<TRecord>> logger
+        ILogger<FixedWidthLoader<TRecord>> logger,
+        Encoding? encoding = null
     )
     {
-        _writer = CreateBufferedWriter(stream);
+        _writer = CreateBufferedWriter(stream, encoding);
         _ownsWriter = true;
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -221,7 +233,7 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
         ILogger<FixedWidthLoader<TRecord>>? logger = null
     )
     {
-        _writer = CreateBufferedWriter(stream);
+        _writer = CreateBufferedWriter(stream, encoding: null);
         _ownsWriter = true;
         _progressTimer = timer ?? throw new ArgumentNullException(nameof(timer));
         _logger = logger ?? (ILogger)NullLogger.Instance;
@@ -231,14 +243,15 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
 
     /// <summary>
     /// Creates the internal <see cref="StreamWriter"/> shared by the
-    /// <see cref="Stream"/>-based constructors: UTF-8, a 64 KB buffer, and
-    /// <c>leaveOpen: true</c> so the caller retains stream ownership.
+    /// <see cref="Stream"/>-based constructors: the requested encoding (or
+    /// <see cref="Encoding.UTF8"/>), a 64 KB buffer, and <c>leaveOpen: true</c>
+    /// so the caller retains stream ownership.
     /// </summary>
     /// <exception cref="ArgumentNullException"><paramref name="stream"/> is null.</exception>
-    private static StreamWriter CreateBufferedWriter(Stream stream)
+    private static StreamWriter CreateBufferedWriter(Stream stream, Encoding? encoding)
     {
         if (stream == null) throw new ArgumentNullException(nameof(stream));
-        return new StreamWriter(stream, encoding: System.Text.Encoding.UTF8, bufferSize: DefaultBufferSize, leaveOpen: true);
+        return new StreamWriter(stream, encoding: encoding ?? Encoding.UTF8, bufferSize: DefaultBufferSize, leaveOpen: true);
     }
 
 

--- a/src/Wolfgang.Etl.FixedWidth/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Etl.FixedWidth/PublicAPI.Shipped.txt
@@ -70,8 +70,6 @@ Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.FieldDelimiter.get -> strin
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.FieldDelimiter.set -> void
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.FieldSeparator.get -> char?
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.FieldSeparator.set -> void
-Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.FixedWidthExtractor(System.IO.Stream stream) -> void
-Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.FixedWidthExtractor(System.IO.Stream stream, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>> logger) -> void
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.FixedWidthExtractor(System.IO.TextReader reader) -> void
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.FixedWidthExtractor(System.IO.TextReader reader, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>> logger) -> void
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.HasHeader.get -> bool
@@ -90,8 +88,6 @@ Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.FieldDelimiter.get -> string?
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.FieldDelimiter.set -> void
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.FieldSeparator.get -> char?
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.FieldSeparator.set -> void
-Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.FixedWidthLoader(System.IO.Stream stream) -> void
-Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.FixedWidthLoader(System.IO.Stream stream, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>> logger) -> void
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.FixedWidthLoader(System.IO.TextWriter writer) -> void
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.FixedWidthLoader(System.IO.TextWriter writer, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>> logger) -> void
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.HeaderConverter.get -> System.Func<string, Wolfgang.Etl.FixedWidth.FieldContext, string>

--- a/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
@@ -1,1 +1,5 @@
 #nullable enable
+Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.FixedWidthExtractor(System.IO.Stream stream, System.Text.Encoding encoding = null) -> void
+Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.FixedWidthExtractor(System.IO.Stream stream, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>> logger, System.Text.Encoding encoding = null) -> void
+Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.FixedWidthLoader(System.IO.Stream stream, System.Text.Encoding encoding = null) -> void
+Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.FixedWidthLoader(System.IO.Stream stream, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>> logger, System.Text.Encoding encoding = null) -> void

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthEncodingTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthEncodingTests.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Wolfgang.Etl.FixedWidth.Tests.Unit;
+
+/// <summary>
+/// Covers the optional <see cref="Encoding"/> parameter on the
+/// <see cref="Stream"/>-based constructors of the extractor and loader (#16).
+/// </summary>
+public class FixedWidthEncodingTests
+{
+    private static readonly IReadOnlyList<PersonRecord> People = new List<PersonRecord>
+    {
+        new() { FirstName = "Alice", LastName = "Anderson", Age = 25 },
+        new() { FirstName = "Bob", LastName = "Brown", Age = 30 },
+    };
+
+
+
+    [Fact]
+    public async Task Loader_writes_in_the_supplied_encoding_and_extractor_reads_it_back()
+    {
+        var stream = new MemoryStream();
+
+        var loader = new FixedWidthLoader<PersonRecord>(stream, Encoding.Unicode);
+        await loader.LoadAsync(People.ToAsyncEnumerable(), CancellationToken.None);
+
+        stream.Position = 0;
+        var extractor = new FixedWidthExtractor<PersonRecord>(stream, Encoding.Unicode);
+        var readBack = new List<PersonRecord>();
+        await foreach (var person in extractor.ExtractAsync(CancellationToken.None))
+        {
+            readBack.Add(person);
+        }
+
+        Assert.Equal(People, readBack);
+    }
+
+
+
+    [Fact]
+    public async Task Loader_with_UTF8_no_BOM_encoding_omits_the_byte_order_mark()
+    {
+        var stream = new MemoryStream();
+
+        using (var loader = new FixedWidthLoader<PersonRecord>(stream, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)))
+        {
+            await loader.LoadAsync(People.ToAsyncEnumerable(), CancellationToken.None);
+        }
+
+        var bytes = stream.ToArray();
+        var utf8Bom = Encoding.UTF8.GetPreamble();
+
+        Assert.False
+        (
+            bytes.Take(utf8Bom.Length).SequenceEqual(utf8Bom)
+        );
+    }
+
+
+
+    [Fact]
+    public async Task Loader_with_default_encoding_writes_the_UTF8_BOM()
+    {
+        var stream = new MemoryStream();
+
+        using (var loader = new FixedWidthLoader<PersonRecord>(stream))
+        {
+            await loader.LoadAsync(People.ToAsyncEnumerable(), CancellationToken.None);
+        }
+
+        var bytes = stream.ToArray();
+        var utf8Bom = Encoding.UTF8.GetPreamble();
+
+        Assert.True
+        (
+            bytes.Take(utf8Bom.Length).SequenceEqual(utf8Bom)
+        );
+    }
+}


### PR DESCRIPTION
Part 1 of 3 in a stacked enhancement series (#16 → #17 → #18). **Base: `vNext`.**

Adds an optional `Encoding? encoding = null` parameter to the `Stream`-based constructors of both `FixedWidthExtractor` and `FixedWidthLoader`. Defaults to `Encoding.UTF8` (non-breaking) and threads through the shared `CreateBufferedReader`/`CreateBufferedWriter` helpers.

**Why:** callers previously had to drop to the `TextReader`/`TextWriter` constructors to change encoding. Now they can pass e.g. `new UTF8Encoding(false)` to omit the BOM (common for fixed-width data files) or a code-page encoding for EBCDIC/mainframe exports.

- PublicAPI: old Stream-ctor entries retired from `Shipped.txt`; new signatures added to `Unshipped.txt` (RS0017 clean; matches the repo's optional-ref `= null` format).
- Tests: `FixedWidthEncodingTests` — encoding round-trip (UTF-16) + no-BOM / default-BOM byte assertions.

**Local gate (full pr.yaml via dotnet):** 0 warnings, **297/297 across all 13 TFMs**, 95.2% coverage. The BOM assertions pass on every Framework leg.

**Stack:** **this** → `feat/issue-17-line-endings` → `feat/issue-18-record-validator`.

Closes #16