### PR TITLE
ci: build-reproducibility verification (#156)

### DIFF
--- a/.github/workflows/reproducible-build.yaml
+++ b/.github/workflows/reproducible-build.yaml
@@ -1,0 +1,70 @@
+name: Build Reproducibility
+
+# Deterministic-build verification (#156).
+#
+# The library builds with Deterministic + ContinuousIntegrationBuild + SourceLink,
+# which should make the compiled assembly byte-for-byte reproducible regardless of
+# the checkout path. This job proves it: check the same commit out to two different
+# directories, build each with ContinuousIntegrationBuild=true (which normalises
+# source paths to /_/), and fail if the produced assemblies don't hash identically.
+
+on:
+  pull_request:
+    branches:
+      - main
+      - vNext
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: reproducible-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  reproducible:
+    name: Reproducible build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      ASM: src/Wolfgang.Etl.FixedWidth/bin/Release/net10.0/Wolfgang.Etl.FixedWidth.dll
+      PROJ: src/Wolfgang.Etl.FixedWidth/Wolfgang.Etl.FixedWidth.csproj
+    steps:
+      - name: Checkout (copy A)
+        uses: actions/checkout@v7
+        with:
+          path: a
+          persist-credentials: false
+
+      - name: Checkout (copy B)
+        uses: actions/checkout@v7
+        with:
+          path: b
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Build copy A
+        run: dotnet build "a/${{ env.PROJ }}" -c Release -f net10.0 -p:ContinuousIntegrationBuild=true
+
+      - name: Build copy B
+        run: dotnet build "b/${{ env.PROJ }}" -c Release -f net10.0 -p:ContinuousIntegrationBuild=true
+
+      - name: Compare assembly hashes
+        run: |
+          ha=$(sha256sum "a/${ASM}" | cut -d' ' -f1)
+          hb=$(sha256sum "b/${ASM}" | cut -d' ' -f1)
+          echo "A: $ha"
+          echo "B: $hb"
+          if [ "$ha" != "$hb" ]; then
+            echo "::error::Build is not reproducible — assembly hashes differ."
+            exit 1
+          fi
+          echo "✅ Reproducible: $ha"


### PR DESCRIPTION
Closes #156. Stacked on #241.

Ports the canonical **reproducible-build** check from D20-Dice: checks the commit out to two directories (`a/`, `b/`), builds each with `ContinuousIntegrationBuild=true` (normalises source paths to `/_/`), and **fails if the assemblies don't hash identically** — proving the `Deterministic` + CI-build + SourceLink settings actually produce a byte-for-byte reproducible assembly regardless of checkout path.

### Locally verified ✅
- Two Release builds with `ContinuousIntegrationBuild=true` → **byte-identical DLLs** (sha256 match).
- Workflow passes the **actionlint + zizmor gate** (both exit 0). The two-path a/-vs-b/ check runs on the runner (no local equivalent for distinct checkout paths, but path-normalisation is exactly what CI-build provides).

🤖 Generated with [Claude Code](https://claude.com/claude-code)