### PR TITLE
ci: actionlint + zizmor workflow-security gate (#163)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -24,6 +24,10 @@ env:
   CODECOV_MINIMUM: 90
   
 on:
+  # zizmor: ignore[dangerous-triggers] pull_request_target is deliberate here: the
+  # protected-file / secret-scan guard must run trusted workflow code from main, not
+  # from the PR head. The workflow never checks out or executes PR-head code with the
+  # elevated token — it fetches only trusted refs (origin/main) for its guard inputs.
   pull_request_target:  # Runs from the main branch, not from PR branch
     branches:
       - main

--- a/.github/workflows/workflow-security.yaml
+++ b/.github/workflows/workflow-security.yaml
@@ -1,0 +1,62 @@
+name: Workflow Security
+
+# Lints the GitHub Actions workflows themselves (#163):
+#   - actionlint: syntax, shell (shellcheck), and expression errors.
+#   - zizmor:     workflow-level security (template injection, over-broad
+#                 permissions, unpinned third-party actions, dangerous triggers).
+# The zizmor pinning policy and its one documented suppression live in
+# .github/zizmor.yml. Both tools fail the PR on a finding, so a workflow change
+# that introduces one is caught before merge rather than on the server after.
+
+on:
+  pull_request:
+    branches:
+      - main
+      - vNext
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Run actionlint
+        # Download + checksum-verify the pinned binary (same pattern as the
+        # gitleaks step in pr.yaml) rather than a floating third-party action.
+        run: |
+          set -euo pipefail
+          ACTIONLINT_VERSION="1.7.12"
+          ACTIONLINT_SHA256="8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+          TARBALL="actionlint.tar.gz"
+          curl -sSfL -o "$TARBALL" "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          echo "${ACTIONLINT_SHA256}  ${TARBALL}" | sha256sum -c -
+          tar -xzf "$TARBALL" actionlint
+          ./actionlint -color
+
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install zizmor
+        run: pip install zizmor==1.26.1
+
+      - name: Run zizmor
+        # --format=github emits inline PR annotations; a high-severity finding
+        # exits non-zero and fails the job.
+        run: zizmor --format=github --min-severity=high --config .github/zizmor.yml .github/workflows/

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,14 @@
+# zizmor configuration (#163).
+#
+# Pinning policy: first-party GitHub-owned actions (actions/*, github/*) may be
+# pinned to a tag ref; every third-party action must be pinned to a full commit
+# hash. This matches the repo's existing convention — the third-party actions
+# (NuGet/login, benchmark-action/*, peaceiris/*, softprops/*) are already
+# hash-pinned; the first-party actions/* and github/codeql-action/* are tag-pinned.
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        actions/*: ref-pin
+        github/*: ref-pin
+        "*": hash-pin


### PR DESCRIPTION
Closes #163. Stacked on #233.

Adds `workflow-security.yaml` — two linters on every PR + push to main:
- **actionlint** (checksum-pinned binary download, same pattern as the gitleaks step in `pr.yaml`) — workflow syntax, shell (shellcheck), expression errors.
- **zizmor** (pinned `pip install zizmor==1.26.1`) — workflow-level security; fails on any **high**-severity finding, emitting inline PR annotations (`--format=github`).

### Pinning policy + suppression baseline (`.github/zizmor.yml`)
zizmor's default flags all non-hash refs. The repo's real, coherent policy is **first-party (`actions/*`, `github/*`) tag-pinned, third-party hash-pinned** — and the third-party actions already are. The config encodes that. The one accepted suppression is documented inline in `pr.yaml`: the deliberate `pull_request_target` (the guard must run trusted workflow code from `main`, never PR-head code with the elevated token).

### Locally verified ✅
Both tools were run locally against every workflow **including this new one**:
- `actionlint` → exit 0, no findings.
- `zizmor --min-severity=high --config .github/zizmor.yml` → exit 0, *No findings to report*.

So unlike a blind CI addition, this gate is proven green before the server ever runs it — and it caught the real state (43 unpinned-uses → resolved by policy; 1 deliberate dangerous-trigger → documented suppression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)