### PR TITLE
feat: add record-level validation callback on the extractor (#18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `FixedWidthExtractor` and `FixedWidthLoader`. Defaults to `Encoding.UTF8`
   (non-breaking); pass e.g. `new UTF8Encoding(false)` to write without a BOM,
   or a code-page encoding for EBCDIC/mainframe data ([#16]).
+- `RecordValidator` callback on `FixedWidthExtractor` (`Func<TRecord,
+  ValidationResult>?`) invoked after a record is parsed but before it is
+  yielded. Return `ValidationResult.Accept()`, `.Skip(reason)` (drops the
+  record and increments `CurrentSkippedItemCount`), or `.Stop(reason)` (ends
+  extraction). Defaults to `null` (no validation) ([#18]).
 
 ### Changed
 
@@ -152,6 +157,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#83]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/83
 [#84]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/84
 [#16]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/16
+[#18]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/18
 [#86]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/86
 [#197]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/197
 [#207]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/207

--- a/src/Wolfgang.Etl.FixedWidth/Enums/ValidationAction.cs
+++ b/src/Wolfgang.Etl.FixedWidth/Enums/ValidationAction.cs
@@ -1,0 +1,24 @@
+namespace Wolfgang.Etl.FixedWidth.Enums;
+
+/// <summary>
+/// The action a record validator asks the extractor to take for a parsed record.
+/// Returned via <see cref="ValidationResult"/> from
+/// <see cref="FixedWidthExtractor{TRecord}.RecordValidator"/>.
+/// </summary>
+public enum ValidationAction
+{
+    /// <summary>Accept the record and yield it.</summary>
+    Accept = 0,
+
+    /// <summary>
+    /// Skip the record. It is not yielded; the extractor increments
+    /// <c>CurrentSkippedItemCount</c> and continues with the next line.
+    /// </summary>
+    Skip = 1,
+
+    /// <summary>
+    /// Stop extraction immediately. The record is not yielded and no further
+    /// lines are read.
+    /// </summary>
+    Stop = 2,
+}

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
@@ -340,6 +340,26 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
 
 
     /// <summary>
+    /// An optional callback invoked for each fully parsed record, after
+    /// <see cref="ValueParser"/> and field assignment but before the record is
+    /// yielded. Return <see cref="ValidationResult.Accept"/> to yield it,
+    /// <see cref="ValidationResult.Skip"/> to drop it (increments
+    /// <c>CurrentSkippedItemCount</c>), or <see cref="ValidationResult.Stop"/> to
+    /// end extraction. <see langword="null"/> (the default) applies no validation.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// extractor.RecordValidator = record =>
+    ///     record.Balance &lt; 0
+    ///         ? ValidationResult.Skip("Negative balance")
+    ///         : ValidationResult.Accept();
+    /// </code>
+    /// </example>
+    public Func<TRecord, ValidationResult>? RecordValidator { get; set; }
+
+
+
+    /// <summary>
     /// A delegate that converts a raw string read from the file into the target property
     /// type. The <see cref="FieldContext"/> provides the property type, format string, and
     /// other field metadata needed to perform the conversion.
@@ -658,12 +678,70 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
                 continue;
             }
 
+            var validation = ApplyRecordValidation(record);
+            if (validation == ValidationAction.Skip)
+            {
+                continue;
+            }
+            if (validation == ValidationAction.Stop)
+            {
+                LogExtractionCompleted();
+                yield break;
+            }
+
             LogDebugRecordParsed();
             IncrementCurrentItemCount();
             yield return record;
         }
 
         LogExtractionCompleted();
+    }
+
+
+
+    /// <summary>
+    /// Runs the optional <see cref="RecordValidator"/> against a parsed record.
+    /// For <see cref="ValidationAction.Skip"/> it increments the skipped count and
+    /// logs; the caller performs the actual skip/stop control flow.
+    /// </summary>
+    private ValidationAction ApplyRecordValidation(TRecord record)
+    {
+        if (RecordValidator == null)
+        {
+            return ValidationAction.Accept;
+        }
+
+        var result = RecordValidator(record);
+        switch (result.Action)
+        {
+            case ValidationAction.Skip:
+                IncrementCurrentSkippedItemCount();
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug
+                    (
+                        "Record at line {LineNumber} skipped by validator: {Reason}",
+                        _currentLineNumber,
+                        result.Reason ?? "(no reason given)"
+                    );
+                }
+                return ValidationAction.Skip;
+
+            case ValidationAction.Stop:
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug
+                    (
+                        "Extraction stopped by validator at line {LineNumber}: {Reason}",
+                        _currentLineNumber,
+                        result.Reason ?? "(no reason given)"
+                    );
+                }
+                return ValidationAction.Stop;
+
+            default:
+                return ValidationAction.Accept;
+        }
     }
 
 

--- a/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
@@ -3,3 +3,15 @@ Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.FixedWidthExtractor(System.
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.FixedWidthExtractor(System.IO.Stream stream, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>> logger, System.Text.Encoding encoding = null) -> void
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.FixedWidthLoader(System.IO.Stream stream, System.Text.Encoding encoding = null) -> void
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.FixedWidthLoader(System.IO.Stream stream, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>> logger, System.Text.Encoding encoding = null) -> void
+Wolfgang.Etl.FixedWidth.Enums.ValidationAction
+Wolfgang.Etl.FixedWidth.Enums.ValidationAction.Accept = 0 -> Wolfgang.Etl.FixedWidth.Enums.ValidationAction
+Wolfgang.Etl.FixedWidth.Enums.ValidationAction.Skip = 1 -> Wolfgang.Etl.FixedWidth.Enums.ValidationAction
+Wolfgang.Etl.FixedWidth.Enums.ValidationAction.Stop = 2 -> Wolfgang.Etl.FixedWidth.Enums.ValidationAction
+Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.RecordValidator.get -> System.Func<TRecord, Wolfgang.Etl.FixedWidth.ValidationResult>
+Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.RecordValidator.set -> void
+Wolfgang.Etl.FixedWidth.ValidationResult
+Wolfgang.Etl.FixedWidth.ValidationResult.Action.get -> Wolfgang.Etl.FixedWidth.Enums.ValidationAction
+Wolfgang.Etl.FixedWidth.ValidationResult.Reason.get -> string?
+static Wolfgang.Etl.FixedWidth.ValidationResult.Accept() -> Wolfgang.Etl.FixedWidth.ValidationResult
+static Wolfgang.Etl.FixedWidth.ValidationResult.Skip(string reason = null) -> Wolfgang.Etl.FixedWidth.ValidationResult
+static Wolfgang.Etl.FixedWidth.ValidationResult.Stop(string reason = null) -> Wolfgang.Etl.FixedWidth.ValidationResult

--- a/src/Wolfgang.Etl.FixedWidth/ValidationResult.cs
+++ b/src/Wolfgang.Etl.FixedWidth/ValidationResult.cs
@@ -1,0 +1,53 @@
+using Wolfgang.Etl.FixedWidth.Enums;
+
+namespace Wolfgang.Etl.FixedWidth;
+
+/// <summary>
+/// The result returned by a <see cref="FixedWidthExtractor{TRecord}.RecordValidator"/>
+/// delegate: the <see cref="ValidationAction"/> to take for a parsed record and an
+/// optional human-readable reason (surfaced in debug logs).
+/// </summary>
+public sealed class ValidationResult
+{
+    private ValidationResult(ValidationAction action, string? reason)
+    {
+        Action = action;
+        Reason = reason;
+    }
+
+
+
+    /// <summary>The action the extractor should take for the record.</summary>
+    public ValidationAction Action { get; }
+
+
+
+    /// <summary>
+    /// An optional reason describing why the record was skipped or extraction
+    /// was stopped. <see langword="null"/> when not supplied.
+    /// </summary>
+    public string? Reason { get; }
+
+
+
+    /// <summary>Accept the record and yield it.</summary>
+    public static ValidationResult Accept() => new(ValidationAction.Accept, reason: null);
+
+
+
+    /// <summary>
+    /// Skip the record, optionally recording <paramref name="reason"/> in the
+    /// debug log.
+    /// </summary>
+    /// <param name="reason">An optional reason the record was skipped.</param>
+    public static ValidationResult Skip(string? reason = null) => new(ValidationAction.Skip, reason);
+
+
+
+    /// <summary>
+    /// Stop extraction, optionally recording <paramref name="reason"/> in the
+    /// debug log.
+    /// </summary>
+    /// <param name="reason">An optional reason extraction was stopped.</param>
+    public static ValidationResult Stop(string? reason = null) => new(ValidationAction.Stop, reason);
+}

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthRecordValidatorTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthRecordValidatorTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Wolfgang.Etl.FixedWidth.Tests.Unit;
+
+/// <summary>
+/// Covers the <see cref="FixedWidthExtractor{TRecord}.RecordValidator"/> callback (#18).
+/// </summary>
+public class FixedWidthRecordValidatorTests
+{
+    private static readonly IReadOnlyList<PersonRecord> Source = new[]
+    {
+        new PersonRecord { FirstName = "Alice", LastName = "Anderson", Age = 25 },
+        new PersonRecord { FirstName = "Bob", LastName = "Brown", Age = 30 },
+        new PersonRecord { FirstName = "Carol", LastName = "Clark", Age = 35 },
+    };
+
+
+
+    // Serialize via the loader so the fixed-width layout is guaranteed correct.
+    private static async Task<string> SerializeAsync(IEnumerable<PersonRecord> people)
+    {
+        var writer = new StringWriter();
+        var loader = new FixedWidthLoader<PersonRecord>(writer);
+        await loader.LoadAsync(people.ToAsyncEnumerable(), CancellationToken.None);
+        return writer.ToString();
+    }
+
+
+
+    private static async Task<List<PersonRecord>> ExtractAsync(FixedWidthExtractor<PersonRecord> extractor)
+    {
+        var results = new List<PersonRecord>();
+        await foreach (var record in extractor.ExtractAsync(CancellationToken.None))
+        {
+            results.Add(record);
+        }
+
+        return results;
+    }
+
+
+
+    [Fact]
+    public async Task RecordValidator_Skip_drops_the_record_and_increments_skipped_count()
+    {
+        var extractor = new FixedWidthExtractor<PersonRecord>(new StringReader(await SerializeAsync(Source)))
+        {
+            RecordValidator = record => string.Equals(record.FirstName, "Bob", StringComparison.Ordinal)
+                ? ValidationResult.Skip("no bobs")
+                : ValidationResult.Accept(),
+        };
+
+        var results = await ExtractAsync(extractor);
+
+        Assert.Equal(new[] { "Alice", "Carol" }, results.Select(r => r.FirstName));
+        Assert.Equal(1, extractor.CurrentSkippedItemCount);
+        Assert.Equal(2, extractor.CurrentItemCount);
+    }
+
+
+
+    [Fact]
+    public async Task RecordValidator_Stop_ends_extraction_before_the_matching_record()
+    {
+        var extractor = new FixedWidthExtractor<PersonRecord>(new StringReader(await SerializeAsync(Source)))
+        {
+            RecordValidator = record => string.Equals(record.FirstName, "Carol", StringComparison.Ordinal)
+                ? ValidationResult.Stop("hit Carol")
+                : ValidationResult.Accept(),
+        };
+
+        var results = await ExtractAsync(extractor);
+
+        Assert.Equal(new[] { "Alice", "Bob" }, results.Select(r => r.FirstName));
+        Assert.Equal(2, extractor.CurrentItemCount);
+    }
+
+
+
+    [Fact]
+    public async Task RecordValidator_null_yields_every_record()
+    {
+        var extractor = new FixedWidthExtractor<PersonRecord>(new StringReader(await SerializeAsync(Source)));
+
+        var results = await ExtractAsync(extractor);
+
+        Assert.Equal(3, results.Count);
+        Assert.Equal(0, extractor.CurrentSkippedItemCount);
+    }
+
+
+
+    [Fact]
+    public async Task RecordValidator_Skip_logs_the_reason_at_Debug()
+    {
+        var logger = new SpyLogger<FixedWidthExtractor<PersonRecord>>();
+        var extractor = new FixedWidthExtractor<PersonRecord>(new StringReader(await SerializeAsync(Source)), logger)
+        {
+            RecordValidator = record => string.Equals(record.FirstName, "Bob", StringComparison.Ordinal)
+                ? ValidationResult.Skip("no bobs")
+                : ValidationResult.Accept(),
+        };
+
+        await ExtractAsync(extractor);
+
+        Assert.Contains
+        (
+            logger.Entries,
+            e => e.Level == LogLevel.Debug && e.Message.IndexOf("no bobs", StringComparison.Ordinal) >= 0
+        );
+    }
+
+
+
+    [Fact]
+    public async Task RecordValidator_Stop_logs_the_reason_at_Debug()
+    {
+        var logger = new SpyLogger<FixedWidthExtractor<PersonRecord>>();
+        var extractor = new FixedWidthExtractor<PersonRecord>(new StringReader(await SerializeAsync(Source)), logger)
+        {
+            RecordValidator = record => string.Equals(record.FirstName, "Carol", StringComparison.Ordinal)
+                ? ValidationResult.Stop("hit Carol")
+                : ValidationResult.Accept(),
+        };
+
+        await ExtractAsync(extractor);
+
+        Assert.Contains
+        (
+            logger.Entries,
+            e => e.Level == LogLevel.Debug && e.Message.IndexOf("hit Carol", StringComparison.Ordinal) >= 0
+        );
+    }
+}


### PR DESCRIPTION
Part 3 of 3 in the stacked enhancement series. **Base: `feat/issue-17-line-endings` (#219)** — review/merge #218 then #219 first.

Adds an optional `RecordValidator` (`Func<TRecord, ValidationResult>?`) on `FixedWidthExtractor`, invoked after a record is parsed (post-`ValueParser`/field-assignment) but before it is yielded. Lets callers reject or halt on record content inline, without a separate transformer stage.

- `ValidationResult.Accept()` → yield the record.
- `ValidationResult.Skip(reason)` → drop it; increments `CurrentSkippedItemCount` and logs the reason at Debug.
- `ValidationResult.Stop(reason)` → end extraction.
- Defaults to `null` (no validation). Implemented **FixedWidth-specific** (not on the Abstractions base), per the issue's open question.

New public types: `ValidationAction` enum + `ValidationResult`.

### Surface / tests
- `PublicAPI.Unshipped.txt` updated (note: the nullable-`Func` getter is recorded *without* a trailing `?` — the form the analyzer accepts).
- `FixedWidthRecordValidatorTests`: skip/stop/accept behavior + Debug-log assertions (via `SpyLogger`) to cover the logging branches.

### Local gate (full pr.yaml via dotnet)
- 0 warnings, **306/306 across all 13 TFMs**
- **Per-class coverage all ≥ 90%** (extractor 91.7%, `ValidationResult` 100%). The gate caught an MA0006 `==` and a coverage dip pre-push.

**Stack:** #218 → #219 → **this**.

Closes #18