### PR TITLE
docs(security): Release path & compromise scope appendix (#161)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,3 +21,13 @@ We will acknowledge your report within 48 hours and provide an estimated timelin
 
 Your help is greatly appreciated!
 Responsible disclosure of security vulnerabilities helps protect our entire community.
+
+## Release path & compromise scope
+
+Facts a maintainer would need at 2am if the release identity is compromised. Generic incident-response steps (rotating credentials, revoking OAuth apps, publishing advisories, unlisting NuGet packages) are not duplicated here — GitHub's and NuGet's own docs update faster than a checked-in runbook.
+
+- **Release path**: OIDC / NuGet Trusted Publishing via `NuGet/login@v1` in `.github/workflows/release.yaml`. The workflow mints an ephemeral push token per run via OIDC — the release path does not depend on a long-lived API key stored in GitHub secrets or on the NuGet account. During an incident, check the NuGet account for any long-lived API keys anyway (they can be created outside of CI) and delete anything you don't recognize.
+- **Fallback**: none. If Trusted Publishing is compromised, the incident is at the GitHub-account level (the OIDC identity is `Chris-Wolfgang/ETL-FixedWidth`).
+- **Owner**: @Chris-Wolfgang.
+- **Downstream consumers**: no known `Wolfgang.*` fleet dependents (ETL-FixedWidth is a leaf library); unknown external consumers may exist on nuget.org.
+- **Package coordinates for unlisting**: `Wolfgang.Etl.FixedWidth` on nuget.org — <https://www.nuget.org/packages/Wolfgang.Etl.FixedWidth/>.


### PR DESCRIPTION
Closes #161. Stacked on #227.

Appends a **Release path & compromise scope** section to `SECURITY.md` — the per-repo facts a maintainer needs mid-incident, filled in for this repo:
- Release path is OIDC Trusted Publishing (`NuGet/login@v1`), no long-lived API key.
- No fallback; OIDC identity is `Chris-Wolfgang/ETL-FixedWidth`.
- Package coordinates for unlisting: `Wolfgang.Etl.FixedWidth`.

Generic incident-response steps are intentionally **not** duplicated (GitHub/NuGet own those). Canonical shape from Etl-DbClient #240. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)