### PR TITLE
feat: public schema introspection API — FixedWidthSchema (#22)

### DIFF
--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthFieldInfo.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthFieldInfo.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Globalization;
+using Wolfgang.Etl.FixedWidth.Attributes;
+using Wolfgang.Etl.FixedWidth.Enums;
+using Wolfgang.Etl.FixedWidth.Parsing;
+
+namespace Wolfgang.Etl.FixedWidth;
+
+/// <summary>
+/// Read-only metadata for a single resolved column in a fixed-width record layout —
+/// either a mapped field or a skipped column — exposed by
+/// <see cref="FixedWidthSchema"/> (#22).
+/// </summary>
+/// <remarks>
+/// Positions are zero-based and inclusive: a field at columns 0..7 has
+/// <see cref="StartPosition"/> 0 and <see cref="EndPosition"/> 7. Skipped columns
+/// (<see cref="IsSkip"/> is <see langword="true"/>) have no
+/// <see cref="Name"/>/<see cref="PropertyType"/>/<see cref="Header"/> and expose
+/// their <see cref="SkipMessage"/> instead.
+/// </remarks>
+public sealed class FixedWidthFieldInfo
+{
+    private FixedWidthFieldInfo
+    (
+        bool isSkip,
+        string? name,
+        int columnIndex,
+        int startPosition,
+        int length,
+        Type? propertyType,
+        FieldAlignment alignment,
+        char pad,
+        string? format,
+        string? header,
+        NumberStyles? numberStyles,
+        string? skipMessage
+    )
+    {
+        IsSkip = isSkip;
+        Name = name;
+        ColumnIndex = columnIndex;
+        StartPosition = startPosition;
+        Length = length;
+        PropertyType = propertyType;
+        Alignment = alignment;
+        Pad = pad;
+        Format = format;
+        Header = header;
+        NumberStyles = numberStyles;
+        SkipMessage = skipMessage;
+    }
+
+
+
+    /// <summary>Whether this column is a skipped column rather than a mapped field.</summary>
+    public bool IsSkip { get; }
+
+
+
+    /// <summary>The mapped property name, or <see langword="null"/> for a skipped column.</summary>
+    public string? Name { get; }
+
+
+
+    /// <summary>The absolute zero-based column index within the record, including skipped columns.</summary>
+    public int ColumnIndex { get; }
+
+
+
+    /// <summary>The zero-based, inclusive start position of this column in the line.</summary>
+    public int StartPosition { get; }
+
+
+
+    /// <summary>The zero-based, inclusive end position of this column (<c>StartPosition + Length - 1</c>).</summary>
+    public int EndPosition => StartPosition + Length - 1;
+
+
+
+    /// <summary>The width of this column in characters.</summary>
+    public int Length { get; }
+
+
+
+    /// <summary>The mapped property's type, or <see langword="null"/> for a skipped column.</summary>
+    public Type? PropertyType { get; }
+
+
+
+    /// <summary>The field alignment. Defaults to <see cref="FieldAlignment.Left"/> for a skipped column.</summary>
+    public FieldAlignment Alignment { get; }
+
+
+
+    /// <summary>The pad character. Defaults to space for a skipped column.</summary>
+    public char Pad { get; }
+
+
+
+    /// <summary>The format string applied to this field, or <see langword="null"/> if none / a skipped column.</summary>
+    public string? Format { get; }
+
+
+
+    /// <summary>The header label written for this field, or <see langword="null"/> for a skipped column.</summary>
+    public string? Header { get; }
+
+
+
+    /// <summary>The explicit <see cref="System.Globalization.NumberStyles"/> for numeric parsing, or <see langword="null"/> to use the type's natural style.</summary>
+    public NumberStyles? NumberStyles { get; }
+
+
+
+    /// <summary>The optional message describing a skipped column, or <see langword="null"/> for a mapped field.</summary>
+    public string? SkipMessage { get; }
+
+
+
+    internal static FixedWidthFieldInfo From(FieldMap.ColumnLayout column)
+    {
+        if (column.IsSkip)
+        {
+            var skip = column.Skip!;
+            return new FixedWidthFieldInfo
+            (
+                isSkip: true,
+                name: null,
+                columnIndex: column.ColumnIndex,
+                startPosition: column.Start,
+                length: column.Length,
+                propertyType: null,
+                alignment: FieldAlignment.Left,
+                pad: ' ',
+                format: null,
+                header: null,
+                numberStyles: null,
+                skipMessage: skip.Message
+            );
+        }
+
+        var property = column.Property!;
+        var field = column.Field!;
+        var numberStyles = field.NumberStyles == FixedWidthFieldAttribute.UnspecifiedNumberStyles
+            ? (NumberStyles?)null
+            : field.NumberStyles;
+
+        return new FixedWidthFieldInfo
+        (
+            isSkip: false,
+            name: property.Name,
+            columnIndex: column.ColumnIndex,
+            startPosition: column.Start,
+            length: column.Length,
+            propertyType: property.PropertyType,
+            alignment: field.Alignment,
+            pad: field.Pad,
+            format: field.Format,
+            header: field.Header ?? property.Name,
+            numberStyles: numberStyles,
+            skipMessage: null
+        );
+    }
+}

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthSchema.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthSchema.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Wolfgang.Etl.FixedWidth.Parsing;
+
+namespace Wolfgang.Etl.FixedWidth;
+
+/// <summary>
+/// A read-only view over the resolved fixed-width field layout for a record type
+/// (#22). Exposes the field/skip columns, positions, widths, types, and formatting
+/// that <see cref="FixedWidthExtractor{TRecord}"/> / <see cref="FixedWidthLoader{TRecord}"/>
+/// derive from <c>[FixedWidthField]</c> / <c>[FixedWidthSkip]</c> attributes — useful
+/// for generating documentation, building validation tooling, or debugging a layout.
+/// </summary>
+/// <example>
+/// <code>
+/// var schema = FixedWidthSchema.For&lt;CustomerRecord&gt;();
+/// foreach (var field in schema.Fields)
+/// {
+///     Console.WriteLine($"{field.StartPosition}-{field.EndPosition} {field.Name} ({field.Length})");
+/// }
+/// Console.WriteLine($"Line width: {schema.ExpectedLineWidth}");
+/// </code>
+/// </example>
+public sealed class FixedWidthSchema
+{
+    private FixedWidthSchema
+    (
+        Type recordType,
+        IReadOnlyList<FixedWidthFieldInfo> fields,
+        int expectedLineWidth
+    )
+    {
+        RecordType = recordType;
+        Fields = fields;
+        ExpectedLineWidth = expectedLineWidth;
+    }
+
+
+
+    /// <summary>
+    /// Resolves the schema for record type <typeparamref name="T"/>. Applies the same
+    /// validation as extraction/loading, so an invalid layout (duplicate column
+    /// indexes, a mapped field with no public setter) throws here too.
+    /// </summary>
+    public static FixedWidthSchema For<T>()
+        where T : notnull
+        => For(typeof(T));
+
+
+
+    /// <summary>
+    /// Resolves the schema for <paramref name="recordType"/>.
+    /// </summary>
+    /// <exception cref="ArgumentNullException"><paramref name="recordType"/> is <see langword="null"/>.</exception>
+    public static FixedWidthSchema For(Type recordType)
+    {
+        if (recordType == null)
+        {
+            throw new ArgumentNullException(nameof(recordType));
+        }
+
+        var columns = FieldMap.GetColumnLayout(recordType);
+        var fields = new List<FixedWidthFieldInfo>(columns.Count);
+        var width = 0;
+        foreach (var column in columns)
+        {
+            fields.Add(FixedWidthFieldInfo.From(column));
+            width += column.Length;
+        }
+
+        return new FixedWidthSchema(recordType, fields.AsReadOnly(), width);
+    }
+
+
+
+    /// <summary>The record type this schema describes.</summary>
+    public Type RecordType { get; }
+
+
+
+    /// <summary>
+    /// All resolved columns in position order, including skipped columns
+    /// (<see cref="FixedWidthFieldInfo.IsSkip"/>). Filter on <c>!IsSkip</c> for the
+    /// mapped fields only.
+    /// </summary>
+    public IReadOnlyList<FixedWidthFieldInfo> Fields { get; }
+
+
+
+    /// <summary>The total line width in characters, including skipped columns.</summary>
+    public int ExpectedLineWidth { get; }
+
+
+
+    /// <summary>The total number of columns, including skipped columns.</summary>
+    public int TotalColumnCount => Fields.Count;
+
+
+
+    /// <summary>The number of mapped fields, excluding skipped columns.</summary>
+    public int FieldCount => Fields.Count(f => !f.IsSkip);
+
+
+
+    /// <summary>The number of skipped columns.</summary>
+    public int SkipCount => Fields.Count(f => f.IsSkip);
+}

--- a/src/Wolfgang.Etl.FixedWidth/Parsing/FieldMap.cs
+++ b/src/Wolfgang.Etl.FixedWidth/Parsing/FieldMap.cs
@@ -194,4 +194,84 @@ internal static class FieldMap
             factory: FieldMapResult.CompileFactory(type)
         );
     }
