### PR TITLE
ci: Semgrep SAST beyond CodeQL (#141)

### DIFF
--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -1,0 +1,65 @@
+name: SAST (Semgrep)
+
+# Security-grade static analysis beyond CodeQL (#141).
+#
+# Semgrep runs a different engine and ruleset from CodeQL (pattern/dataflow rules
+# for C#, a general security-audit pack, and a secrets pack), so it surfaces
+# issues CodeQL's queries don't. Findings upload to Code Scanning (Security tab)
+# as an additional signal; report-only for now (`|| true`) so a noisy new ruleset
+# version can't block merges — the current baseline is clean (0 findings), so this
+# can be promoted to a gate later.
+#
+# Uses the public Semgrep registry packs, which need no account/login.
+
+on:
+  pull_request:
+    branches:
+      - main
+      - vNext
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: semgrep-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  semgrep:
+    name: Semgrep
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Semgrep
+        run: pip install semgrep
+
+      - name: Run Semgrep
+        run: |
+          semgrep scan \
+            --config p/csharp \
+            --config p/security-audit \
+            --config p/secrets \
+            --sarif --output semgrep.sarif \
+            --error || true
+
+      - name: Upload Semgrep SARIF
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: semgrep.sarif


### PR DESCRIPTION
Closes #141. Stacked on #242.

Ports the canonical **Semgrep** workflow from D20-Dice: runs the public `p/csharp`, `p/security-audit`, and `p/secrets` registry packs (a different engine + ruleset from CodeQL, so it catches things CodeQL's queries don't) and uploads findings to Code Scanning / the Security tab.

**Report-only** (`|| true`) so a noisy ruleset version can't block merges — the current baseline is clean, so it can be promoted to a gate later.

### Locally verified ✅
- `semgrep scan --config p/csharp --config p/security-audit --config p/secrets` over `src/` → **0 findings** (65 rules, 27 files, exit 0).
- Workflow passes the **actionlint + zizmor gate** (both exit 0). SARIF upload runs server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)