### PR TITLE
feat: add NumberStyles support for numeric field parsing (#9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (non-breaking); pass e.g. `new UTF8Encoding(false)` to write without a BOM,
   or a code-page encoding for EBCDIC/mainframe data ([#16]).
 - `NumberStyles` property on `[FixedWidthField]` controlling how a numeric field
-  is parsed during extraction. Defaults to `NumberStyles.Any` (parsed with
-  `InvariantCulture`); restrict it — e.g. `NumberStyles.Integer` — to reject
-  decimals or thousands separators ([#9]).
+  is parsed during extraction. Defaults to `null`, using the target type's
+  natural style — `Integer` for integral types, `Number` for
+  `decimal`/`double`/`float` (matching `int.Parse` / `decimal.Parse`, parsed with
+  `InvariantCulture`). Set it explicitly — e.g. `NumberStyles.Currency` — to
+  accept currency symbols, scientific notation, or parenthesized negatives ([#9]).
 - `RecordValidator` callback on `FixedWidthExtractor` (`Func<TRecord,
   ValidationResult>?`) invoked after a record is parsed but before it is
   yielded. Return `ValidationResult.Accept()`, `.Skip(reason)` (rejects the
@@ -37,11 +39,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `SkipItemCount` budget. Records discarded by `MalformedLineHandling.Skip`
   now increment the new `CurrentRejectedItemCount` instead — a behavior change
   from 0.4.0, where they counted toward `CurrentSkippedItemCount` ([#18]).
-- On .NET Framework / netstandard targets, numeric fields are now parsed with an
-  explicit `NumberStyles` (defaulting to `NumberStyles.Any`) rather than
-  `TypeConverter.ConvertFromInvariantString`, matching net8.0+ behavior — so
-  values with thousands separators, currency symbols, or parenthesized negatives
-  parse identically on every target framework ([#9]).
+- Numeric fields are now parsed with the target type's natural `NumberStyles`
+  (`Integer` / `Number`) by default, consistently across every target framework,
+  configurable via `[FixedWidthField(NumberStyles = …)]`. Previously net8.0+
+  parsed with `NumberStyles.Any` and .NET Framework / netstandard used
+  `TypeConverter.ConvertFromInvariantString`. As a result, currency symbols,
+  scientific notation, and parenthesized negatives no longer parse by default —
+  opt in per field with an explicit `NumberStyles` ([#9]).
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `FixedWidthExtractor` and `FixedWidthLoader`. Defaults to `Encoding.UTF8`
   (non-breaking); pass e.g. `new UTF8Encoding(false)` to write without a BOM,
   or a code-page encoding for EBCDIC/mainframe data ([#16]).
+- `NumberStyles` property on `[FixedWidthField]` controlling how a numeric field
+  is parsed during extraction. Defaults to `NumberStyles.Any` (parsed with
+  `InvariantCulture`); restrict it — e.g. `NumberStyles.Integer` — to reject
+  decimals or thousands separators ([#9]).
 - `RecordValidator` callback on `FixedWidthExtractor` (`Func<TRecord,
   ValidationResult>?`) invoked after a record is parsed but before it is
   yielded. Return `ValidationResult.Accept()`, `.Skip(reason)` (rejects the
@@ -33,6 +37,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `SkipItemCount` budget. Records discarded by `MalformedLineHandling.Skip`
   now increment the new `CurrentRejectedItemCount` instead — a behavior change
   from 0.4.0, where they counted toward `CurrentSkippedItemCount` ([#18]).
+- On .NET Framework / netstandard targets, numeric fields are now parsed with an
+  explicit `NumberStyles` (defaulting to `NumberStyles.Any`) rather than
+  `TypeConverter.ConvertFromInvariantString`, matching net8.0+ behavior — so
+  values with thousands separators, currency symbols, or parenthesized negatives
+  parse identically on every target framework ([#9]).
 
 ### Deprecated
 
@@ -169,6 +178,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#62]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/62
 [#83]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/83
 [#84]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/84
+[#9]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/9
 [#16]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/16
 [#18]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/18
 [#86]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/pull/86

--- a/src/Wolfgang.Etl.FixedWidth/Attributes/FixedWidthFieldAttribute.cs
+++ b/src/Wolfgang.Etl.FixedWidth/Attributes/FixedWidthFieldAttribute.cs
@@ -149,15 +149,27 @@ public sealed class FixedWidthFieldAttribute : Attribute
 
 
     /// <summary>
+    /// Sentinel for <see cref="NumberStyles"/> meaning "not specified" — resolved to
+    /// the target type's natural style. Nullable enums cannot be attribute arguments,
+    /// so an out-of-range value stands in for "unset".
+    /// </summary>
+    internal const NumberStyles UnspecifiedNumberStyles = (NumberStyles)(-1);
+
+
+
+    /// <summary>
     /// The <see cref="System.Globalization.NumberStyles"/> permitted when parsing a
-    /// numeric property during a read (extract) operation. Defaults to
-    /// <see cref="System.Globalization.NumberStyles.Any"/>. Restrict it to reject
-    /// unwanted forms — for example
-    /// <see cref="System.Globalization.NumberStyles.Integer"/> to disallow decimals
-    /// and thousands separators. Parsing always uses
+    /// numeric property during a read (extract) operation. Leave unset to use the
+    /// target type's natural style —
+    /// <see cref="System.Globalization.NumberStyles.Integer"/> for integral types and
+    /// <see cref="System.Globalization.NumberStyles.Number"/> for
+    /// <see cref="decimal"/>/<see cref="double"/>/<see cref="float"/> — matching
+    /// <c>int.Parse</c> / <c>decimal.Parse</c>. Set it explicitly to opt into other
+    /// forms, e.g. <see cref="System.Globalization.NumberStyles.Currency"/> to accept
+    /// currency symbols or parenthesized negatives. Parsing always uses
     /// <see cref="System.Globalization.CultureInfo.InvariantCulture"/>.
     /// </summary>
-    public NumberStyles NumberStyles { get; set; } = NumberStyles.Any;
+    public NumberStyles NumberStyles { get; set; } = UnspecifiedNumberStyles;
 
 
 

--- a/src/Wolfgang.Etl.FixedWidth/Attributes/FixedWidthFieldAttribute.cs
+++ b/src/Wolfgang.Etl.FixedWidth/Attributes/FixedWidthFieldAttribute.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using Wolfgang.Etl.FixedWidth.Enums;
 
 namespace Wolfgang.Etl.FixedWidth.Attributes;
@@ -144,6 +145,19 @@ public sealed class FixedWidthFieldAttribute : Attribute
     /// <c>"D5"</c> for a zero-padded integer.
     /// </summary>
     public string? Format { get; set; }
+
+
+
+    /// <summary>
+    /// The <see cref="System.Globalization.NumberStyles"/> permitted when parsing a
+    /// numeric property during a read (extract) operation. Defaults to
+    /// <see cref="System.Globalization.NumberStyles.Any"/>. Restrict it to reject
+    /// unwanted forms — for example
+    /// <see cref="System.Globalization.NumberStyles.Integer"/> to disallow decimals
+    /// and thousands separators. Parsing always uses
+    /// <see cref="System.Globalization.CultureInfo.InvariantCulture"/>.
+    /// </summary>
+    public NumberStyles NumberStyles { get; set; } = NumberStyles.Any;
 
 
 

--- a/src/Wolfgang.Etl.FixedWidth/FieldContext.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FieldContext.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using Wolfgang.Etl.FixedWidth.Enums;
 
 namespace Wolfgang.Etl.FixedWidth;
@@ -30,7 +31,8 @@ public sealed class FieldContext
         char pad,
         FieldAlignment alignment,
         string? format,
-        string headerLabel
+        string headerLabel,
+        NumberStyles numberStyles = NumberStyles.Any
     )
     {
         PropertyName = propertyName;
@@ -40,6 +42,7 @@ public sealed class FieldContext
         Alignment = alignment;
         Format = format;
         HeaderLabel = headerLabel;
+        NumberStyles = numberStyles;
     }
 
 
@@ -99,4 +102,13 @@ public sealed class FieldContext
     /// <see langword="null"/> if none was specified.
     /// </summary>
     public string? Format { get; }
+
+
+
+    /// <summary>
+    /// The <see cref="System.Globalization.NumberStyles"/> permitted when parsing a
+    /// numeric field, from the field attribute. Defaults to
+    /// <see cref="System.Globalization.NumberStyles.Any"/>.
+    /// </summary>
+    public NumberStyles NumberStyles { get; }
 }

--- a/src/Wolfgang.Etl.FixedWidth/FieldContext.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FieldContext.cs
@@ -32,7 +32,7 @@ public sealed class FieldContext
         FieldAlignment alignment,
         string? format,
         string headerLabel,
-        NumberStyles numberStyles = NumberStyles.Any
+        NumberStyles? numberStyles = null
     )
     {
         PropertyName = propertyName;
@@ -107,8 +107,8 @@ public sealed class FieldContext
 
     /// <summary>
     /// The <see cref="System.Globalization.NumberStyles"/> permitted when parsing a
-    /// numeric field, from the field attribute. Defaults to
-    /// <see cref="System.Globalization.NumberStyles.Any"/>.
+    /// numeric field, from the field attribute, or <see langword="null"/> to use the
+    /// target type's natural style.
     /// </summary>
-    public NumberStyles NumberStyles { get; }
+    public NumberStyles? NumberStyles { get; }
 }

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthConverter.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthConverter.cs
@@ -237,7 +237,8 @@ public static class FixedWidthConverter
         (
             text,
             context.PropertyType,
-            context.Format
+            context.Format,
+            numberStyles: context.NumberStyles
         );
 
 
@@ -299,7 +300,8 @@ public static class FixedWidthConverter
         ReadOnlyMemory<char> text,
         Type targetType,
         string? format,
-        TypeConverter? cachedConverter = null
+        TypeConverter? cachedConverter = null,
+        NumberStyles numberStyles = NumberStyles.Any
     )
     {
         var span = text.Span;
@@ -315,7 +317,8 @@ public static class FixedWidthConverter
                 text,
                 underlying,
                 format,
-                cachedConverter
+                cachedConverter,
+                numberStyles
             );
         }
 
@@ -341,12 +344,14 @@ public static class FixedWidthConverter
         }
 
 #if NET8_0_OR_GREATER
-        var numericResult = ParseNumericSpan(span, targetType);
+        var numericResult = ParseNumericSpan(span, targetType, numberStyles);
+#else
+        var numericResult = ParseNumericString(text.ToString(), targetType, numberStyles);
+#endif
         if (numericResult != null)
         {
             return numericResult;
         }
-#endif
 
         return ParseViaTypeConverter(text, targetType, cachedConverter);
     }
@@ -428,6 +433,47 @@ public static class FixedWidthConverter
             CultureInfo.InvariantCulture
         );
     }
+
+
+
+    /// <summary>
+    /// Parses a numeric value from <paramref name="text"/> using the supplied
+    /// <paramref name="style"/> and <see cref="CultureInfo.InvariantCulture"/>.
+    /// The net8+ build uses the allocation-free span overloads instead
+    /// (<c>ParseNumericSpan</c>). Returns <see langword="null"/> when
+    /// <paramref name="targetType"/> is not a supported numeric type.
+    /// </summary>
+    private static object? ParseNumericString(string text, Type targetType, NumberStyles style)
+    {
+        var culture = CultureInfo.InvariantCulture;
+
+        if (targetType == typeof(int))
+            return int.Parse(text, style, culture);
+        if (targetType == typeof(long))
+            return long.Parse(text, style, culture);
+        if (targetType == typeof(decimal))
+            return decimal.Parse(text, style, culture);
+        if (targetType == typeof(double))
+            return double.Parse(text, style, culture);
+        if (targetType == typeof(float))
+            return float.Parse(text, style, culture);
+        if (targetType == typeof(short))
+            return short.Parse(text, style, culture);
+        if (targetType == typeof(byte))
+            return byte.Parse(text, style, culture);
+        if (targetType == typeof(bool))
+            return bool.Parse(text);
+        if (targetType == typeof(uint))
+            return uint.Parse(text, style, culture);
+        if (targetType == typeof(ulong))
+            return ulong.Parse(text, style, culture);
+        if (targetType == typeof(ushort))
+            return ushort.Parse(text, style, culture);
+        if (targetType == typeof(sbyte))
+            return sbyte.Parse(text, style, culture);
+
+        return null;
+    }
 #endif
 
 
@@ -489,9 +535,8 @@ public static class FixedWidthConverter
     /// recognized type, signalling the caller to fall back to the
     /// <see cref="TypeDescriptor"/> path.
     /// </summary>
-    private static object? ParseNumericSpan(ReadOnlySpan<char> span, Type targetType)
+    private static object? ParseNumericSpan(ReadOnlySpan<char> span, Type targetType, NumberStyles style)
     {
-        var style = NumberStyles.Any;
         var culture = CultureInfo.InvariantCulture;
 
         if (targetType == typeof(int))

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthConverter.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthConverter.cs
@@ -301,7 +301,7 @@ public static class FixedWidthConverter
         Type targetType,
         string? format,
         TypeConverter? cachedConverter = null,
-        NumberStyles numberStyles = NumberStyles.Any
+        NumberStyles? numberStyles = null
     )
     {
         var span = text.Span;
@@ -386,6 +386,27 @@ public static class FixedWidthConverter
 
 
 
+    /// <summary>
+    /// Resolves the effective <see cref="NumberStyles"/> for a numeric parse: the
+    /// explicitly requested style when set, otherwise the target type's natural
+    /// style — <see cref="NumberStyles.Number"/> for decimal / floating-point types
+    /// and <see cref="NumberStyles.Integer"/> for integral types (matching
+    /// <c>decimal.Parse</c> / <c>int.Parse</c>).
+    /// </summary>
+    private static NumberStyles ResolveNumberStyles(NumberStyles? requestedStyle, TypeCode typeCode)
+    {
+        if (requestedStyle.HasValue)
+        {
+            return requestedStyle.Value;
+        }
+
+        return typeCode is TypeCode.Decimal or TypeCode.Double or TypeCode.Single
+            ? NumberStyles.Number
+            : NumberStyles.Integer;
+    }
+
+
+
 #if !NET8_0_OR_GREATER
     /// <summary>
     /// Parses a <see cref="DateTime"/>, <see cref="DateTimeOffset"/>, or
@@ -437,13 +458,14 @@ public static class FixedWidthConverter
 
 
     /// <summary>
-    /// Parses a numeric value from <paramref name="text"/> using the supplied
-    /// <paramref name="style"/> and <see cref="CultureInfo.InvariantCulture"/>.
-    /// The net8+ build uses the allocation-free span overloads instead
+    /// Parses a numeric value from <paramref name="text"/> using
+    /// <paramref name="requestedStyle"/> (or the type's natural style when null) and
+    /// <see cref="CultureInfo.InvariantCulture"/>. The net8+ build uses the
+    /// allocation-free span overloads instead
     /// (<c>ParseNumericSpan</c>). Returns <see langword="null"/> when
     /// <paramref name="targetType"/> is not a supported numeric type.
     /// </summary>
-    private static object? ParseNumericString(string text, Type targetType, NumberStyles style)
+    private static object? ParseNumericString(string text, Type targetType, NumberStyles? requestedStyle)
     {
         var culture = CultureInfo.InvariantCulture;
 
@@ -454,10 +476,13 @@ public static class FixedWidthConverter
             return null;
         }
 
+        var typeCode = Type.GetTypeCode(targetType);
+        var style = ResolveNumberStyles(requestedStyle, typeCode);
+
         // Switch on TypeCode (a dense enum) so the JIT emits a jump table rather
         // than the sequential type comparisons an if-ladder or a Dictionary lookup
         // would produce.
-        return Type.GetTypeCode(targetType) switch
+        return typeCode switch
         {
             TypeCode.Int32 => int.Parse(text, style, culture),
             TypeCode.Int64 => long.Parse(text, style, culture),
@@ -535,7 +560,7 @@ public static class FixedWidthConverter
     /// recognized type, signalling the caller to fall back to the
     /// <see cref="TypeDescriptor"/> path.
     /// </summary>
-    private static object? ParseNumericSpan(ReadOnlySpan<char> span, Type targetType, NumberStyles style)
+    private static object? ParseNumericSpan(ReadOnlySpan<char> span, Type targetType, NumberStyles? requestedStyle)
     {
         var culture = CultureInfo.InvariantCulture;
 
@@ -546,10 +571,13 @@ public static class FixedWidthConverter
             return null;
         }
 
+        var typeCode = Type.GetTypeCode(targetType);
+        var style = ResolveNumberStyles(requestedStyle, typeCode);
+
         // Switch on TypeCode (a dense enum) so the JIT emits a jump table rather
         // than the sequential type comparisons an if-ladder or a Dictionary lookup
         // would produce. Keeps the allocation-free span overloads.
-        return Type.GetTypeCode(targetType) switch
+        return typeCode switch
         {
             TypeCode.Int32 => int.Parse(span, style, culture),
             TypeCode.Int64 => long.Parse(span, style, culture),

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthConverter.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthConverter.cs
@@ -447,32 +447,32 @@ public static class FixedWidthConverter
     {
         var culture = CultureInfo.InvariantCulture;
 
-        if (targetType == typeof(int))
-            return int.Parse(text, style, culture);
-        if (targetType == typeof(long))
-            return long.Parse(text, style, culture);
-        if (targetType == typeof(decimal))
-            return decimal.Parse(text, style, culture);
-        if (targetType == typeof(double))
-            return double.Parse(text, style, culture);
-        if (targetType == typeof(float))
-            return float.Parse(text, style, culture);
-        if (targetType == typeof(short))
-            return short.Parse(text, style, culture);
-        if (targetType == typeof(byte))
-            return byte.Parse(text, style, culture);
-        if (targetType == typeof(bool))
-            return bool.Parse(text);
-        if (targetType == typeof(uint))
-            return uint.Parse(text, style, culture);
-        if (targetType == typeof(ulong))
-            return ulong.Parse(text, style, culture);
-        if (targetType == typeof(ushort))
-            return ushort.Parse(text, style, culture);
-        if (targetType == typeof(sbyte))
-            return sbyte.Parse(text, style, culture);
+        // Enums share a TypeCode with their underlying integral type; exclude them
+        // so the TypeConverter fallback (which parses enum member names) is used.
+        if (targetType.IsEnum)
+        {
+            return null;
+        }
 
-        return null;
+        // Switch on TypeCode (a dense enum) so the JIT emits a jump table rather
+        // than the sequential type comparisons an if-ladder or a Dictionary lookup
+        // would produce.
+        return Type.GetTypeCode(targetType) switch
+        {
+            TypeCode.Int32 => int.Parse(text, style, culture),
+            TypeCode.Int64 => long.Parse(text, style, culture),
+            TypeCode.Decimal => decimal.Parse(text, style, culture),
+            TypeCode.Double => double.Parse(text, style, culture),
+            TypeCode.Single => float.Parse(text, style, culture),
+            TypeCode.Int16 => short.Parse(text, style, culture),
+            TypeCode.Byte => byte.Parse(text, style, culture),
+            TypeCode.Boolean => bool.Parse(text),
+            TypeCode.UInt32 => uint.Parse(text, style, culture),
+            TypeCode.UInt64 => ulong.Parse(text, style, culture),
+            TypeCode.UInt16 => ushort.Parse(text, style, culture),
+            TypeCode.SByte => sbyte.Parse(text, style, culture),
+            _ => (object?)null,
+        };
     }
 #endif
 
@@ -539,32 +539,32 @@ public static class FixedWidthConverter
     {
         var culture = CultureInfo.InvariantCulture;
 
-        if (targetType == typeof(int))
-            return int.Parse(span, style, culture);
-        if (targetType == typeof(long))
-            return long.Parse(span, style, culture);
-        if (targetType == typeof(decimal))
-            return decimal.Parse(span, style, culture);
-        if (targetType == typeof(double))
-            return double.Parse(span, style, culture);
-        if (targetType == typeof(float))
-            return float.Parse(span, style, culture);
-        if (targetType == typeof(short))
-            return short.Parse(span, style, culture);
-        if (targetType == typeof(byte))
-            return byte.Parse(span, style, culture);
-        if (targetType == typeof(bool))
-            return bool.Parse(span);
-        if (targetType == typeof(uint))
-            return uint.Parse(span, style, culture);
-        if (targetType == typeof(ulong))
-            return ulong.Parse(span, style, culture);
-        if (targetType == typeof(ushort))
-            return ushort.Parse(span, style, culture);
-        if (targetType == typeof(sbyte))
-            return sbyte.Parse(span, style, culture);
+        // Enums share a TypeCode with their underlying integral type; exclude them
+        // so the TypeConverter fallback (which parses enum member names) is used.
+        if (targetType.IsEnum)
+        {
+            return null;
+        }
 
-        return null;
+        // Switch on TypeCode (a dense enum) so the JIT emits a jump table rather
+        // than the sequential type comparisons an if-ladder or a Dictionary lookup
+        // would produce. Keeps the allocation-free span overloads.
+        return Type.GetTypeCode(targetType) switch
+        {
+            TypeCode.Int32 => int.Parse(span, style, culture),
+            TypeCode.Int64 => long.Parse(span, style, culture),
+            TypeCode.Decimal => decimal.Parse(span, style, culture),
+            TypeCode.Double => double.Parse(span, style, culture),
+            TypeCode.Single => float.Parse(span, style, culture),
+            TypeCode.Int16 => short.Parse(span, style, culture),
+            TypeCode.Byte => byte.Parse(span, style, culture),
+            TypeCode.Boolean => bool.Parse(span),
+            TypeCode.UInt32 => uint.Parse(span, style, culture),
+            TypeCode.UInt64 => ulong.Parse(span, style, culture),
+            TypeCode.UInt16 => ushort.Parse(span, style, culture),
+            TypeCode.SByte => sbyte.Parse(span, style, culture),
+            _ => (object?)null,
+        };
     }
 #endif
 }

--- a/src/Wolfgang.Etl.FixedWidth/Parsing/FieldDescriptor.cs
+++ b/src/Wolfgang.Etl.FixedWidth/Parsing/FieldDescriptor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using System.Globalization;
 using System.Linq.Expressions;
 using System.Reflection;
 using Wolfgang.Etl.FixedWidth.Attributes;
@@ -37,7 +38,9 @@ internal sealed class FieldDescriptor
             attribute.Alignment,
             attribute.Format,
             attribute.Header ?? property.Name,
-            attribute.NumberStyles
+            attribute.NumberStyles == FixedWidthFieldAttribute.UnspecifiedNumberStyles
+                ? (NumberStyles?)null
+                : attribute.NumberStyles
         );
         Getter = property.GetMethod != null && property.GetMethod.IsPublic
             ? CompileGetter(property)

--- a/src/Wolfgang.Etl.FixedWidth/Parsing/FieldDescriptor.cs
+++ b/src/Wolfgang.Etl.FixedWidth/Parsing/FieldDescriptor.cs
@@ -36,7 +36,8 @@ internal sealed class FieldDescriptor
             attribute.Pad,
             attribute.Alignment,
             attribute.Format,
-            attribute.Header ?? property.Name
+            attribute.Header ?? property.Name,
+            attribute.NumberStyles
         );
         Getter = property.GetMethod != null && property.GetMethod.IsPublic
             ? CompileGetter(property)

--- a/src/Wolfgang.Etl.FixedWidth/Parsing/FixedWidthLineParser.cs
+++ b/src/Wolfgang.Etl.FixedWidth/Parsing/FixedWidthLineParser.cs
@@ -499,7 +499,7 @@ internal static class FixedWidthLineParser
             // Fast path: when using the default parser, pass the cached TypeConverter
             // to avoid TypeDescriptor.GetConverter on every field of every record.
             var converted = ReferenceEquals(valueParser, FixedWidthConverter.DefaultParser)
-                ? FixedWidthConverter.ParseValue(value, descriptor.Context.PropertyType, descriptor.Context.Format, descriptor.TypeConverter)
+                ? FixedWidthConverter.ParseValue(value, descriptor.Context.PropertyType, descriptor.Context.Format, descriptor.TypeConverter, descriptor.Context.NumberStyles)
                 : valueParser(value, descriptor.Context);
             descriptor.Setter(record!, converted);
         }

--- a/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
@@ -1,7 +1,7 @@
 #nullable enable
 Wolfgang.Etl.FixedWidth.Attributes.FixedWidthFieldAttribute.NumberStyles.get -> System.Globalization.NumberStyles
 Wolfgang.Etl.FixedWidth.Attributes.FixedWidthFieldAttribute.NumberStyles.set -> void
-Wolfgang.Etl.FixedWidth.FieldContext.NumberStyles.get -> System.Globalization.NumberStyles
+Wolfgang.Etl.FixedWidth.FieldContext.NumberStyles.get -> System.Globalization.NumberStyles?
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.FixedWidthExtractor(System.IO.Stream stream, System.Text.Encoding encoding = null) -> void
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.FixedWidthExtractor(System.IO.Stream stream, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>> logger, System.Text.Encoding encoding = null) -> void
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.FixedWidthLoader(System.IO.Stream stream, System.Text.Encoding encoding = null) -> void

--- a/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
@@ -1,4 +1,7 @@
 #nullable enable
+Wolfgang.Etl.FixedWidth.Attributes.FixedWidthFieldAttribute.NumberStyles.get -> System.Globalization.NumberStyles
+Wolfgang.Etl.FixedWidth.Attributes.FixedWidthFieldAttribute.NumberStyles.set -> void
+Wolfgang.Etl.FixedWidth.FieldContext.NumberStyles.get -> System.Globalization.NumberStyles
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.FixedWidthExtractor(System.IO.Stream stream, System.Text.Encoding encoding = null) -> void
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.FixedWidthExtractor(System.IO.Stream stream, Microsoft.Extensions.Logging.ILogger<Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>> logger, System.Text.Encoding encoding = null) -> void
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.FixedWidthLoader(System.IO.Stream stream, System.Text.Encoding encoding = null) -> void

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthNumberStylesTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthNumberStylesTests.cs
@@ -1,0 +1,102 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.FixedWidth.Attributes;
+using Wolfgang.Etl.FixedWidth.Enums;
+using Xunit;
+
+namespace Wolfgang.Etl.FixedWidth.Tests.Unit;
+
+/// <summary>
+/// Covers the <see cref="FixedWidthFieldAttribute.NumberStyles"/> property (#9).
+/// </summary>
+public class FixedWidthNumberStylesTests
+{
+    [ExcludeFromCodeCoverage]
+    private class MoneyRecord
+    {
+        // Default NumberStyles.Any — permissive.
+        [FixedWidthField(0, 12)]
+        public decimal Amount { get; set; }
+    }
+
+
+
+    [ExcludeFromCodeCoverage]
+    private class StrictIntRecord
+    {
+        // Integer only — no decimals, no thousands separators.
+        [FixedWidthField(0, 12, NumberStyles = NumberStyles.Integer)]
+        public int Value { get; set; }
+    }
+
+
+
+    private static async Task<T[]> ExtractAsync<T>(string line, MalformedLineHandling malformed = MalformedLineHandling.ThrowException)
+        where T : notnull, new()
+    {
+        var extractor = new FixedWidthExtractor<T>(new StringReader(line))
+        {
+            MalformedLineHandling = malformed,
+        };
+
+        var results = new System.Collections.Generic.List<T>();
+        await foreach (var record in extractor.ExtractAsync(CancellationToken.None))
+        {
+            results.Add(record);
+        }
+
+        return results.ToArray();
+    }
+
+
+
+    [Fact]
+    public async Task Default_Any_parses_thousands_and_decimal()
+    {
+        var records = await ExtractAsync<MoneyRecord>("1,234.56    ");
+
+        Assert.Equal(1234.56m, Assert.Single(records).Amount);
+    }
+
+
+
+    [Fact]
+    public async Task Default_Any_parses_parenthesized_negative()
+    {
+        var records = await ExtractAsync<MoneyRecord>("(500)       ");
+
+        Assert.Equal(-500m, Assert.Single(records).Amount);
+    }
+
+
+
+    [Fact]
+    public async Task NumberStyles_Integer_parses_a_plain_integer()
+    {
+        var records = await ExtractAsync<StrictIntRecord>("1234        ");
+
+        Assert.Equal(1234, Assert.Single(records).Value);
+    }
+
+
+
+    [Fact]
+    public async Task NumberStyles_Integer_rejects_a_decimal_value()
+    {
+        // The Integer style disallows the decimal point, so parsing fails and the
+        // malformed line is skipped (rejected) rather than yielded.
+        var extractor = new FixedWidthExtractor<StrictIntRecord>(new StringReader("12.5        "))
+        {
+            MalformedLineHandling = MalformedLineHandling.Skip,
+        };
+
+        var results = await extractor.ExtractAsync(CancellationToken.None).ToListAsync();
+
+        Assert.Empty(results);
+        Assert.Equal(1, extractor.CurrentRejectedItemCount);
+    }
+}

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthNumberStylesTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthNumberStylesTests.cs
@@ -12,13 +12,16 @@ namespace Wolfgang.Etl.FixedWidth.Tests.Unit;
 
 /// <summary>
 /// Covers the <see cref="FixedWidthFieldAttribute.NumberStyles"/> property (#9).
+/// The default (<see langword="null"/>) uses the target type's natural style —
+/// <c>Integer</c> for integral types, <c>Number</c> for decimal / floating-point —
+/// so the permissive forms (currency, exponent, parentheses) must be opted into.
 /// </summary>
 public class FixedWidthNumberStylesTests
 {
     [ExcludeFromCodeCoverage]
     private class MoneyRecord
     {
-        // Default NumberStyles.Any — permissive.
+        // Default (null) -> Number for decimal: allows sign, decimal, thousands.
         [FixedWidthField(0, 12)]
         public decimal Amount { get; set; }
     }
@@ -26,11 +29,21 @@ public class FixedWidthNumberStylesTests
 
 
     [ExcludeFromCodeCoverage]
-    private class StrictIntRecord
+    private class PlainIntRecord
     {
-        // Integer only — no decimals, no thousands separators.
-        [FixedWidthField(0, 12, NumberStyles = NumberStyles.Integer)]
+        // Default (null) -> Integer for int: no decimals, no thousands.
+        [FixedWidthField(0, 12)]
         public int Value { get; set; }
+    }
+
+
+
+    [ExcludeFromCodeCoverage]
+    private class AnyMoneyRecord
+    {
+        // Explicit opt-in to the permissive forms (currency, parentheses, ...).
+        [FixedWidthField(0, 12, NumberStyles = NumberStyles.Any)]
+        public decimal Amount { get; set; }
     }
 
 
@@ -73,7 +86,7 @@ public class FixedWidthNumberStylesTests
 
 
     [Fact]
-    public async Task Default_Any_parses_thousands_and_decimal()
+    public async Task Default_for_decimal_allows_thousands_and_decimal_point()
     {
         var records = await ExtractAsync<MoneyRecord>("1,234.56    ");
 
@@ -83,31 +96,10 @@ public class FixedWidthNumberStylesTests
 
 
     [Fact]
-    public async Task Default_Any_parses_parenthesized_negative()
+    public async Task Default_for_decimal_rejects_a_parenthesized_negative()
     {
-        var records = await ExtractAsync<MoneyRecord>("(500)       ");
-
-        Assert.Equal(-500m, Assert.Single(records).Amount);
-    }
-
-
-
-    [Fact]
-    public async Task NumberStyles_Integer_parses_a_plain_integer()
-    {
-        var records = await ExtractAsync<StrictIntRecord>("1234        ");
-
-        Assert.Equal(1234, Assert.Single(records).Value);
-    }
-
-
-
-    [Fact]
-    public async Task NumberStyles_Integer_rejects_a_decimal_value()
-    {
-        // The Integer style disallows the decimal point, so parsing fails and the
-        // malformed line is skipped (rejected) rather than yielded.
-        var extractor = new FixedWidthExtractor<StrictIntRecord>(new StringReader("12.5        "))
+        // Parentheses are not part of the natural (Number) style — rejected.
+        var extractor = new FixedWidthExtractor<MoneyRecord>(new StringReader("(500)       "))
         {
             MalformedLineHandling = MalformedLineHandling.Skip,
         };
@@ -116,6 +108,43 @@ public class FixedWidthNumberStylesTests
 
         Assert.Empty(results);
         Assert.Equal(1, extractor.CurrentRejectedItemCount);
+    }
+
+
+
+    [Fact]
+    public async Task Default_for_int_parses_a_plain_integer()
+    {
+        var records = await ExtractAsync<PlainIntRecord>("1234        ");
+
+        Assert.Equal(1234, Assert.Single(records).Value);
+    }
+
+
+
+    [Fact]
+    public async Task Default_for_int_rejects_a_decimal_point()
+    {
+        // Integer (the natural style for int) disallows the decimal point.
+        var extractor = new FixedWidthExtractor<PlainIntRecord>(new StringReader("12.5        "))
+        {
+            MalformedLineHandling = MalformedLineHandling.Skip,
+        };
+
+        var results = await extractor.ExtractAsync(CancellationToken.None).ToListAsync();
+
+        Assert.Empty(results);
+        Assert.Equal(1, extractor.CurrentRejectedItemCount);
+    }
+
+
+
+    [Fact]
+    public async Task Explicit_NumberStyles_Any_allows_a_parenthesized_negative()
+    {
+        var records = await ExtractAsync<AnyMoneyRecord>("(500)       ");
+
+        Assert.Equal(-500m, Assert.Single(records).Amount);
     }
 
 

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthNumberStylesTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthNumberStylesTests.cs
@@ -35,6 +35,24 @@ public class FixedWidthNumberStylesTests
 
 
 
+    private enum Priority
+    {
+        Low,
+        Medium,
+        High,
+    }
+
+
+
+    [ExcludeFromCodeCoverage]
+    private class TicketRecord
+    {
+        [FixedWidthField(0, 8)]
+        public Priority Priority { get; set; }
+    }
+
+
+
     private static async Task<T[]> ExtractAsync<T>(string line, MalformedLineHandling malformed = MalformedLineHandling.ThrowException)
         where T : notnull, new()
     {
@@ -98,5 +116,18 @@ public class FixedWidthNumberStylesTests
 
         Assert.Empty(results);
         Assert.Equal(1, extractor.CurrentRejectedItemCount);
+    }
+
+
+
+    [Fact]
+    public async Task Enum_field_parses_by_member_name_not_its_underlying_integer()
+    {
+        // Enums share a TypeCode with their underlying integral type; the parser
+        // must route them to the TypeConverter (which parses "High"), not to
+        // int.Parse.
+        var records = await ExtractAsync<TicketRecord>("High    ");
+
+        Assert.Equal(Priority.High, Assert.Single(records).Priority);
     }
 }


### PR DESCRIPTION
Adds a `NumberStyles` property to `[FixedWidthField]` controlling how a numeric field is parsed during extraction.

```csharp
[FixedWidthField(0, 12, NumberStyles = NumberStyles.Integer)]  // reject decimals/thousands
public int Quantity { get; set; }
```

- Defaults to `NumberStyles.Any`, parsed with `InvariantCulture` — restrict it to tighten validation.
- Threaded `[FixedWidthField]` → `FieldContext` → `FixedWidthConverter.ParseValue` (and the line parser's cached path).

### Cross-TFM unification
Previously net8.0+ parsed numerics via span overloads (`NumberStyles.Any`) while .NET Framework / netstandard fell through to `TypeConverter.ConvertFromInvariantString` (ignoring `NumberStyles`). Added a non-net8 `ParseNumericString` path so the style is honored **everywhere** — values with thousands separators / currency symbols / parenthesized negatives now parse identically on every target framework. Noted under CHANGELOG *Changed*.

### Tests / surface
- `FixedWidthNumberStylesTests`: default `Any` parses thousands + decimal and parenthesized negatives; `NumberStyles.Integer` parses plain ints and **rejects** a decimal (→ malformed/rejected).
- `NumberStyles` added to `[FixedWidthField]` + `FieldContext` in `PublicAPI.Unshipped.txt`.

### Local gate (full pr.yaml via dotnet)
0 warnings, **309/309 across all 13 TFMs**, all classes ≥ 90%. (The gate caught a CS0310 generic-constraint slip pre-push.)

Base `vNext` (0.5.0 cycle). Closes #9.