### PR TITLE
chore: bump PackageValidation baseline to 0.5.1 (post-release)

### DIFF
--- a/src/Wolfgang.Etl.FixedWidth/Wolfgang.Etl.FixedWidth.csproj
+++ b/src/Wolfgang.Etl.FixedWidth/Wolfgang.Etl.FixedWidth.csproj
@@ -22,7 +22,7 @@
          Intentional breaks in a MAJOR bump are recorded via a generated
          CompatibilitySuppressions.xml. -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.5.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.5.1</PackageValidationBaselineVersion>
     <Title>Wolfgang.Etl.FixedWidth</Title>
     <Description>Extractor and Loader implementations for reading and writing fixed-width text files, built on Wolfgang.Etl.Abstractions.</Description>
     <PackageProjectUrl>https://github.com/Chris-Wolfgang/ETL-FixedWidth</PackageProjectUrl>


### PR DESCRIPTION
Routine post-release step: advance `PackageValidationBaselineVersion` **0.5.0 → 0.5.1** now that 0.5.1 is live on NuGet, so the next release's ABI gate diffs against 0.5.1.

Timed after publish (per the NU1102 rule — bumping before 0.5.1 was on the CDN would fail pack). Verified locally: `dotnet pack` downloads 0.5.1 and PackageValidation passes clean. Single non-protected csproj change → full CI, no bypass.