### PR TITLE
ci: adopt OSSF Scorecard supply-chain scoring (#162)

### DIFF
--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -1,0 +1,52 @@
+name: Scorecard supply-chain security
+
+# OSSF Scorecard (#162): scores the repository's security posture (branch
+# protection, pinned dependencies, dangerous-workflow patterns, token
+# permissions, ...) against ~20 best practices and uploads the result to the
+# code-scanning / Security tab. Distinct from CodeQL — Scorecard grades the repo
+# *configuration*, not the source code. publish_results powers the README badge.
+
+on:
+  # Re-score when branch-protection rules change (a common posture regression).
+  branch_protection_rule:
+  schedule:
+    - cron: '20 7 * * 1'   # weekly, Monday 07:20 UTC
+  push:
+    branches:
+      - main
+
+# Top-level least privilege; the analysis job opts into exactly what it needs.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write   # upload the SARIF result to code-scanning
+      id-token: write          # publish to the OpenSSF API (badge + transparency log)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Publish to the OpenSSF transparency log so the README badge resolves.
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Extractor and Loader for reading and writing fixed width files and text streams
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![.NET](https://img.shields.io/badge/.NET-Multi--Targeted-purple.svg)](https://dotnet.microsoft.com/)
 [![GitHub](https://img.shields.io/badge/GitHub-Repository-181717?logo=github)](https://github.com/Chris-Wolfgang/ETL-FixedWidth)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/Chris-Wolfgang/ETL-FixedWidth/badge)](https://scorecard.dev/viewer/?uri=github.com/Chris-Wolfgang/ETL-FixedWidth)
 
 ---
 


### PR DESCRIPTION
Closes #162. Stacked on #234.

Adds `scorecard.yaml` (OSSF Scorecard) — weekly + on push to `main` + on branch-protection-rule changes:
- `ossf/scorecard-action` **hash-pinned to v2.4.3** via its dereferenced commit `4eaacf0…` (the tag is annotated; pinned to the commit, not the tag object).
- Uploads SARIF to code-scanning and `publish_results: true` feeds the OpenSSF API so the new **README badge** resolves.
- `permissions: read-all` top-level; the job opts into `security-events: write` + `id-token: write` only.

Scores the repo **configuration** (branch protection, pinned deps, dangerous-workflow patterns, token scope) — complementary to CodeQL's source scanning.

### Validation
- The workflow file passes the **actionlint + zizmor gate from #234** locally (both exit 0) — syntax + workflow-security verified.
- Scorecard's actual scoring runs server-side after merge to `main`; the badge populates on first run (no local equivalent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)