+
+
+
+    // ------------------------------------------------------------------
+    // Layout introspection (public FixedWidthSchema, #22)
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// A single resolved column in position order — either a mapped field or a
+    /// skipped column — with its computed start position and absolute column index.
+    /// Unlike <see cref="FieldMapResult.Descriptors"/> (fields only), this retains
+    /// skipped columns so the layout can be presented in full.
+    /// </summary>
+#pragma warning disable S3898 // value type only used for internal layout iteration — equality is never needed
+    internal readonly struct ColumnLayout
+#pragma warning restore S3898
+    {
+        internal ColumnLayout
+        (
+            int columnIndex,
+            int start,
+            PropertyInfo? property,
+            FixedWidthFieldAttribute? field,
+            FixedWidthSkipAttribute? skip
+        )
+        {
+            ColumnIndex = columnIndex;
+            Start = start;
+            Property = property;
+            Field = field;
+            Skip = skip;
+        }
+
+        internal int ColumnIndex { get; }
+
+        internal int Start { get; }
+
+        internal PropertyInfo? Property { get; }
+
+        internal FixedWidthFieldAttribute? Field { get; }
+
+        internal FixedWidthSkipAttribute? Skip { get; }
+
+        internal bool IsSkip => Skip != null;
+
+        internal int Length => Skip != null ? Skip.Length : Field!.Length;
+    }
+
+
+
+    /// <summary>
+    /// Returns the resolved column layout — every <see cref="FixedWidthFieldAttribute"/>
+    /// and <see cref="FixedWidthSkipAttribute"/> column in <c>Index</c> order, with
+    /// computed start positions. Reuses the same collection, validation, and sort as
+    /// extraction, so it surfaces identical errors (duplicate indexes, a mapped field
+    /// with no public setter).
+    /// </summary>
+    internal static IReadOnlyList<ColumnLayout> GetColumnLayout(Type type)
+    {
+        var entries = CollectEntries(type);
+        if (entries.Count == 0)
+        {
+            return Array.AsReadOnly(Array.Empty<ColumnLayout>());
+        }
+
+        ValidateNoDuplicateIndexes(type, entries);
+        entries.Sort((a, b) => a.Index.CompareTo(b.Index));
+
+        var columns = new List<ColumnLayout>(entries.Count);
+        var position = 0;
+        var columnIndex = 0;
+        foreach (var entry in entries)
+        {
+            columns.Add(new ColumnLayout(columnIndex, position, entry.Property, entry.Field, entry.Skip));
+            position += entry.Length;
+            columnIndex++;
+        }
+
+        return columns.AsReadOnly();
+    }
 }

