### PR TITLE
feat: FixedWidthSchema.ToDiagram() layout diagram (#24)

### DIFF
--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthSchema.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthSchema.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
+using System.Text;
 using Wolfgang.Etl.FixedWidth.Parsing;
 
 namespace Wolfgang.Etl.FixedWidth;
@@ -105,4 +107,97 @@ public sealed class FixedWidthSchema
 
     /// <summary>The number of skipped columns.</summary>
     public int SkipCount => Fields.Count(f => f.IsSkip);
+
+
+
+    /// <summary>
+    /// Renders the resolved layout as a human-readable text table for debugging,
+    /// logging, and documentation (#24). Columns line up on their widest cell; lines
+    /// are separated by <c>\n</c> and carry no trailing whitespace.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// Console.WriteLine(FixedWidthSchema.For&lt;CustomerRecord&gt;().ToDiagram());
+    /// </code>
+    /// </example>
+    public string ToDiagram()
+    {
+        string[] headers = { "Position", "Field", "Type", "Length", "Align", "Pad", "Format" };
+
+        var rows = new List<string[]>(Fields.Count);
+        foreach (var field in Fields)
+        {
+            rows.Add(new[]
+            {
+                $"{field.StartPosition}-{field.EndPosition}",
+                field.IsSkip ? "[skip]" : field.Name!,
+                field.IsSkip ? string.Empty : field.PropertyType!.Name,
+                field.Length.ToString(CultureInfo.InvariantCulture),
+                field.IsSkip ? string.Empty : field.Alignment.ToString(),
+                field.IsSkip ? string.Empty : $"'{field.Pad}'",
+                field.Format ?? string.Empty,
+            });
+        }
+
+        var widths = new int[headers.Length];
+        for (var col = 0; col < headers.Length; col++)
+        {
+            widths[col] = headers[col].Length;
+            foreach (var row in rows)
+            {
+                widths[col] = Math.Max(widths[col], row[col].Length);
+            }
+        }
+
+        var separators = widths.Select(w => new string('-', w)).ToArray();
+
+        var builder = new StringBuilder();
+        AppendRow(builder, headers, widths);
+        AppendRow(builder, separators, widths);
+        foreach (var row in rows)
+        {
+            AppendRow(builder, row, widths);
+        }
+
+        builder.Append('\n');
+        var footer = string.Format
+        (
+            CultureInfo.InvariantCulture,
+            "Total width: {0}  |  Columns: {1} ({2} field{3} + {4} skip{5})  |  Delimiter: none",
+            ExpectedLineWidth,
+            TotalColumnCount,
+            FieldCount,
+            Plural(FieldCount),
+            SkipCount,
+            Plural(SkipCount)
+        );
+        builder.Append(footer);
+
+        return builder.ToString();
+    }
+
+
+
+    private static void AppendRow(StringBuilder builder, string[] cells, int[] widths)
+    {
+        var line = new StringBuilder();
+        for (var col = 0; col < cells.Length; col++)
+        {
+            if (col > 0)
+            {
+                line.Append("  ");
+            }
+
+            line.Append(cells[col].PadRight(widths[col]));
+        }
+
+        // Drop the trailing padding on the last column so lines have no trailing space.
+        var text = line.ToString().TrimEnd();
+        builder.Append(text);
+        builder.Append('\n');
+    }
+
+
+
+    private static string Plural(int count) => count == 1 ? string.Empty : "s";
 }

--- a/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
@@ -19,6 +19,7 @@ Wolfgang.Etl.FixedWidth.FixedWidthSchema.FieldCount.get -> int
 Wolfgang.Etl.FixedWidth.FixedWidthSchema.Fields.get -> System.Collections.Generic.IReadOnlyList<Wolfgang.Etl.FixedWidth.FixedWidthFieldInfo>
 Wolfgang.Etl.FixedWidth.FixedWidthSchema.RecordType.get -> System.Type
 Wolfgang.Etl.FixedWidth.FixedWidthSchema.SkipCount.get -> int
+Wolfgang.Etl.FixedWidth.FixedWidthSchema.ToDiagram() -> string
 Wolfgang.Etl.FixedWidth.FixedWidthSchema.TotalColumnCount.get -> int
 static Wolfgang.Etl.FixedWidth.FixedWidthSchema.For(System.Type recordType) -> Wolfgang.Etl.FixedWidth.FixedWidthSchema
 static Wolfgang.Etl.FixedWidth.FixedWidthSchema.For<T>() -> Wolfgang.Etl.FixedWidth.FixedWidthSchema

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthSchemaTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthSchemaTests.cs
@@ -133,4 +133,33 @@ public class FixedWidthSchemaTests
     {
         Assert.Throws<ArgumentNullException>(() => FixedWidthSchema.For(null!));
     }
+
+
+
+    [Fact]
+    public void ToDiagram_renders_layout_table_with_skips_and_footer()
+    {
+        var diagram = FixedWidthSchema.For<SkipLayoutRecord>().ToDiagram();
+
+        Assert.StartsWith("Position  Field", diagram, StringComparison.Ordinal);
+        Assert.Contains("[skip]", diagram, StringComparison.Ordinal);
+        Assert.Contains("EmployeeNumber", diagram, StringComparison.Ordinal);
+        Assert.Contains("Total width: 24  |  Columns: 3 (2 fields + 1 skip)  |  Delimiter: none", diagram, StringComparison.Ordinal);
+        Assert.DoesNotContain(" \n", diagram, StringComparison.Ordinal);   // no trailing whitespace
+    }
+
+
+
+    [Fact]
+    public void ToDiagram_shows_alignment_pad_and_format_for_fields()
+    {
+        var diagram = FixedWidthSchema.For<TypedRecord>().ToDiagram();
+
+        Assert.Contains("Id", diagram, StringComparison.Ordinal);
+        Assert.Contains("Int32", diagram, StringComparison.Ordinal);
+        Assert.Contains("Right", diagram, StringComparison.Ordinal);
+        Assert.Contains("'0'", diagram, StringComparison.Ordinal);
+        Assert.Contains("yyyyMMdd", diagram, StringComparison.Ordinal);   // Date format
+        Assert.Contains("3 fields + 0 skips", diagram, StringComparison.Ordinal);
+    }
 }


### PR DESCRIPTION
Closes #24. Stacked on #254 (#22).

Adds `FixedWidthSchema.For<T>().ToDiagram()` — a formatter on top of the #22 schema:

```
Position  Field           Type    Length  Align  Pad  Format
--------  --------------  ------  ------  -----  ---  ------
0-9       FirstName       String  10      Left   ' '
10-17     [skip]                  8
18-23     EmployeeNumber  String  6       Left   ' '

Total width: 24  |  Columns: 3 (2 fields + 1 skip)  |  Delimiter: none
```

Columns auto-size to their widest cell; skip columns render as `[skip]` with empty type/align/pad; lines use `\n` with no trailing whitespace.

## Local gate ✅
- Build all TFMs, **0 warnings**.
- **333 tests pass** net462–net10.0.
- `FixedWidthSchema` + `FixedWidthFieldInfo` **100% line + branch**.

Together with #254 this completes the #22/#24 pair — the "schema & diagnostics" feature for **0.6.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)