### PR TITLE
ci(security): attest SLSA build provenance for packages (#148)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -678,7 +678,8 @@ jobs:
     if: needs.pack-and-validate.outputs.has-packages == 'true'
     runs-on: windows-latest
     permissions:
-      id-token: write   # required for OIDC token issuance to nuget.org
+      id-token: write       # required for OIDC token issuance to nuget.org (Trusted Publishing) AND for SLSA provenance signing
+      attestations: write   # required to record the SLSA build-provenance attestation on GitHub (#148)
       contents: read
     steps:
       - name: Setup .NET
@@ -698,6 +699,18 @@ jobs:
         with:
           name: nuget-packages
           path: ./packages
+
+      # SLSA build provenance (#148): generate a signed attestation binding each packed
+      # .nupkg (by SHA-256 digest) to the exact repo, commit and workflow run that produced
+      # it. Uses the workflow's OIDC identity — no signing key to manage (same keyless trust
+      # model as NuGet Trusted Publishing below). Attest BEFORE pushing so the provenance
+      # covers the exact bytes we publish; consumers verify with `gh attestation verify`.
+      # Package *signing* (an author signature) is intentionally out of scope — it needs a
+      # code-signing certificate.
+      - name: Attest build provenance for packages
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: './packages/*.nupkg'
 
       - name: NuGet login (OIDC → temporary API key)
         uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,3 +31,13 @@ Facts a maintainer would need at 2am if the release identity is compromised. Gen
 - **Owner**: @Chris-Wolfgang.
 - **Downstream consumers**: no known `Wolfgang.*` fleet dependents (ETL-FixedWidth is a leaf library); unknown external consumers may exist on nuget.org.
 - **Package coordinates for unlisting**: `Wolfgang.Etl.FixedWidth` on nuget.org — <https://www.nuget.org/packages/Wolfgang.Etl.FixedWidth/>.
+
+## Verifying package provenance
+
+Each release attaches a signed [SLSA build-provenance](https://slsa.dev/) attestation binding the published `.nupkg` (by SHA-256 digest) to the exact repository, commit, and workflow run that produced it — generated keylessly via the release workflow's OIDC identity (`actions/attest-build-provenance`). To verify a downloaded package was built from this repo:
+
+```sh
+gh attestation verify Wolfgang.Etl.FixedWidth.<version>.nupkg --owner Chris-Wolfgang
+```
+
+Package *signing* (an author signature via a code-signing certificate) is intentionally out of scope; provenance attestation provides the build-integrity guarantee without a signing key to manage.


### PR DESCRIPTION
Closes #148. Stacked on #232.

Ports the **canonical build-provenance attestation** already proven in [D20-Dice #171](https://github.com/Chris-Wolfgang/D20-Dice) to this repo's `release.yaml`:
- `publish-nuget` job gains `attestations: write`.
- An `actions/attest-build-provenance` step (**SHA-pinned to v4.1.1**, the commit the tag derefs to) signs each packed `.nupkg` by SHA-256 digest via the workflow's **OIDC identity** — keyless, no signing key to manage — **before** the NuGet push, so the provenance covers the exact published bytes.

SBOM (CycloneDX) generation was already present in `release.yaml`. `SECURITY.md` documents consumer verification (`gh attestation verify … --owner Chris-Wolfgang`).

**Scope note:** package *signing* (an author signature) is intentionally excluded — it needs a code-signing certificate. Provenance gives the build-integrity guarantee without one.

### Validation
- `release.yaml` parses as valid YAML; action is SHA-pinned per the annotated-tag rule.
- This is a **port of a working fleet pattern**, not authored-blind. It exercises on the next release (no local equivalent for OIDC attestation upload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)