### PR TITLE
docs: Architecture Decision Records (#160)

### DIFF
--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,29 @@
+# 0001. Record architecture decisions
+
+- **Status**: accepted
+- **Date**: 2026-07-16
+
+## Context
+
+Non-obvious design choices — why the numeric parser defaults to a per-type
+`NumberStyles`, why the extractor splits its counters four ways, why line-ending
+control is a documentation pattern rather than an enum — get lost six months
+after the PR that introduced them. Future maintainers re-derive the same
+trade-offs, often worse, or unknowingly reverse them.
+
+## Decision
+
+We keep Architecture Decision Records (ADRs) — short markdown documents capturing
+the context, decision, and consequences of each non-obvious choice — in
+`docs/adr/`, numbered sequentially, using the [TEMPLATE.md](TEMPLATE.md) shape
+(a trimmed Michael Nygard template). A new ADR lands alongside the PR that makes
+the decision; superseding decisions link back to the ADR they replace rather than
+editing history.
+
+## Consequences
+
+- The reasoning behind a choice survives independently of the PR discussion that
+  produced it.
+- There is a small per-decision authoring cost; it applies only to *non-obvious*
+  choices, not routine changes.
+- Retroactive ADRs (0002–0004) capture decisions that predate this record.

--- a/docs/adr/0002-numberstyles-per-type-default.md
+++ b/docs/adr/0002-numberstyles-per-type-default.md
@@ -1,0 +1,39 @@
+# 0002. Per-type default NumberStyles for field parsing
+
+- **Status**: accepted
+- **Date**: 2026-07-16
+
+## Context
+
+`[FixedWidthField]` gained a `NumberStyles` property (#9) so callers can control
+how numeric fields are parsed. The question was what the *default* should be when
+the caller does not specify one. `NumberStyles.Any` is permissive (accepts
+currency symbols, parentheses-for-negative, exponents, thousands) but silently
+masks malformed data; `NumberStyles.None` is stricter than the BCL's own
+`int.Parse(string)` / `decimal.Parse(string)` and would surprise callers.
+
+An attribute argument cannot be a nullable enum (CS0655), so "unset" cannot be
+represented as `null` on the attribute itself.
+
+## Decision
+
+The default mirrors the BCL's own per-type parse defaults: `NumberStyles.Integer`
+for integral types and `NumberStyles.Number` for `decimal` / `double` / `float`
+(resolved in `FixedWidthConverter.ResolveNumberStyles`). The permissive forms
+(currency, parentheses, exponent) must be opted into explicitly with
+`NumberStyles = NumberStyles.Any`.
+
+"Unset" is encoded as the sentinel `(NumberStyles)(-1)`
+(`FixedWidthFieldAttribute.UnspecifiedNumberStyles`); `FieldDescriptor` maps the
+sentinel to a nullable `NumberStyles?` in the parsing context, and a null there
+selects the per-type default.
+
+## Consequences
+
+- Parsing behaviour matches what a developer expects from `int.Parse` /
+  `decimal.Parse` with no configuration — a plain integer field rejects a decimal
+  point; a decimal field accepts a decimal point and thousands separators.
+- Malformed data is rejected by default rather than coerced, surfacing as a
+  rejected line (see [ADR-0003](0003-line-accounting-counters.md)).
+- The sentinel is an internal implementation detail; the public surface is the
+  ordinary non-nullable `NumberStyles` property.

--- a/docs/adr/0003-line-accounting-counters.md
+++ b/docs/adr/0003-line-accounting-counters.md
@@ -1,0 +1,38 @@
+# 0003. Four-way line accounting: items / skipped / rejected / filtered
+
+- **Status**: accepted
+- **Date**: 2026-07-16
+
+## Context
+
+The extractor drops input lines for several distinct reasons, and consumers need
+to tell them apart: a line intentionally paged over (`SkipItemCount`), a line the
+caller's `RecordValidator` rejected, a structurally malformed line, a blank line,
+and a line removed by a `LineFilter`. Collapsing all of these into a single
+"skipped" count loses the signal a consumer needs to distinguish "the file had
+bad data" from "I asked to skip these".
+
+## Decision
+
+The extractor exposes four counters that partition every physical line:
+
+- `CurrentItemCount` — lines successfully yielded as records.
+- `CurrentSkippedItemCount` — lines skipped by the `SkipItemCount` pagination budget.
+- `CurrentRejectedItemCount` — lines that *looked like* records but failed:
+  malformed layout, or a `RecordValidator` returning `Skip`/`Stop`.
+- `CurrentFilteredLineCount` — lines that were never candidate records: blank
+  lines under `BlankLineHandling.Skip`, `LineFilter` removals, and structural
+  early-stops.
+
+These close exactly:
+`CurrentLineNumber == Items + Skipped + Rejected + Filtered`.
+
+## Consequences
+
+- `LineFilter` removals stay "invisible" as data (they are filtered, not
+  rejected), yet `CurrentLineNumber` still reflects the true physical position in
+  the source.
+- The closed identity is a testable invariant (see `FixedWidthLineAccountingTests`).
+- Adding a new drop reason in future requires deciding which of the four buckets
+  it belongs to — rejected (was-a-candidate) vs filtered (never-a-candidate) — so
+  the identity keeps closing.

--- a/docs/adr/0004-line-endings-via-textwriter-newline.md
+++ b/docs/adr/0004-line-endings-via-textwriter-newline.md
@@ -1,0 +1,37 @@
+# 0004. Line-ending control via TextWriter.NewLine, not a LineEnding enum
+
+- **Status**: accepted
+- **Date**: 2026-07-16
+- **Supersedes**: the `LineEnding` enum proposed in #17
+
+## Context
+
+Consumers asked to control the line ending the loader writes (#17). The proposed
+API was a `LineEnding { Lf, CrLf, ... }` enum on `FixedWidthLoader`. Two problems
+surfaced: (1) .NET has no standard line-ending enum, so we would be inventing one
+that every consumer must learn; and (2) the enum conflated *which* ending with
+*whether a trailing* ending is written, and it would have shadowed the
+`TextWriter.NewLine` mechanism the BCL already provides.
+
+## Decision
+
+We do not add a `LineEnding` enum. The loader honours the `TextWriter.NewLine`
+of the writer it is given, which is the idiomatic BCL mechanism:
+
+```csharp
+await using var writer = new StreamWriter(stream) { NewLine = "\n" }; // force LF
+using var loader = new FixedWidthLoader<PersonRecord>(writer);
+```
+
+The extractor already reads `\n`, `\r`, and `\r\n` transparently via
+`TextReader.ReadLine()`, so no reader-side option is needed. This is documented in
+the README and DocFX getting-started (#222).
+
+## Consequences
+
+- No new public surface to version or explain; consumers use a mechanism they
+  already know.
+- Output line endings are controlled at writer-construction time rather than via
+  a loader property.
+- #17 is closed as addressed-by-documentation rather than implemented; PR #219
+  (the enum implementation) was dropped.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,11 @@
+# Architecture Decision Records
+
+Short records of non-obvious design choices — see [ADR-0001](0001-record-architecture-decisions.md)
+for why we keep them and [TEMPLATE.md](TEMPLATE.md) for the shape.
+
+| ADR | Decision |
+| --- | --- |
+| [0001](0001-record-architecture-decisions.md) | Record architecture decisions |
+| [0002](0002-numberstyles-per-type-default.md) | Per-type default `NumberStyles` for field parsing |
+| [0003](0003-line-accounting-counters.md) | Four-way line accounting: items / skipped / rejected / filtered |
+| [0004](0004-line-endings-via-textwriter-newline.md) | Line-ending control via `TextWriter.NewLine`, not a `LineEnding` enum |

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -1,0 +1,18 @@
+# NNNN. Short title of the decision
+
+- **Status**: proposed | accepted | superseded by [ADR-XXXX](XXXX-....md)
+- **Date**: YYYY-MM-DD
+
+## Context
+
+What is the problem or force that made this decision necessary? What constraints
+(SemVer, target frameworks, analyzer rules, downstream consumers) are in play?
+
+## Decision
+
+The choice that was made, stated in one or two sentences, then the reasoning.
+
+## Consequences
+
+What becomes easier or harder as a result. Include the trade-offs accepted and
+any follow-up work the decision implies.


### PR DESCRIPTION
Closes #160. Stacked on #228.

Establishes `docs/adr/` with a Nygard-style `TEMPLATE.md` and seeds it with the repo's genuinely non-obvious choices — documented retroactively rather than invented:

| ADR | Decision |
| --- | --- |
| 0001 | Record architecture decisions (meta) |
| 0002 | Per-type default `NumberStyles` + `(NumberStyles)(-1)` sentinel (#9) |
| 0003 | Four-way line accounting: items/skipped/rejected/filtered (#18) |
| 0004 | Line-ending control via `TextWriter.NewLine`, not a `LineEnding` enum (#17) |

Each records a real decision made in this repo (traceable to its issue/PR). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)