### PR TITLE
feat: add configurable LineEnding on FixedWidthLoader (#17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `FixedWidthExtractor` and `FixedWidthLoader`. Defaults to `Encoding.UTF8`
   (non-breaking); pass e.g. `new UTF8Encoding(false)` to write without a BOM,
   or a code-page encoding for EBCDIC/mainframe data ([#16]).
+- `LineEnding` property on `FixedWidthLoader` (`Default`, `Lf`, `CrLf`, `None`)
+  to control the newline written after each record regardless of platform.
+  `None` omits the trailing newline after the final record. Defaults to
+  `Default` (the platform newline, preserving prior behavior) ([#17]).
 
 ### Changed
 
@@ -152,6 +156,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#83]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/83
 [#84]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/84
 [#16]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/16
+[#17]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/17
 [#86]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/86
 [#197]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/197
 [#207]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/207

--- a/src/Wolfgang.Etl.FixedWidth/Enums/LineEnding.cs
+++ b/src/Wolfgang.Etl.FixedWidth/Enums/LineEnding.cs
@@ -1,0 +1,31 @@
+namespace Wolfgang.Etl.FixedWidth.Enums;
+
+/// <summary>
+/// Controls the line ending written after each record by
+/// <see cref="FixedWidthLoader{TRecord}"/>.
+/// </summary>
+public enum LineEnding
+{
+    /// <summary>
+    /// The platform default (<see cref="System.Environment.NewLine"/>) after every
+    /// record, including the last. This is the default and preserves prior behavior.
+    /// </summary>
+    Default = 0,
+
+    /// <summary>
+    /// Unix-style line feed (<c>\n</c>) after every record, including the last.
+    /// </summary>
+    Lf = 1,
+
+    /// <summary>
+    /// Windows-style carriage return + line feed (<c>\r\n</c>) after every record,
+    /// including the last.
+    /// </summary>
+    CrLf = 2,
+
+    /// <summary>
+    /// No line ending after the final record. Intermediate records (and any header
+    /// or separator line) remain separated by <see cref="System.Environment.NewLine"/>.
+    /// </summary>
+    None = 3,
+}

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthLoader.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthLoader.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.FixedWidth.Enums;
 using Wolfgang.Etl.FixedWidth.Parsing;
 
 namespace Wolfgang.Etl.FixedWidth;
@@ -331,6 +332,18 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
 
 
 
+    /// <summary>
+    /// The line ending written after each record. Defaults to
+    /// <see cref="Enums.LineEnding.Default"/> (the platform newline after every
+    /// record, preserving prior behavior). Use <see cref="Enums.LineEnding.Lf"/> or
+    /// <see cref="Enums.LineEnding.CrLf"/> to pin the ending regardless of platform,
+    /// or <see cref="Enums.LineEnding.None"/> to omit the trailing newline after the
+    /// final record.
+    /// </summary>
+    public LineEnding LineEnding { get; set; }
+
+
+
     /// <inheritdoc />
     /// <remarks>
     /// When <see langword="true"/>, the loader enumerates the source and evaluates
@@ -482,12 +495,57 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
         // reaches the output stream. The real writer is left untouched and so
         // flushes nothing below.
         var target = IsDryRun ? TextWriter.Null : _writer;
+        var newLine = ResolveNewLine();
+        var linesWritten = 0;
+
+        // Emit the separating newline BEFORE every line except the first, so that
+        // LineEnding.None can suppress the trailing newline after the last line
+        // while all intermediate lines stay separated.
+        async Task SeparateAsync()
+        {
+            if (linesWritten > 0)
+            {
+                await target.WriteAsync(newLine).ConfigureAwait(false);
+            }
+            linesWritten++;
+        }
 
         if (WriteHeader)
         {
-            await WriteHeaderAsync(fieldMap, target).ConfigureAwait(false);
+            await WriteHeaderAsync(fieldMap, target, SeparateAsync).ConfigureAwait(false);
         }
 
+        await WriteRecordsAsync(items, target, fieldMap, SeparateAsync, token).ConfigureAwait(false);
+
+        if (LineEnding != LineEnding.None && linesWritten > 0)
+        {
+            await target.WriteAsync(newLine).ConfigureAwait(false);
+        }
+
+        await FlushIfOwnedAsync(token).ConfigureAwait(false);
+
+        LogLoadingCompleted();
+    }
+
+
+
+    /// <summary>
+    /// Enumerates the source, applying null/skip/max rules, and writes each record.
+    /// <paramref name="separateAsync"/> emits the inter-line newline before each
+    /// record (see <see cref="LoadWorkerAsync"/>).
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when a null record is encountered in <paramref name="items"/>.
+    /// </exception>
+    private async Task WriteRecordsAsync
+    (
+        IAsyncEnumerable<TRecord> items,
+        TextWriter target,
+        FieldMapResult fieldMap,
+        Func<Task> separateAsync,
+        CancellationToken token
+    )
+    {
         await foreach (var item in items.WithCancellation(token).ConfigureAwait(false))
         {
             token.ThrowIfCancellationRequested();
@@ -510,6 +568,7 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
                 break;
             }
 
+            await separateAsync().ConfigureAwait(false);
             FixedWidthLineParser.WriteRecord
             (
                 target,
@@ -519,15 +578,24 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
                 FieldDelimiter
             );
             Interlocked.Increment(ref _currentLineNumber);
-            await target.WriteLineAsync().ConfigureAwait(false);
             IncrementCurrentItemCount();
             LogDebugRecordWritten();
         }
-
-        await FlushIfOwnedAsync(token).ConfigureAwait(false);
-
-        LogLoadingCompleted();
     }
+
+
+
+    /// <summary>
+    /// Resolves the newline string used between records from <see cref="LineEnding"/>.
+    /// <see cref="Enums.LineEnding.None"/> uses <see cref="Environment.NewLine"/> as
+    /// the inter-record separator; the trailing newline is suppressed separately.
+    /// </summary>
+    private string ResolveNewLine() => LineEnding switch
+    {
+        LineEnding.Lf => "\n",
+        LineEnding.CrLf => "\r\n",
+        _ => Environment.NewLine,
+    };
 
 
 
@@ -559,10 +627,12 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
 
     /// <summary>
     /// Writes the header line and, if <see cref="FieldSeparator"/> is set, the
-    /// separator line that follows it.
+    /// separator line that follows it. <paramref name="separateAsync"/> emits the
+    /// inter-line newline (see <see cref="LoadWorkerAsync"/>).
     /// </summary>
-    private async Task WriteHeaderAsync(FieldMapResult fieldMap, TextWriter target)
+    private async Task WriteHeaderAsync(FieldMapResult fieldMap, TextWriter target, Func<Task> separateAsync)
     {
+        await separateAsync().ConfigureAwait(false);
         FixedWidthLineParser.WriteHeader
         (
             target,
@@ -571,7 +641,6 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
             FieldDelimiter
         );
         Interlocked.Increment(ref _currentLineNumber);
-        await target.WriteLineAsync().ConfigureAwait(false);
 
         if (_logger.IsEnabled(LogLevel.Debug))
         {
@@ -580,6 +649,7 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
 
         if (FieldSeparator.HasValue)
         {
+            await separateAsync().ConfigureAwait(false);
             FixedWidthLineParser.WriteSeparator
             (
                 target,
@@ -588,7 +658,6 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
                 FieldDelimiter
             );
             Interlocked.Increment(ref _currentLineNumber);
-            await target.WriteLineAsync().ConfigureAwait(false);
 
             if (_logger.IsEnabled(LogLevel.Debug))
             {

--- a/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
@@ -3,3 +3,10 @@ Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.FixedWidthExtractor(System.
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.FixedWidthExtractor(System.IO.Stream stream, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>> logger, System.Text.Encoding encoding = null) -> void
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.FixedWidthLoader(System.IO.Stream stream, System.Text.Encoding encoding = null) -> void
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.FixedWidthLoader(System.IO.Stream stream, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>> logger, System.Text.Encoding encoding = null) -> void
+Wolfgang.Etl.FixedWidth.Enums.LineEnding
+Wolfgang.Etl.FixedWidth.Enums.LineEnding.CrLf = 2 -> Wolfgang.Etl.FixedWidth.Enums.LineEnding
+Wolfgang.Etl.FixedWidth.Enums.LineEnding.Default = 0 -> Wolfgang.Etl.FixedWidth.Enums.LineEnding
+Wolfgang.Etl.FixedWidth.Enums.LineEnding.Lf = 1 -> Wolfgang.Etl.FixedWidth.Enums.LineEnding
+Wolfgang.Etl.FixedWidth.Enums.LineEnding.None = 3 -> Wolfgang.Etl.FixedWidth.Enums.LineEnding
+Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.LineEnding.get -> Wolfgang.Etl.FixedWidth.Enums.LineEnding
+Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.LineEnding.set -> void

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthLineEndingTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthLineEndingTests.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.FixedWidth.Enums;
+using Xunit;
+
+namespace Wolfgang.Etl.FixedWidth.Tests.Unit;
+
+/// <summary>
+/// Covers the <see cref="FixedWidthLoader{TRecord}.LineEnding"/> property (#17).
+/// </summary>
+public class FixedWidthLineEndingTests
+{
+    private static readonly IReadOnlyList<PersonRecord> People = new List<PersonRecord>
+    {
+        new() { FirstName = "Alice", LastName = "Anderson", Age = 25 },
+        new() { FirstName = "Bob", LastName = "Brown", Age = 30 },
+    };
+
+
+
+    private static async Task<string> LoadAsync(LineEnding lineEnding)
+    {
+        var writer = new StringWriter();
+        var loader = new FixedWidthLoader<PersonRecord>(writer) { LineEnding = lineEnding };
+
+        await loader.LoadAsync(People.ToAsyncEnumerable(), CancellationToken.None);
+
+        return writer.ToString();
+    }
+
+
+
+    private static int CountOccurrences(string text, string value)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = text.IndexOf(value, index, StringComparison.Ordinal)) != -1)
+        {
+            count++;
+            index += value.Length;
+        }
+
+        return count;
+    }
+
+
+
+    [Fact]
+    public async Task LineEnding_Lf_uses_line_feed_with_a_trailing_newline()
+    {
+        var output = await LoadAsync(LineEnding.Lf);
+
+        Assert.DoesNotContain("\r", output);
+        Assert.EndsWith("\n", output);
+        // Two records, each followed by a line feed (trailing included).
+        Assert.Equal(2, output.Count(c => c == '\n'));
+    }
+
+
+
+    [Fact]
+    public async Task LineEnding_CrLf_uses_carriage_return_line_feed()
+    {
+        var output = await LoadAsync(LineEnding.CrLf);
+
+        Assert.EndsWith("\r\n", output);
+        Assert.Equal(2, CountOccurrences(output, "\r\n"));
+    }
+
+
+
+    [Fact]
+    public async Task LineEnding_None_omits_the_trailing_newline()
+    {
+        var output = await LoadAsync(LineEnding.None);
+
+        Assert.False(output.EndsWith("\n", StringComparison.Ordinal));
+        // Two records → a single inter-record separator, no trailing newline.
+        Assert.Equal(1, CountOccurrences(output, Environment.NewLine));
+    }
+
+
+
+    [Fact]
+    public async Task LineEnding_Default_ends_with_the_platform_newline()
+    {
+        var output = await LoadAsync(LineEnding.Default);
+
+        Assert.EndsWith(Environment.NewLine, output);
+        Assert.Equal(2, CountOccurrences(output, Environment.NewLine));
+    }
+}


### PR DESCRIPTION
Part 2 of 3 in the stacked enhancement series. **Base: `feat/issue-16-encoding` (#218)** — review/merge #218 first.

Adds a `LineEnding` property (`Default` / `Lf` / `CrLf` / `None`) to `FixedWidthLoader` so callers can pin the newline written after each record regardless of platform — useful for mainframe/FTP integrations. `None` omits the trailing newline after the **final** record while keeping intermediate records (and any header/separator) separated by the platform newline.

### Implementation
Reworked the loader write path to a **deferred-newline** model: emit the separator *before* each line except the first, then add a trailing newline unless `None`. This naturally supports all four modes. `Default` output is byte-identical to before (existing loader tests still pass). Extracted `WriteRecordsAsync` to keep `LoadWorkerAsync` under the method-length gate.

### Surface / tests
- `LineEnding` enum + property added to `PublicAPI.Unshipped.txt`.
- `FixedWidthLineEndingTests` covers all four modes (Lf/CrLf trailing, None no-trailing, Default platform).

**Local gate:** 0 warnings, **301/301 across all 13 TFMs**, 95.2% coverage.

**Stack:** #218 → **this** → `feat/issue-18-record-validator`.

Closes #17