### PR TITLE
docs: major-version migration-guide convention (#159)

### DIFF
--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -1,0 +1,10 @@
+# Migration guides
+
+Per-major-version upgrade guides live here, named `vX-to-vY.md`, created during
+release prep for any major bump (0.x → 1.0 with breaking changes, or 1.0 → 2.0)
+and linked from the corresponding GitHub Release notes.
+
+No major version has shipped yet — ETL-FixedWidth is in its `0.x` line — so only
+the [template](TEMPLATE-major-version-migration.md) exists. The convention is
+established now so the first major release can use it without inventing structure
+under time pressure.

--- a/docs/migrations/TEMPLATE-major-version-migration.md
+++ b/docs/migrations/TEMPLATE-major-version-migration.md
@@ -1,0 +1,47 @@
+# Migrating from vX to vY
+
+> Copy this template to `vX-to-vY.md` during release prep for a major version
+> bump, fill in each section, and link it from the GitHub Release notes. Delete
+> any section that does not apply (but prefer "None" over deletion so readers know
+> it was considered).
+
+## Summary
+
+One paragraph: who is affected, roughly how much work the upgrade is, and whether
+a compatibility shim exists.
+
+## Breaking-change inventory
+
+| API | Change | Replacement |
+| --- | --- | --- |
+| `OldType.OldMember` | removed / renamed / behaviour change | `NewType.NewMember` |
+
+## Before / after
+
+```csharp
+// Before (vX)
+```
+
+```csharp
+// After (vY)
+```
+
+Repeat per breaking change that needs a code edit.
+
+## Behavioural changes (no signature change)
+
+Changes that compile unchanged but behave differently at runtime (default-value
+changes, nullability flips, parsing-tolerance changes). These are the dangerous
+ones — call each out explicitly.
+
+## Deprecation timeline
+
+- **vX**: member marked `[Obsolete]` (warning).
+- **vY**: member removed.
+
+State when deprecated members were first warned about and when they were removed.
+
+## Verifying the upgrade
+
+How a consumer confirms the migration succeeded (build clean, tests green, ABI
+check via the release `api-compat` gate).


### PR DESCRIPTION
Closes #159. Stacked on #229.

Establishes `docs/migrations/` with a `TEMPLATE-major-version-migration.md` (breaking-change inventory, before/after samples, behavioural-change callouts, deprecation timeline, verification) plus a README.

No major version has shipped (ETL-FixedWidth is 0.x), so this lands the **convention** now — per-version guides (`vX-to-vY.md`) are authored during release prep and linked from the GitHub Release notes. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)