### PR TITLE
docs: allocation-profile snapshot (#157)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,3 +21,13 @@ We will acknowledge your report within 48 hours and provide an estimated timelin
 
 Your help is greatly appreciated!
 Responsible disclosure of security vulnerabilities helps protect our entire community.
+
+## Release path & compromise scope
+
+Facts a maintainer would need at 2am if the release identity is compromised. Generic incident-response steps (rotating credentials, revoking OAuth apps, publishing advisories, unlisting NuGet packages) are not duplicated here — GitHub's and NuGet's own docs update faster than a checked-in runbook.
+
+- **Release path**: OIDC / NuGet Trusted Publishing via `NuGet/login@v1` in `.github/workflows/release.yaml`. The workflow mints an ephemeral push token per run via OIDC — the release path does not depend on a long-lived API key stored in GitHub secrets or on the NuGet account. During an incident, check the NuGet account for any long-lived API keys anyway (they can be created outside of CI) and delete anything you don't recognize.
+- **Fallback**: none. If Trusted Publishing is compromised, the incident is at the GitHub-account level (the OIDC identity is `Chris-Wolfgang/ETL-FixedWidth`).
+- **Owner**: @Chris-Wolfgang.
+- **Downstream consumers**: no known `Wolfgang.*` fleet dependents (ETL-FixedWidth is a leaf library); unknown external consumers may exist on nuget.org.
+- **Package coordinates for unlisting**: `Wolfgang.Etl.FixedWidth` on nuget.org — <https://www.nuget.org/packages/Wolfgang.Etl.FixedWidth/>.

--- a/docs/ALLOCATION-PROFILE.md
+++ b/docs/ALLOCATION-PROFILE.md
@@ -1,0 +1,50 @@
+# Allocation profile
+
+This document is the snapshot the thorough-review pass ([#157]) asks for: an
+explicit statement of what allocates, what does not, and how allocation is
+guarded against regression.
+
+## Is any public method zero-allocation?
+
+**No.** ETL-FixedWidth is a materializing library by design. Every public
+operation produces managed objects that must be allocated:
+
+| Surface | Unavoidable allocations |
+| --- | --- |
+| `FixedWidthExtractor<T>.ExtractAsync` | one `T` record per line; a `string` per string-typed field; a boxed `object` per value-typed field (the converter returns `object`); the `IAsyncEnumerator` state machine. |
+| `FixedWidthLoader<T>.LoadAsync` | the formatted `string`/`char[]` segments written per record; the async state machine. |
+
+Because the field converter returns `object`, even the span-based fast path
+(`int.Parse(span, …)` on net8+) boxes its result. There is therefore **no call
+site with a zero-allocation contract to enforce**, so — per the [#157] acceptance
+criteria — this repo intentionally does **not** carry
+`GC.GetAllocatedBytesForCurrentThread()` unit tests. A half-implemented "assert
+zero bytes" test would either be trivially false or pinned to an arbitrary
+threshold that adds maintenance noise without protecting a real contract.
+
+## What the fast path *does* optimize
+
+On `net8.0`+ the numeric and `DateTime` parse paths read directly from the line's
+`ReadOnlySpan<char>` (`ParseNumericSpan` / `ParseDateTimeValueSpan`), avoiding the
+**intermediate per-field substring** that the netstandard2.0 build must allocate
+before parsing. That is a real, measured reduction — but the boxed result and the
+record itself remain, so it is "fewer allocations", not "zero".
+
+## How allocation is guarded
+
+Allocation regressions are caught at the **benchmark** level, not by unit tests.
+Every benchmark class carries BenchmarkDotNet's `[MemoryDiagnoser]`, so the
+`Allocated` column is captured on every run and published to the trend chart:
+
+- `ExtractorBenchmarks`
+- `LoaderBenchmarks`
+- `DateTimeBenchmarks`
+- `PeakMemoryBenchmarks`
+
+Chart: <https://chris-wolfgang.github.io/ETL-FixedWidth/dev/bench/>
+
+A change that regresses per-record allocation shows up as a step in the
+`Allocated` series on that chart. That is the appropriate granularity for a
+library whose hot path is inherently allocating.
+
+[#157]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/157

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,29 @@
+# 0001. Record architecture decisions
+
+- **Status**: accepted
+- **Date**: 2026-07-16
+
+## Context
+
+Non-obvious design choices — why the numeric parser defaults to a per-type
+`NumberStyles`, why the extractor splits its counters four ways, why line-ending
+control is a documentation pattern rather than an enum — get lost six months
+after the PR that introduced them. Future maintainers re-derive the same
+trade-offs, often worse, or unknowingly reverse them.
+
+## Decision
+
+We keep Architecture Decision Records (ADRs) — short markdown documents capturing
+the context, decision, and consequences of each non-obvious choice — in
+`docs/adr/`, numbered sequentially, using the [TEMPLATE.md](TEMPLATE.md) shape
+(a trimmed Michael Nygard template). A new ADR lands alongside the PR that makes
+the decision; superseding decisions link back to the ADR they replace rather than
+editing history.
+
+## Consequences
+
+- The reasoning behind a choice survives independently of the PR discussion that
+  produced it.
+- There is a small per-decision authoring cost; it applies only to *non-obvious*
+  choices, not routine changes.
+- Retroactive ADRs (0002–0004) capture decisions that predate this record.

--- a/docs/adr/0002-numberstyles-per-type-default.md
+++ b/docs/adr/0002-numberstyles-per-type-default.md
@@ -1,0 +1,39 @@
+# 0002. Per-type default NumberStyles for field parsing
+
+- **Status**: accepted
+- **Date**: 2026-07-16
+
+## Context
+
+`[FixedWidthField]` gained a `NumberStyles` property (#9) so callers can control
+how numeric fields are parsed. The question was what the *default* should be when
+the caller does not specify one. `NumberStyles.Any` is permissive (accepts
+currency symbols, parentheses-for-negative, exponents, thousands) but silently
+masks malformed data; `NumberStyles.None` is stricter than the BCL's own
+`int.Parse(string)` / `decimal.Parse(string)` and would surprise callers.
+
+An attribute argument cannot be a nullable enum (CS0655), so "unset" cannot be
+represented as `null` on the attribute itself.
+
+## Decision
+
+The default mirrors the BCL's own per-type parse defaults: `NumberStyles.Integer`
+for integral types and `NumberStyles.Number` for `decimal` / `double` / `float`
+(resolved in `FixedWidthConverter.ResolveNumberStyles`). The permissive forms
+(currency, parentheses, exponent) must be opted into explicitly with
+`NumberStyles = NumberStyles.Any`.
+
+"Unset" is encoded as the sentinel `(NumberStyles)(-1)`
+(`FixedWidthFieldAttribute.UnspecifiedNumberStyles`); `FieldDescriptor` maps the
+sentinel to a nullable `NumberStyles?` in the parsing context, and a null there
+selects the per-type default.
+
+## Consequences
+
+- Parsing behaviour matches what a developer expects from `int.Parse` /
+  `decimal.Parse` with no configuration — a plain integer field rejects a decimal
+  point; a decimal field accepts a decimal point and thousands separators.
+- Malformed data is rejected by default rather than coerced, surfacing as a
+  rejected line (see [ADR-0003](0003-line-accounting-counters.md)).
+- The sentinel is an internal implementation detail; the public surface is the
+  ordinary non-nullable `NumberStyles` property.

--- a/docs/adr/0003-line-accounting-counters.md
+++ b/docs/adr/0003-line-accounting-counters.md
@@ -1,0 +1,38 @@
+# 0003. Four-way line accounting: items / skipped / rejected / filtered
+
+- **Status**: accepted
+- **Date**: 2026-07-16
+
+## Context
+
+The extractor drops input lines for several distinct reasons, and consumers need
+to tell them apart: a line intentionally paged over (`SkipItemCount`), a line the
+caller's `RecordValidator` rejected, a structurally malformed line, a blank line,
+and a line removed by a `LineFilter`. Collapsing all of these into a single
+"skipped" count loses the signal a consumer needs to distinguish "the file had
+bad data" from "I asked to skip these".
+
+## Decision
+
+The extractor exposes four counters that partition every physical line:
+
+- `CurrentItemCount` — lines successfully yielded as records.
+- `CurrentSkippedItemCount` — lines skipped by the `SkipItemCount` pagination budget.
+- `CurrentRejectedItemCount` — lines that *looked like* records but failed:
+  malformed layout, or a `RecordValidator` returning `Skip`/`Stop`.
+- `CurrentFilteredLineCount` — lines that were never candidate records: blank
+  lines under `BlankLineHandling.Skip`, `LineFilter` removals, and structural
+  early-stops.
+
+These close exactly:
+`CurrentLineNumber == Items + Skipped + Rejected + Filtered`.
+
+## Consequences
+
+- `LineFilter` removals stay "invisible" as data (they are filtered, not
+  rejected), yet `CurrentLineNumber` still reflects the true physical position in
+  the source.
+- The closed identity is a testable invariant (see `FixedWidthLineAccountingTests`).
+- Adding a new drop reason in future requires deciding which of the four buckets
+  it belongs to — rejected (was-a-candidate) vs filtered (never-a-candidate) — so
+  the identity keeps closing.

--- a/docs/adr/0004-line-endings-via-textwriter-newline.md
+++ b/docs/adr/0004-line-endings-via-textwriter-newline.md
@@ -1,0 +1,37 @@
+# 0004. Line-ending control via TextWriter.NewLine, not a LineEnding enum
+
+- **Status**: accepted
+- **Date**: 2026-07-16
+- **Supersedes**: the `LineEnding` enum proposed in #17
+
+## Context
+
+Consumers asked to control the line ending the loader writes (#17). The proposed
+API was a `LineEnding { Lf, CrLf, ... }` enum on `FixedWidthLoader`. Two problems
+surfaced: (1) .NET has no standard line-ending enum, so we would be inventing one
+that every consumer must learn; and (2) the enum conflated *which* ending with
+*whether a trailing* ending is written, and it would have shadowed the
+`TextWriter.NewLine` mechanism the BCL already provides.
+
+## Decision
+
+We do not add a `LineEnding` enum. The loader honours the `TextWriter.NewLine`
+of the writer it is given, which is the idiomatic BCL mechanism:
+
+```csharp
+await using var writer = new StreamWriter(stream) { NewLine = "\n" }; // force LF
+using var loader = new FixedWidthLoader<PersonRecord>(writer);
+```
+
+The extractor already reads `\n`, `\r`, and `\r\n` transparently via
+`TextReader.ReadLine()`, so no reader-side option is needed. This is documented in
+the README and DocFX getting-started (#222).
+
+## Consequences
+
+- No new public surface to version or explain; consumers use a mechanism they
+  already know.
+- Output line endings are controlled at writer-construction time rather than via
+  a loader property.
+- #17 is closed as addressed-by-documentation rather than implemented; PR #219
+  (the enum implementation) was dropped.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,11 @@
+# Architecture Decision Records
+
+Short records of non-obvious design choices — see [ADR-0001](0001-record-architecture-decisions.md)
+for why we keep them and [TEMPLATE.md](TEMPLATE.md) for the shape.
+
+| ADR | Decision |
+| --- | --- |
+| [0001](0001-record-architecture-decisions.md) | Record architecture decisions |
+| [0002](0002-numberstyles-per-type-default.md) | Per-type default `NumberStyles` for field parsing |
+| [0003](0003-line-accounting-counters.md) | Four-way line accounting: items / skipped / rejected / filtered |
+| [0004](0004-line-endings-via-textwriter-newline.md) | Line-ending control via `TextWriter.NewLine`, not a `LineEnding` enum |

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -1,0 +1,18 @@
+# NNNN. Short title of the decision
+
+- **Status**: proposed | accepted | superseded by [ADR-XXXX](XXXX-....md)
+- **Date**: YYYY-MM-DD
+
+## Context
+
+What is the problem or force that made this decision necessary? What constraints
+(SemVer, target frameworks, analyzer rules, downstream consumers) are in play?
+
+## Decision
+
+The choice that was made, stated in one or two sentences, then the reasoning.
+
+## Consequences
+
+What becomes easier or harder as a result. Include the trade-offs accepted and
+any follow-up work the decision implies.


### PR DESCRIPTION
Closes #157. Stacked on #226 (#155).

The thorough-review pass asks for zero-alloc hot-path verification. Per **its own acceptance criteria**, a library where no public method is intended to be zero-allocation gets a *snapshot doc explaining why* rather than half-implemented `GC.GetAllocatedBytesForCurrentThread()` tests.

## Finding
Nothing here has a zero-alloc contract:
- The extractor allocates a record per line, a string per string field, and **boxes every value-typed field** (the converter returns `object`).
- The loader allocates the formatted segments it writes.

The net8+ span path removes the *intermediate per-field substring* — a real reduction — but the box and the record remain.

## Guard
Allocation regressions are caught at the **benchmark** level: every benchmark class already has `[MemoryDiagnoser]`, publishing the `Allocated` column to the [trend chart](https://chris-wolfgang.github.io/ETL-FixedWidth/dev/bench/). `docs/ALLOCATION-PROFILE.md` documents this.

Docs-only — no build/test surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)