--- a/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
@@ -1,1 +1,24 @@
 #nullable enable
+Wolfgang.Etl.FixedWidth.FixedWidthFieldInfo
+Wolfgang.Etl.FixedWidth.FixedWidthFieldInfo.Alignment.get -> Wolfgang.Etl.FixedWidth.Enums.FieldAlignment
+Wolfgang.Etl.FixedWidth.FixedWidthFieldInfo.ColumnIndex.get -> int
+Wolfgang.Etl.FixedWidth.FixedWidthFieldInfo.EndPosition.get -> int
+Wolfgang.Etl.FixedWidth.FixedWidthFieldInfo.Format.get -> string?
+Wolfgang.Etl.FixedWidth.FixedWidthFieldInfo.Header.get -> string?
+Wolfgang.Etl.FixedWidth.FixedWidthFieldInfo.IsSkip.get -> bool
+Wolfgang.Etl.FixedWidth.FixedWidthFieldInfo.Length.get -> int
+Wolfgang.Etl.FixedWidth.FixedWidthFieldInfo.Name.get -> string?
+Wolfgang.Etl.FixedWidth.FixedWidthFieldInfo.NumberStyles.get -> System.Globalization.NumberStyles?
+Wolfgang.Etl.FixedWidth.FixedWidthFieldInfo.Pad.get -> char
+Wolfgang.Etl.FixedWidth.FixedWidthFieldInfo.PropertyType.get -> System.Type?
+Wolfgang.Etl.FixedWidth.FixedWidthFieldInfo.SkipMessage.get -> string?
+Wolfgang.Etl.FixedWidth.FixedWidthFieldInfo.StartPosition.get -> int
+Wolfgang.Etl.FixedWidth.FixedWidthSchema
+Wolfgang.Etl.FixedWidth.FixedWidthSchema.ExpectedLineWidth.get -> int
+Wolfgang.Etl.FixedWidth.FixedWidthSchema.FieldCount.get -> int
+Wolfgang.Etl.FixedWidth.FixedWidthSchema.Fields.get -> System.Collections.Generic.IReadOnlyList<Wolfgang.Etl.FixedWidth.FixedWidthFieldInfo>
+Wolfgang.Etl.FixedWidth.FixedWidthSchema.RecordType.get -> System.Type
+Wolfgang.Etl.FixedWidth.FixedWidthSchema.SkipCount.get -> int
+Wolfgang.Etl.FixedWidth.FixedWidthSchema.TotalColumnCount.get -> int
+static Wolfgang.Etl.FixedWidth.FixedWidthSchema.For(System.Type recordType) -> Wolfgang.Etl.FixedWidth.FixedWidthSchema
+static Wolfgang.Etl.FixedWidth.FixedWidthSchema.For<T>() -> Wolfgang.Etl.FixedWidth.FixedWidthSchema

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthSchemaTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthSchemaTests.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using Wolfgang.Etl.FixedWidth.Attributes;
+using Wolfgang.Etl.FixedWidth.Enums;
+using Xunit;
+
+namespace Wolfgang.Etl.FixedWidth.Tests.Unit;
+
+/// <summary>
+/// Covers the public schema-introspection API <see cref="FixedWidthSchema"/> (#22).
+/// </summary>
+public class FixedWidthSchemaTests
+{
+    [ExcludeFromCodeCoverage]
+    private record SkipLayoutRecord
+    {
+        [FixedWidthField(0, 10)]
+        public string FirstName { get; set; } = string.Empty;
+
+        [FixedWidthSkip(1, 8, Message = "DOB")]
+        [FixedWidthField(2, 6)]
+        public string EmployeeNumber { get; set; } = string.Empty;
+    }
+
+
+
+    [ExcludeFromCodeCoverage]
+    private record TypedRecord
+    {
+        [FixedWidthField(0, 8, Alignment = FieldAlignment.Right, Pad = '0')]
+        public int Id { get; set; }
+
+        [FixedWidthField(1, 12, NumberStyles = NumberStyles.Any, Format = "0.00")]
+        public decimal Amount { get; set; }
+
+        [FixedWidthField(2, 8, Format = "yyyyMMdd", Header = "TxnDate")]
+        public DateTime Date { get; set; }
+    }
+
+
+
+    [Fact]
+    public void For_resolves_positions_widths_and_totals()
+    {
+        // PersonRecord: FirstName(0,10) LastName(1,10) Age(2,3 right '0')
+        var schema = FixedWidthSchema.For<PersonRecord>();
+
+        Assert.Equal(typeof(PersonRecord), schema.RecordType);
+        Assert.Equal(23, schema.ExpectedLineWidth);
+        Assert.Equal(3, schema.TotalColumnCount);
+        Assert.Equal(3, schema.FieldCount);
+        Assert.Equal(0, schema.SkipCount);
+
+        var age = schema.Fields[2];
+        Assert.Equal("Age", age.Name);
+        Assert.Equal(20, age.StartPosition);
+        Assert.Equal(22, age.EndPosition);
+        Assert.Equal(3, age.Length);
+        Assert.Equal(typeof(int), age.PropertyType);
+        Assert.Equal(FieldAlignment.Right, age.Alignment);
+        Assert.Equal('0', age.Pad);
+        Assert.False(age.IsSkip);
+    }
+
+
+
+    [Fact]
+    public void Fields_include_skip_columns_in_position_order()
+    {
+        // FirstName(0,10) [skip DOB](1,8) EmployeeNumber(2,6)
+        var schema = FixedWidthSchema.For<SkipLayoutRecord>();
+
+        Assert.Equal(3, schema.TotalColumnCount);
+        Assert.Equal(2, schema.FieldCount);
+        Assert.Equal(1, schema.SkipCount);
+        Assert.Equal(24, schema.ExpectedLineWidth);
+
+        var skip = schema.Fields[1];
+        Assert.True(skip.IsSkip);
+        Assert.Equal(1, skip.ColumnIndex);
+        Assert.Null(skip.Name);
+        Assert.Null(skip.PropertyType);
+        Assert.Equal("DOB", skip.SkipMessage);
+        Assert.Equal(10, skip.StartPosition);
+        Assert.Equal(17, skip.EndPosition);
+        Assert.Equal(8, skip.Length);
+
+        var employeeNumber = schema.Fields[2];
+        Assert.Equal("EmployeeNumber", employeeNumber.Name);
+        Assert.Equal(18, employeeNumber.StartPosition);
+    }
+
+
+
+    [Fact]
+    public void Field_metadata_reflects_format_header_and_numberstyles()
+    {
+        var schema = FixedWidthSchema.For<TypedRecord>();
+
+        var amount = schema.Fields.Single(f => string.Equals(f.Name, "Amount", StringComparison.Ordinal));
+        Assert.Equal("0.00", amount.Format);
+        Assert.Equal(NumberStyles.Any, amount.NumberStyles);
+
+        var date = schema.Fields.Single(f => string.Equals(f.Name, "Date", StringComparison.Ordinal));
+        Assert.Equal("yyyyMMdd", date.Format);
+        Assert.Equal("TxnDate", date.Header);
+
+        var id = schema.Fields.Single(f => string.Equals(f.Name, "Id", StringComparison.Ordinal));
+        // No explicit NumberStyles -> null (uses the type's natural style).
+        Assert.Null(id.NumberStyles);
+        // Header defaults to the property name when not specified.
+        Assert.Equal("Id", id.Header);
+    }
+
+
+
+    [Fact]
+    public void For_Type_overload_matches_generic()
+    {
+        var generic = FixedWidthSchema.For<PersonRecord>();
+        var byType = FixedWidthSchema.For(typeof(PersonRecord));
+
+        Assert.Equal(generic.ExpectedLineWidth, byType.ExpectedLineWidth);
+        Assert.Equal(generic.TotalColumnCount, byType.TotalColumnCount);
+    }
+
+
+
+    [Fact]
+    public void For_null_type_throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => FixedWidthSchema.For(null!));
+    }
+}


