### PR TITLE
ci: PackageValidation ABI gate against last release (#146)

### DIFF
--- a/src/Wolfgang.Etl.FixedWidth/Wolfgang.Etl.FixedWidth.csproj
+++ b/src/Wolfgang.Etl.FixedWidth/Wolfgang.Etl.FixedWidth.csproj
@@ -13,6 +13,16 @@
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>$([System.Text.RegularExpressions.Regex]::Replace("$(Version)", "[-+].*$", "")).0</FileVersion>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    <!-- Package validation (#146): diff each pack against the last published
+         version on NuGet and fail on an ABI break (removed/changed member,
+         nullability flip, dropped TFM) that a non-major bump forbids. This
+         catches behavioural / binary breaks that the PublicAPI.Shipped.txt diff
+         does not. Keep the baseline at the last PUBLISHED version; bump it only
+         after a new release is live on NuGet (otherwise pack fails NU1102).
+         Intentional breaks in a MAJOR bump are recorded via a generated
+         CompatibilitySuppressions.xml. -->
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <PackageValidationBaselineVersion>0.5.0</PackageValidationBaselineVersion>
     <Title>Wolfgang.Etl.FixedWidth</Title>
     <Description>Extractor and Loader implementations for reading and writing fixed-width text files, built on Wolfgang.Etl.Abstractions.</Description>
     <PackageProjectUrl>https://github.com/Chris-Wolfgang/ETL-FixedWidth</PackageProjectUrl>


### PR DESCRIPTION
Closes #146. Stacked on #230.

Enables **Microsoft.NET PackageValidation** on the packable project, baseline pinned to the last published version (`0.5.0`):

```xml
<EnablePackageValidation>true</EnablePackageValidation>
<PackageValidationBaselineVersion>0.5.0</PackageValidationBaselineVersion>
```

Every `dotnet pack` downloads the baseline from NuGet and **fails on an ABI break** — removed/changed member, nullability flip, dropped TFM — that a PATCH/MINOR bump forbids. This closes the gap the `PublicAPI.Shipped.txt` diff leaves (it catches signature adds/removes but not behavioural/binary breaks).

### Why PackageValidation instead of the manual `ApiCompat` step
It's the modern, pack-time incarnation of the same ABI-diff the issue describes — no need to script "download previous .dll + run ApiCompat" in `release.yaml`, and critically it's **locally verifiable** (which the release-only step is not).

### Local gate
- `dotnet pack -c Release` — succeeds; baseline `0.5.0` resolves from NuGet (no NU1102); `0.5.0`-vs-`0.5.0` diffs clean, no false positive.
- Baseline discipline: keep at last *published* version; bump post-publish (per the NU1102 timing rule).

### Follow-up
Intentional breaks in a future MAJOR bump are recorded via a generated `CompatibilitySuppressions.xml` (committed at that time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)