### PR TITLE
feat: record validation + skipped/rejected/filtered line accounting (#18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   or a code-page encoding for EBCDIC/mainframe data ([#16]).
 - `RecordValidator` callback on `FixedWidthExtractor` (`Func<TRecord,
   ValidationResult>?`) invoked after a record is parsed but before it is
-  yielded. Return `ValidationResult.Accept()`, `.Skip(reason)` (drops the
-  record and increments `CurrentSkippedItemCount`), or `.Stop(reason)` (ends
-  extraction). Defaults to `null` (no validation) ([#18]).
+  yielded. Return `ValidationResult.Accept()`, `.Skip(reason)` (rejects the
+  record), or `.Stop(reason)` (ends extraction). Defaults to `null` (no
+  validation) ([#18]).
+- Line-accounting counters on `FixedWidthExtractor` (surfaced on
+  `FixedWidthReport`): `CurrentRejectedItemCount` (records dropped by
+  `MalformedLineHandling.Skip` or `RecordValidator.Skip`) and
+  `CurrentFilteredLineCount` (non-record lines: headers, the separator, blank
+  lines dropped per `BlankLineHandling`, `LineFilter`-skipped lines, and the
+  early-termination trigger line). Together they close the line accounting:
+  `CurrentLineNumber = CurrentItemCount + CurrentSkippedItemCount +
+  CurrentRejectedItemCount + CurrentFilteredLineCount` ([#18]).
 
 ### Changed
+
+- `CurrentSkippedItemCount` now counts **only** records skipped by the
+  `SkipItemCount` budget. Records discarded by `MalformedLineHandling.Skip`
+  now increment the new `CurrentRejectedItemCount` instead — a behavior change
+  from 0.4.0, where they counted toward `CurrentSkippedItemCount` ([#18]).
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `FixedWidthExtractor` and `FixedWidthLoader`. Defaults to `Encoding.UTF8`
   (non-breaking); pass e.g. `new UTF8Encoding(false)` to write without a BOM,
   or a code-page encoding for EBCDIC/mainframe data ([#16]).
+- `RecordValidator` callback on `FixedWidthExtractor` (`Func<TRecord,
+  ValidationResult>?`) invoked after a record is parsed but before it is
+  yielded. Return `ValidationResult.Accept()`, `.Skip(reason)` (drops the
+  record and increments `CurrentSkippedItemCount`), or `.Stop(reason)` (ends
+  extraction). Defaults to `null` (no validation) ([#18]).
 
 ### Changed
 
@@ -152,6 +157,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#83]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/83
 [#84]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/84
 [#16]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/16
+[#18]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/18
 [#86]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/86
 [#197]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/197
 [#207]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/207

--- a/src/Wolfgang.Etl.FixedWidth/Enums/ValidationAction.cs
+++ b/src/Wolfgang.Etl.FixedWidth/Enums/ValidationAction.cs
@@ -1,0 +1,24 @@
+namespace Wolfgang.Etl.FixedWidth.Enums;
+
+/// <summary>
+/// The action a record validator asks the extractor to take for a parsed record.
+/// Returned via <see cref="ValidationResult"/> from
+/// <see cref="FixedWidthExtractor{TRecord}.RecordValidator"/>.
+/// </summary>
+public enum ValidationAction
+{
+    /// <summary>Accept the record and yield it.</summary>
+    Accept = 0,
+
+    /// <summary>
+    /// Skip the record. It is not yielded; the extractor increments
+    /// <c>CurrentSkippedItemCount</c> and continues with the next line.
+    /// </summary>
+    Skip = 1,
+
+    /// <summary>
+    /// Stop extraction immediately. The record is not yielded and no further
+    /// lines are read.
+    /// </summary>
+    Stop = 2,
+}

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
@@ -66,6 +66,8 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
     private readonly IProgressTimer? _progressTimer;
     private bool _progressTimerWired;
     private long _currentLineNumber;
+    private int _currentRejectedItemCount;
+    private int _currentFilteredLineCount;
 
     // _currentLineNumber is read by CreateProgressReport on a Timer threadpool thread
     // and written by ExtractWorkerAsync on the async continuation thread.
@@ -500,6 +502,40 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
     /// </remarks>
     public long CurrentLineNumber => Interlocked.Read(ref _currentLineNumber);
 
+
+
+    /// <summary>
+    /// The number of parsed records rejected so far: records discarded via
+    /// <see cref="Enums.MalformedLineHandling.Skip"/> and records rejected by
+    /// <see cref="RecordValidator"/>. Distinct from
+    /// <see cref="ExtractorBase{TRecord,FixedWidthReport}.CurrentSkippedItemCount"/>
+    /// (the <c>SkipItemCount</c> pagination budget).
+    /// </summary>
+    public int CurrentRejectedItemCount => Volatile.Read(ref _currentRejectedItemCount);
+
+
+
+    /// <summary>
+    /// The number of physical lines read that did not produce a record and were
+    /// neither skipped by the budget nor rejected: header lines, the separator line,
+    /// blank lines dropped per <see cref="BlankLineHandling"/>, lines dropped by
+    /// <see cref="LineFilter"/>, and the line that triggered early termination. With
+    /// <see cref="CurrentLineNumber"/> this closes the line accounting:
+    /// <c>CurrentLineNumber = CurrentItemCount + CurrentSkippedItemCount +
+    /// CurrentRejectedItemCount + CurrentFilteredLineCount</c>.
+    /// </summary>
+    public int CurrentFilteredLineCount => Volatile.Read(ref _currentFilteredLineCount);
+
+
+
+    private void IncrementRejectedItemCount() => Interlocked.Increment(ref _currentRejectedItemCount);
+
+
+
+    private void IncrementFilteredLineCount() => Interlocked.Increment(ref _currentFilteredLineCount);
+
+
+
     /// <summary>
     /// Creates a progress report snapshot for the current extractor state.
     /// </summary>
@@ -507,6 +543,7 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
     /// A <see cref="FixedWidthReport"/> snapshot containing
     /// <see cref="ExtractorBase{TRecord,FixedWidthReport}.CurrentItemCount"/>,
     /// <see cref="ExtractorBase{TRecord,FixedWidthReport}.CurrentSkippedItemCount"/>,
+    /// <see cref="CurrentRejectedItemCount"/>, <see cref="CurrentFilteredLineCount"/>,
     /// and <see cref="CurrentLineNumber"/> at the moment of the call.
     /// </returns>
     protected override FixedWidthReport CreateProgressReport()
@@ -515,6 +552,8 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
         (
             CurrentItemCount,
             CurrentSkippedItemCount,
+            CurrentRejectedItemCount,
+            CurrentFilteredLineCount,
             Interlocked.Read(ref _currentLineNumber)
         );
     }
@@ -610,6 +649,7 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
 
             if (IsStructuralLine(separatorLineNo))
             {
+                IncrementFilteredLineCount();
                 LogDebugStructuralLineSkipped();
                 continue;
             }
@@ -618,6 +658,7 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
             {
                 if (!HandleBlankLine(fieldMap, out var defaultRecord))
                 {
+                    IncrementFilteredLineCount();
                     LogDebugBlankLineSkipped();
                     continue;
                 }
@@ -634,6 +675,7 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
 
                 if (CurrentItemCount >= MaximumItemCount)
                 {
+                    IncrementFilteredLineCount();
                     LogDebugMaxReached();
                     LogExtractionCompleted();
                     yield break;
@@ -648,12 +690,14 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
             var filterAction = LineFilter(line);
             if (filterAction == LineAction.Stop)
             {
+                IncrementFilteredLineCount();
                 LogDebugLineFilterStop();
                 LogExtractionCompleted();
                 yield break;
             }
             if (filterAction == LineAction.Skip)
             {
+                IncrementFilteredLineCount();
                 LogDebugLineFilterSkip();
                 continue;
             }
@@ -668,6 +712,7 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
 
             if (CurrentItemCount >= MaximumItemCount)
             {
+                IncrementFilteredLineCount();
                 LogDebugMaxReached();
                 LogExtractionCompleted();
                 yield break;
@@ -685,6 +730,7 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
             }
             if (validation == ValidationAction.Stop)
             {
+                IncrementFilteredLineCount();
                 LogExtractionCompleted();
                 yield break;
             }
@@ -701,7 +747,7 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
 
     /// <summary>
     /// Runs the optional <see cref="RecordValidator"/> against a parsed record.
-    /// For <see cref="ValidationAction.Skip"/> it increments the skipped count and
+    /// For <see cref="ValidationAction.Skip"/> it increments the rejected count and
     /// logs; the caller performs the actual skip/stop control flow.
     /// </summary>
     private ValidationAction ApplyRecordValidation(TRecord record)
@@ -715,7 +761,7 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
         switch (result.Action)
         {
             case ValidationAction.Skip:
-                IncrementCurrentSkippedItemCount();
+                IncrementRejectedItemCount();
                 if (_logger.IsEnabled(LogLevel.Debug))
                 {
                     _logger.LogDebug
@@ -1085,7 +1131,7 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
             switch (MalformedLineHandling)
             {
                 case MalformedLineHandling.Skip:
-                    IncrementCurrentSkippedItemCount();
+                    IncrementRejectedItemCount();
                     return false;
 
                 case MalformedLineHandling.ReturnDefault:

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
@@ -340,6 +340,26 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
 
 
     /// <summary>
+    /// An optional callback invoked for each fully parsed record, after
+    /// <see cref="ValueParser"/> and field assignment but before the record is
+    /// yielded. Return <see cref="ValidationResult.Accept"/> to yield it,
+    /// <see cref="ValidationResult.Skip"/> to drop it (increments
+    /// <c>CurrentSkippedItemCount</c>), or <see cref="ValidationResult.Stop"/> to
+    /// end extraction. <see langword="null"/> (the default) applies no validation.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// extractor.RecordValidator = record =>
+    ///     record.Balance &lt; 0
+    ///         ? ValidationResult.Skip("Negative balance")
+    ///         : ValidationResult.Accept();
+    /// </code>
+    /// </example>
+    public Func<TRecord, ValidationResult>? RecordValidator { get; set; }
+
+
+
+    /// <summary>
     /// A delegate that converts a raw string read from the file into the target property
     /// type. The <see cref="FieldContext"/> provides the property type, format string, and
     /// other field metadata needed to perform the conversion.
@@ -658,12 +678,70 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
                 continue;
             }
 
+            var validation = ApplyRecordValidation(record);
+            if (validation == ValidationAction.Skip)
+            {
+                continue;
+            }
+            if (validation == ValidationAction.Stop)
+            {
+                LogExtractionCompleted();
+                yield break;
+            }
+
             LogDebugRecordParsed();
             IncrementCurrentItemCount();
             yield return record;
         }
 
         LogExtractionCompleted();
+    }
+
+
+
+    /// <summary>
+    /// Runs the optional <see cref="RecordValidator"/> against a parsed record.
+    /// For <see cref="ValidationAction.Skip"/> it increments the skipped count and
+    /// logs; the caller performs the actual skip/stop control flow.
+    /// </summary>
+    private ValidationAction ApplyRecordValidation(TRecord record)
+    {
+        if (RecordValidator == null)
+        {
+            return ValidationAction.Accept;
+        }
+
+        var result = RecordValidator(record);
+        switch (result.Action)
+        {
+            case ValidationAction.Skip:
+                IncrementCurrentSkippedItemCount();
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug
+                    (
+                        "Record at line {LineNumber} skipped by validator: {Reason}",
+                        _currentLineNumber,
+                        result.Reason ?? "(no reason given)"
+                    );
+                }
+                return ValidationAction.Skip;
+
+            case ValidationAction.Stop:
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug
+                    (
+                        "Extraction stopped by validator at line {LineNumber}: {Reason}",
+                        _currentLineNumber,
+                        result.Reason ?? "(no reason given)"
+                    );
+                }
+                return ValidationAction.Stop;
+
+            default:
+                return ValidationAction.Accept;
+        }
     }
 
 

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthLoader.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthLoader.cs
@@ -414,6 +414,8 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
         (
             CurrentItemCount,
             CurrentSkippedItemCount,
+            currentRejectedItemCount: 0,
+            currentFilteredLineCount: 0,
             Interlocked.Read(ref _currentLineNumber)
         );
     }

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthReport.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthReport.cs
@@ -28,10 +28,12 @@ public record FixedWidthReport : Report
     // ------------------------------------------------------------------
 
     /// <summary>
-    /// Initializes a new instance of <see cref="FixedWidthReport"/>.
+    /// Initializes a new instance of <see cref="FixedWidthReport"/> with the
+    /// rejected and filtered counts defaulted to zero. Retained for backward
+    /// compatibility; prefer the five-parameter overload.
     /// </summary>
     /// <param name="currentCount">The number of data records processed so far.</param>
-    /// <param name="currentSkippedItemCount">The number of records skipped so far.</param>
+    /// <param name="currentSkippedItemCount">The number of records skipped by the skip budget so far.</param>
     /// <param name="currentLineNumber">
     /// The 1-based physical line number currently being processed in the file.
     /// </param>
@@ -41,9 +43,35 @@ public record FixedWidthReport : Report
         int currentSkippedItemCount,
         long currentLineNumber
     )
+        : this(currentCount, currentSkippedItemCount, 0, 0, currentLineNumber)
+    {
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="FixedWidthReport"/>.
+    /// </summary>
+    /// <param name="currentCount">The number of data records processed so far.</param>
+    /// <param name="currentSkippedItemCount">The number of records skipped by the skip budget so far.</param>
+    /// <param name="currentRejectedItemCount">The number of records rejected so far (extractor only).</param>
+    /// <param name="currentFilteredLineCount">The number of non-record lines read so far (extractor only).</param>
+    /// <param name="currentLineNumber">
+    /// The 1-based physical line number currently being processed in the file.
+    /// </param>
+    public FixedWidthReport
+    (
+        int currentCount,
+        int currentSkippedItemCount,
+        int currentRejectedItemCount,
+        int currentFilteredLineCount,
+        long currentLineNumber
+    )
         : base(currentCount)
     {
         CurrentSkippedItemCount = currentSkippedItemCount;
+        CurrentRejectedItemCount = currentRejectedItemCount;
+        CurrentFilteredLineCount = currentFilteredLineCount;
         CurrentLineNumber = currentLineNumber;
     }
 
@@ -54,12 +82,35 @@ public record FixedWidthReport : Report
     // ------------------------------------------------------------------
 
     /// <summary>
-    /// The number of records skipped so far. For the extractor, includes records
-    /// skipped by the skip budget and records silently discarded due to
-    /// <see cref="MalformedLineHandling.Skip"/>. For the loader, includes records
+    /// The number of records skipped by the <c>SkipItemCount</c> budget (pagination)
+    /// so far. This does <em>not</em> include records rejected for content or data
+    /// quality — see <see cref="CurrentRejectedItemCount"/> — nor non-record lines —
+    /// see <see cref="CurrentFilteredLineCount"/>. For the loader, includes records
     /// skipped by the skip budget.
     /// </summary>
     public int CurrentSkippedItemCount { get; }
+
+
+
+    /// <summary>
+    /// (Extractor only.) The number of parsed records rejected so far: records
+    /// discarded via <see cref="MalformedLineHandling.Skip"/> and records rejected
+    /// by <c>RecordValidator</c>. Always <c>0</c> for the loader.
+    /// </summary>
+    public int CurrentRejectedItemCount { get; }
+
+
+
+    /// <summary>
+    /// (Extractor only.) The number of physical lines read that did not produce a
+    /// record and were neither skipped by the budget nor rejected: header lines, the
+    /// separator line, blank lines dropped per <see cref="BlankLineHandling"/>, lines
+    /// dropped by <c>LineFilter</c>, and the line that triggered early termination.
+    /// With <see cref="CurrentLineNumber"/> this closes the line accounting:
+    /// <c>CurrentLineNumber = CurrentItemCount + CurrentSkippedItemCount +
+    /// CurrentRejectedItemCount + CurrentFilteredLineCount</c>. Always <c>0</c> for the loader.
+    /// </summary>
+    public int CurrentFilteredLineCount { get; }
 
 
 

--- a/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
@@ -7,8 +7,13 @@ Wolfgang.Etl.FixedWidth.Enums.ValidationAction
 Wolfgang.Etl.FixedWidth.Enums.ValidationAction.Accept = 0 -> Wolfgang.Etl.FixedWidth.Enums.ValidationAction
 Wolfgang.Etl.FixedWidth.Enums.ValidationAction.Skip = 1 -> Wolfgang.Etl.FixedWidth.Enums.ValidationAction
 Wolfgang.Etl.FixedWidth.Enums.ValidationAction.Stop = 2 -> Wolfgang.Etl.FixedWidth.Enums.ValidationAction
+Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.CurrentFilteredLineCount.get -> int
+Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.CurrentRejectedItemCount.get -> int
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.RecordValidator.get -> System.Func<TRecord, Wolfgang.Etl.FixedWidth.ValidationResult>
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.RecordValidator.set -> void
+Wolfgang.Etl.FixedWidth.FixedWidthReport.CurrentFilteredLineCount.get -> int
+Wolfgang.Etl.FixedWidth.FixedWidthReport.CurrentRejectedItemCount.get -> int
+Wolfgang.Etl.FixedWidth.FixedWidthReport.FixedWidthReport(int currentCount, int currentSkippedItemCount, int currentRejectedItemCount, int currentFilteredLineCount, long currentLineNumber) -> void
 Wolfgang.Etl.FixedWidth.ValidationResult
 Wolfgang.Etl.FixedWidth.ValidationResult.Action.get -> Wolfgang.Etl.FixedWidth.Enums.ValidationAction
 Wolfgang.Etl.FixedWidth.ValidationResult.Reason.get -> string?

--- a/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
@@ -3,3 +3,15 @@ Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.FixedWidthExtractor(System.
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.FixedWidthExtractor(System.IO.Stream stream, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>> logger, System.Text.Encoding encoding = null) -> void
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.FixedWidthLoader(System.IO.Stream stream, System.Text.Encoding encoding = null) -> void
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.FixedWidthLoader(System.IO.Stream stream, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>> logger, System.Text.Encoding encoding = null) -> void
+Wolfgang.Etl.FixedWidth.Enums.ValidationAction
+Wolfgang.Etl.FixedWidth.Enums.ValidationAction.Accept = 0 -> Wolfgang.Etl.FixedWidth.Enums.ValidationAction
+Wolfgang.Etl.FixedWidth.Enums.ValidationAction.Skip = 1 -> Wolfgang.Etl.FixedWidth.Enums.ValidationAction
+Wolfgang.Etl.FixedWidth.Enums.ValidationAction.Stop = 2 -> Wolfgang.Etl.FixedWidth.Enums.ValidationAction
+Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.RecordValidator.get -> System.Func<TRecord, Wolfgang.Etl.FixedWidth.ValidationResult>
+Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.RecordValidator.set -> void
+Wolfgang.Etl.FixedWidth.ValidationResult
+Wolfgang.Etl.FixedWidth.ValidationResult.Action.get -> Wolfgang.Etl.FixedWidth.Enums.ValidationAction
+Wolfgang.Etl.FixedWidth.ValidationResult.Reason.get -> string?
+static Wolfgang.Etl.FixedWidth.ValidationResult.Accept() -> Wolfgang.Etl.FixedWidth.ValidationResult
+static Wolfgang.Etl.FixedWidth.ValidationResult.Skip(string reason = null) -> Wolfgang.Etl.FixedWidth.ValidationResult
+static Wolfgang.Etl.FixedWidth.ValidationResult.Stop(string reason = null) -> Wolfgang.Etl.FixedWidth.ValidationResult

--- a/src/Wolfgang.Etl.FixedWidth/ValidationResult.cs
+++ b/src/Wolfgang.Etl.FixedWidth/ValidationResult.cs
@@ -1,0 +1,53 @@
+using Wolfgang.Etl.FixedWidth.Enums;
+
+namespace Wolfgang.Etl.FixedWidth;
+
+/// <summary>
+/// The result returned by a <see cref="FixedWidthExtractor{TRecord}.RecordValidator"/>
+/// delegate: the <see cref="ValidationAction"/> to take for a parsed record and an
+/// optional human-readable reason (surfaced in debug logs).
+/// </summary>
+public sealed class ValidationResult
+{
+    private ValidationResult(ValidationAction action, string? reason)
+    {
+        Action = action;
+        Reason = reason;
+    }
+
+
+
+    /// <summary>The action the extractor should take for the record.</summary>
+    public ValidationAction Action { get; }
+
+
+
+    /// <summary>
+    /// An optional reason describing why the record was skipped or extraction
+    /// was stopped. <see langword="null"/> when not supplied.
+    /// </summary>
+    public string? Reason { get; }
+
+
+
+    /// <summary>Accept the record and yield it.</summary>
+    public static ValidationResult Accept() => new(ValidationAction.Accept, reason: null);
+
+
+
+    /// <summary>
+    /// Skip the record, optionally recording <paramref name="reason"/> in the
+    /// debug log.
+    /// </summary>
+    /// <param name="reason">An optional reason the record was skipped.</param>
+    public static ValidationResult Skip(string? reason = null) => new(ValidationAction.Skip, reason);
+
+
+
+    /// <summary>
+    /// Stop extraction, optionally recording <paramref name="reason"/> in the
+    /// debug log.
+    /// </summary>
+    /// <param name="reason">An optional reason extraction was stopped.</param>
+    public static ValidationResult Stop(string? reason = null) => new(ValidationAction.Stop, reason);
+}

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthExtractorTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthExtractorTests.cs
@@ -893,10 +893,10 @@ public class FixedWidthExtractorTests
 
 
     [Fact]
-    public async Task ExtractAsync_when_using_FixedWidthReport_and_MalformedLineHandling_is_Skip_CurrentSkippedItemCount_reflects_skipped_malformed_lines()
+    public async Task ExtractAsync_when_MalformedLineHandling_is_Skip_CurrentRejectedItemCount_reflects_rejected_malformed_lines()
     {
         const string content = "John      Smith     042\n" +
-                               "Bad       Line     \n" + // too short — skipped
+                               "Bad       Line     \n" + // too short — rejected
                                "Jane      Doe       030";
 
         var extractor = new FixedWidthExtractor<PersonRecord>(new StringReader(content))
@@ -911,9 +911,16 @@ public class FixedWidthExtractorTests
             2,
             extractor.CurrentItemCount
         );
+        // Malformed-line skips now count as rejections, not skips (the
+        // SkipItemCount pagination budget owns CurrentSkippedItemCount).
         Assert.Equal
         (
             1,
+            extractor.CurrentRejectedItemCount
+        );
+        Assert.Equal
+        (
+            0,
             extractor.CurrentSkippedItemCount
         );
     }

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthLineAccountingTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthLineAccountingTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.FixedWidth.Enums;
+using Xunit;
+
+namespace Wolfgang.Etl.FixedWidth.Tests.Unit;
+
+/// <summary>
+/// Verifies the extractor's line accounting: every physical line lands in exactly
+/// one counter, and the counters partition <c>CurrentLineNumber</c> — see #18 /
+/// the skipped / rejected / filtered split.
+/// </summary>
+public class FixedWidthLineAccountingTests
+{
+    // One line per category:
+    //   1 comment  -> LineFilter.Skip        -> filtered
+    //   2 Alice    -> SkipItemCount budget   -> skipped
+    //   3 (blank)  -> BlankLineHandling.Skip -> filtered
+    //   4 Bob      -> RecordValidator.Skip   -> rejected
+    //   5 Eve/abc  -> malformed (bad Age)    -> rejected
+    //   6 Carol    -> emitted                -> item
+    //   7 Dan      -> emitted                -> item
+    private const string Input =
+        "# comment line\n" +
+        "Alice     Anderson  025\n" +
+        "\n" +
+        "Bob       Brown     030\n" +
+        "Eve       Evans     abc\n" +
+        "Carol     Clark     035\n" +
+        "Dan       Davis     040";
+
+
+
+    private static FixedWidthExtractor<PersonRecord> CreateExtractor() =>
+        new(new StringReader(Input))
+        {
+            SkipItemCount = 1,
+            BlankLineHandling = BlankLineHandling.Skip,
+            MalformedLineHandling = MalformedLineHandling.Skip,
+            LineFilter = line => line.StartsWith("#", StringComparison.Ordinal)
+                ? LineAction.Skip
+                : LineAction.Process,
+            RecordValidator = record => string.Equals(record.FirstName, "Bob", StringComparison.Ordinal)
+                ? ValidationResult.Skip("no bobs")
+                : ValidationResult.Accept(),
+        };
+
+
+
+    [Fact]
+    public async Task Counters_partition_every_line_by_category()
+    {
+        var extractor = CreateExtractor();
+
+        var results = new List<PersonRecord>();
+        await foreach (var record in extractor.ExtractAsync(CancellationToken.None))
+        {
+            results.Add(record);
+        }
+
+        Assert.Equal(2, extractor.CurrentItemCount);         // Carol, Dan
+        Assert.Equal(1, extractor.CurrentSkippedItemCount);  // Alice (pagination)
+        Assert.Equal(2, extractor.CurrentRejectedItemCount); // Bob (validator) + Eve (malformed)
+        Assert.Equal(2, extractor.CurrentFilteredLineCount); // comment + blank
+    }
+
+
+
+    [Fact]
+    public async Task Line_accounting_closes_exactly()
+    {
+        var extractor = CreateExtractor();
+
+        await foreach (var _ in extractor.ExtractAsync(CancellationToken.None))
+        {
+        }
+
+        var accounted = extractor.CurrentItemCount
+            + extractor.CurrentSkippedItemCount
+            + extractor.CurrentRejectedItemCount
+            + extractor.CurrentFilteredLineCount;
+
+        Assert.Equal(7L, extractor.CurrentLineNumber);
+        Assert.Equal(extractor.CurrentLineNumber, accounted);
+    }
+}

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthRecordValidatorTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthRecordValidatorTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Wolfgang.Etl.FixedWidth.Tests.Unit;
+
+/// <summary>
+/// Covers the <see cref="FixedWidthExtractor{TRecord}.RecordValidator"/> callback (#18).
+/// </summary>
+public class FixedWidthRecordValidatorTests
+{
+    private static readonly IReadOnlyList<PersonRecord> Source = new[]
+    {
+        new PersonRecord { FirstName = "Alice", LastName = "Anderson", Age = 25 },
+        new PersonRecord { FirstName = "Bob", LastName = "Brown", Age = 30 },
+        new PersonRecord { FirstName = "Carol", LastName = "Clark", Age = 35 },
+    };
+
+
+
+    // Serialize via the loader so the fixed-width layout is guaranteed correct.
+    private static async Task<string> SerializeAsync(IEnumerable<PersonRecord> people)
+    {
+        var writer = new StringWriter();
+        var loader = new FixedWidthLoader<PersonRecord>(writer);
+        await loader.LoadAsync(people.ToAsyncEnumerable(), CancellationToken.None);
+        return writer.ToString();
+    }
+
+
+
+    private static async Task<List<PersonRecord>> ExtractAsync(FixedWidthExtractor<PersonRecord> extractor)
+    {
+        var results = new List<PersonRecord>();
+        await foreach (var record in extractor.ExtractAsync(CancellationToken.None))
+        {
+            results.Add(record);
+        }
+
+        return results;
+    }
+
+
+
+    [Fact]
+    public async Task RecordValidator_Skip_drops_the_record_and_increments_skipped_count()
+    {
+        var extractor = new FixedWidthExtractor<PersonRecord>(new StringReader(await SerializeAsync(Source)))
+        {
+            RecordValidator = record => string.Equals(record.FirstName, "Bob", StringComparison.Ordinal)
+                ? ValidationResult.Skip("no bobs")
+                : ValidationResult.Accept(),
+        };
+
+        var results = await ExtractAsync(extractor);
+
+        Assert.Equal(new[] { "Alice", "Carol" }, results.Select(r => r.FirstName));
+        Assert.Equal(1, extractor.CurrentSkippedItemCount);
+        Assert.Equal(2, extractor.CurrentItemCount);
+    }
+
+
+
+    [Fact]
+    public async Task RecordValidator_Stop_ends_extraction_before_the_matching_record()
+    {
+        var extractor = new FixedWidthExtractor<PersonRecord>(new StringReader(await SerializeAsync(Source)))
+        {
+            RecordValidator = record => string.Equals(record.FirstName, "Carol", StringComparison.Ordinal)
+                ? ValidationResult.Stop("hit Carol")
+                : ValidationResult.Accept(),
+        };
+
+        var results = await ExtractAsync(extractor);
+
+        Assert.Equal(new[] { "Alice", "Bob" }, results.Select(r => r.FirstName));
+        Assert.Equal(2, extractor.CurrentItemCount);
+    }
+
+
+
+    [Fact]
+    public async Task RecordValidator_null_yields_every_record()
+    {
+        var extractor = new FixedWidthExtractor<PersonRecord>(new StringReader(await SerializeAsync(Source)));
+
+        var results = await ExtractAsync(extractor);
+
+        Assert.Equal(3, results.Count);
+        Assert.Equal(0, extractor.CurrentSkippedItemCount);
+    }
+
+
+
+    [Fact]
+    public async Task RecordValidator_Skip_logs_the_reason_at_Debug()
+    {
+        var logger = new SpyLogger<FixedWidthExtractor<PersonRecord>>();
+        var extractor = new FixedWidthExtractor<PersonRecord>(new StringReader(await SerializeAsync(Source)), logger)
+        {
+            RecordValidator = record => string.Equals(record.FirstName, "Bob", StringComparison.Ordinal)
+                ? ValidationResult.Skip("no bobs")
+                : ValidationResult.Accept(),
+        };
+
+        await ExtractAsync(extractor);
+
+        Assert.Contains
+        (
+            logger.Entries,
+            e => e.Level == LogLevel.Debug && e.Message.IndexOf("no bobs", StringComparison.Ordinal) >= 0
+        );
+    }
+
+
+
+    [Fact]
+    public async Task RecordValidator_Stop_logs_the_reason_at_Debug()
+    {
+        var logger = new SpyLogger<FixedWidthExtractor<PersonRecord>>();
+        var extractor = new FixedWidthExtractor<PersonRecord>(new StringReader(await SerializeAsync(Source)), logger)
+        {
+            RecordValidator = record => string.Equals(record.FirstName, "Carol", StringComparison.Ordinal)
+                ? ValidationResult.Stop("hit Carol")
+                : ValidationResult.Accept(),
+        };
+
+        await ExtractAsync(extractor);
+
+        Assert.Contains
+        (
+            logger.Entries,
+            e => e.Level == LogLevel.Debug && e.Message.IndexOf("hit Carol", StringComparison.Ordinal) >= 0
+        );
+    }
+}

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthRecordValidatorTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthRecordValidatorTests.cs
@@ -60,7 +60,8 @@ public class FixedWidthRecordValidatorTests
         var results = await ExtractAsync(extractor);
 
         Assert.Equal(new[] { "Alice", "Carol" }, results.Select(r => r.FirstName));
-        Assert.Equal(1, extractor.CurrentSkippedItemCount);
+        Assert.Equal(1, extractor.CurrentRejectedItemCount);
+        Assert.Equal(0, extractor.CurrentSkippedItemCount);
         Assert.Equal(2, extractor.CurrentItemCount);
     }
 
@@ -93,6 +94,7 @@ public class FixedWidthRecordValidatorTests
 
         Assert.Equal(3, results.Count);
         Assert.Equal(0, extractor.CurrentSkippedItemCount);
+        Assert.Equal(0, extractor.CurrentRejectedItemCount);
     }
 
 

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthReportTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthReportTests.cs
@@ -29,6 +29,30 @@ public class FixedWidthReportTests
             15L,
             report.CurrentLineNumber
         );
+        // The three-parameter overload defaults the rejected/filtered counts to zero.
+        Assert.Equal(0, report.CurrentRejectedItemCount);
+        Assert.Equal(0, report.CurrentFilteredLineCount);
+    }
+
+
+
+    [Fact]
+    public void Five_parameter_constructor_sets_rejected_and_filtered_counts()
+    {
+        var report = new FixedWidthReport
+        (
+            currentCount: 10,
+            currentSkippedItemCount: 2,
+            currentRejectedItemCount: 3,
+            currentFilteredLineCount: 4,
+            currentLineNumber: 20L
+        );
+
+        Assert.Equal(10, report.CurrentItemCount);
+        Assert.Equal(2, report.CurrentSkippedItemCount);
+        Assert.Equal(3, report.CurrentRejectedItemCount);
+        Assert.Equal(4, report.CurrentFilteredLineCount);
+        Assert.Equal(20L, report.CurrentLineNumber);
     }
 
 


### PR DESCRIPTION
Implements `RecordValidator` on `FixedWidthExtractor` **and** reworks the extractor's line accounting into three distinct counters so every physical line is categorized.

### RecordValidator
Optional `Func<TRecord, ValidationResult>?` invoked after a record is parsed, before it's yielded: `Accept()` / `Skip(reason)` (rejects) / `Stop(reason)`. Defaults to `null`. New public types `ValidationAction` + `ValidationResult`.

### Line accounting (closed identity)
```
CurrentLineNumber = CurrentItemCount + CurrentSkippedItemCount + CurrentRejectedItemCount + CurrentFilteredLineCount
```
| Counter | Contents |
|---------|----------|
| `CurrentSkippedItemCount` | **pagination only** (`SkipItemCount` budget) |
| `CurrentRejectedItemCount` *(new)* | `MalformedLineHandling.Skip` + `RecordValidator.Skip` |
| `CurrentFilteredLineCount` *(new)* | headers, separator, blank-drops, `LineFilter.Skip`, early-stop trigger line |

Both new counts are on `FixedWidthExtractor` and surfaced on `FixedWidthReport`.

### ⚠️ Behavior change vs 0.4.0
`MalformedLineHandling.Skip` now increments `CurrentRejectedItemCount` instead of `CurrentSkippedItemCount`. Documented in the CHANGELOG under *Changed*.

### Non-breaking API
`FixedWidthReport` gains a 5-param constructor; the 3-param one is retained (delegating, defaults the new counts to 0). Loader reports 0 for both (extractor-only metrics).

### Tests
- New `FixedWidthLineAccountingTests` — exercises every bucket (comment/pagination/blank/validator/malformed/emit) and asserts the identity closes exactly.
- Updated the malformed-skip test (now asserts `CurrentRejectedItemCount`), the validator tests, and the report tests.

### Local gate (full pr.yaml via dotnet)
0 warnings, **305/305 across all 13 TFMs**, every class ≥ 90%.

Re-targeted to `vNext` (after #16 merged, #17 dropped). Closes #18.