### PR DESCRIPTION
Closes #22. First of the #22/#24 pair (0.6.0 MINOR cycle on a fresh vNext).

Exposes the resolved field layout that was previously internal to `FieldMap`:

```csharp
var schema = FixedWidthSchema.For<CustomerRecord>();
foreach (var field in schema.Fields)            // includes skip columns (IsSkip)
    Console.WriteLine($"{field.StartPosition}-{field.EndPosition} {field.Name} ({field.Length})");
schema.ExpectedLineWidth;   // total incl. skips
schema.TotalColumnCount;    // incl. skips
schema.FieldCount;          // mapped fields only
```

## API
- **`FixedWidthSchema`** — `For<T>()` / `For(Type)`, `RecordType`, `Fields`, `ExpectedLineWidth`, `TotalColumnCount`, `FieldCount`, `SkipCount`.
- **`FixedWidthFieldInfo`** — `IsSkip`, `Name`, `ColumnIndex`, `StartPosition`, `EndPosition`, `Length`, `PropertyType`, `Alignment`, `Pad`, `Format`, `Header`, `NumberStyles`, `SkipMessage`.

## Implementation
- New internal `FieldMap.GetColumnLayout` reuses the **same collect / validate / sort** as extraction (so an invalid layout — duplicate index, no public setter — throws identically) but **retains skip columns**, which `FieldMapResult.Descriptors` drops. **No hot path touched.**
- `PublicAPI.Unshipped.txt` updated (hand-maintained per fleet convention).

## Local gate ✅
- Build all TFMs, **0 warnings** (PublicAPI accepted).
- **331 tests pass** on every TFM (net462–net10.0).
- Coverage: `FixedWidthSchema` **100%**, `FixedWidthFieldInfo` **100%**, `FieldMap` 100%.

`#24` (`.ToDiagram()`) stacks on this next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)