### PR TITLE
docs: explain controlling output line endings via TextWriter.NewLine

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,23 @@ using var loader = new FixedWidthLoader<PersonRecord>(writeGzip);
 
 See the [CompressedStreams](examples/CompressedStreams) example for a complete GZip and Brotli round trip.
 
+### Controlling line endings
+
+`FixedWidthExtractor` reads any line ending automatically — `\n`, `\r`, or `\r\n` — so no configuration is needed for input.
+
+For **output**, the loader writes each record with its `TextWriter`'s newline. To force a specific ending regardless of the platform you run on — for example, a downstream mainframe or FTP consumer that requires Unix `\n` — pass a `TextWriter` with the `NewLine` you want:
+
+```csharp
+// Force Unix (LF) line endings, even on Windows
+await using var stream = File.Create("output.dat");
+await using var writer = new StreamWriter(stream) { NewLine = "\n" };
+using var loader = new FixedWidthLoader<PersonRecord>(writer);
+
+await loader.LoadAsync(records, CancellationToken.None);
+```
+
+`NewLine` accepts any string (`"\n"`, `"\r\n"`, or a custom terminator). The default is `Environment.NewLine`.
+
 ---
 
 ## ✨ Features

--- a/docfx_project/docs/getting-started.md
+++ b/docfx_project/docs/getting-started.md
@@ -90,6 +90,25 @@ Console.WriteLine($"Total loaded: {loader.CurrentItemCount}");
 
 In production, replace `StringReader` / `StringWriter` with a `FileStream` or `StreamReader` — the extractor and loader accept any `TextReader` / `TextWriter`, or a raw `Stream` directly.
 
+### Controlling line endings
+
+`FixedWidthExtractor` reads `\n`, `\r`, and `\r\n` automatically, so input needs no configuration.
+
+For output, the loader writes each record with its `TextWriter`'s newline. To force a specific ending regardless of platform — e.g. Unix `\n` for a downstream mainframe or FTP consumer — pass a `TextWriter` with the `NewLine` you want:
+
+```csharp
+using System.IO;
+
+// Force Unix (LF) line endings, even on Windows
+await using var stream = File.Create("output.dat");
+await using var writer = new StreamWriter(stream) { NewLine = "\n" };
+using var loader = new FixedWidthLoader<PersonRecord>(writer);
+
+await loader.LoadAsync(recordsAsyncEnumerable, CancellationToken.None);
+```
+
+`NewLine` accepts any string; the default is `Environment.NewLine`.
+
 ## Next Steps
 
 - Browse the [Examples](examples.md) for more detailed scenarios


### PR DESCRIPTION
Replaces the withdrawn **#17** (`LineEnding` enum) with documentation, per the discussion: .NET has no standard line-ending type — the idiomatic mechanism is `TextWriter.NewLine` (a string) — and `TextReader.ReadLine()` already parses `\n`/`\r`/`\r\n` transparently, so the extractor needs nothing.

Adds a **"Controlling line endings"** section to both the README (Quick Start / Loading area) and the DocFX getting-started guide, with a simple, clear example:

```csharp
// Force Unix (LF) line endings, even on Windows
await using var writer = new StreamWriter(stream) { NewLine = "\n" };
using var loader = new FixedWidthLoader<PersonRecord>(writer);
```

Docs only — no code, no build/test surface. Example verified accurate against `vNext` (the loader writes via `WriteLineAsync`, which honors `TextWriter.NewLine`).

Base: `vNext` (independent of #221).