### PR TITLE
ci: enforce mutation-score floor as a release gate (#145)

### DIFF
--- a/.github/workflows/stryker.yaml
+++ b/.github/workflows/stryker.yaml
@@ -10,6 +10,14 @@
 # - schedule (weekly Sunday 06:00 UTC): catch quality regressions between
 #   releases without burning CI time on every PR (mutation testing is slow)
 #
+# Quality gate (#145): stryker-config.json sets thresholds.break, so a run whose
+# mutation score falls below the floor exits non-zero and fails this workflow —
+# turning the score into an enforced release-gate quality bar rather than an
+# advisory number. The floor starts at 70% (current score ~74.7%, with headroom
+# for run-to-run variance) and is ratcheted up as surviving mutants are killed.
+# A per-PR gate is intentionally NOT added — full mutation testing is too slow to
+# run on every PR (see the scheduled-run rationale above).
+#
 # Stryker discovers each test project's mutation targets via the standard
 # project-reference graph. Two configuration modes are supported:
 # - Root stryker-config.json (umbrella): if present, runs Stryker once with

--- a/stryker-config.json
+++ b/stryker-config.json
@@ -13,7 +13,7 @@
     "thresholds": {
       "high": 90,
       "low": 75,
-      "break": 0
+      "break": 70
     }
   }
 }


### PR DESCRIPTION
Closes #145. Stacked on #236.

Turns the mutation score into an **enforced quality bar**: `stryker-config.json` `thresholds.break` goes `0 → 70`, so a scheduled Stryker run whose score falls below the floor exits non-zero and **fails the workflow** — rather than the score being an advisory number that never blocks.

### The floor
Current score (from the 2026-07-12 scheduled run) is **74.72%** (454 killed / 136 survived). The floor starts at **70** — below current, with headroom for run-to-run variance — and is documented as ratcheting up as the 136 survivors are killed ("start at current, only ratchet up").

### Scope decision
A **per-PR** `stryker-gate` step is intentionally **not** added. Full mutation testing is minutes-slow; the workflow already runs weekly precisely to avoid burning that on every PR (see its header). Enforcing the floor on the scheduled run is the proportionate "release-gate quality bar" for this repo. Publishing a score-trend chart to gh-pages and filing per-survivor `kind:mutation-survives` issues are noted as follow-ups.

### Validation
- `stryker-config.json` is valid JSON (`break = 70`).
- `stryker.yaml` passes the actionlint + zizmor gate.
- The gate itself exercises on the next scheduled/dispatch run (mutation testing is too slow to run in this loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)