### PR TITLE
docs: document 0.6.0 API — FixedWidthSchema, ToDiagram, FixedWidthTransformer (#22, #24, #14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,42 @@ await loader.LoadAsync(records, CancellationToken.None);
 
 `NewLine` accepts any string (`"\n"`, `"\r\n"`, or a custom terminator). The default is `Environment.NewLine`.
 
+### Inspecting the layout
+
+`FixedWidthSchema.For<T>()` exposes the resolved field layout as a read-only view — useful for generating documentation, building validation tooling, or debugging a mapping. It applies the same validation as extraction, so an invalid layout (duplicate column index, a mapped field with no public setter) throws here too.
+
+```csharp
+var schema = FixedWidthSchema.For<PersonRecord>();
+
+foreach (var field in schema.Fields)   // includes skip columns (field.IsSkip)
+{
+    Console.WriteLine($"{field.StartPosition}-{field.EndPosition}  {field.Name}  ({field.Length})");
+}
+
+schema.ExpectedLineWidth;   // total line width, including skipped columns
+schema.TotalColumnCount;    // columns including skips
+schema.FieldCount;          // mapped fields only
+schema.SkipCount;           // skipped columns
+```
+
+Each `FixedWidthFieldInfo` carries `Name`, `StartPosition`/`EndPosition`, `Length`, `ColumnIndex`, `PropertyType`, `Alignment`, `Pad`, `Format`, `Header`, and `NumberStyles`. Skipped columns have `IsSkip == true` and expose a `SkipMessage` instead of a name.
+
+`ToDiagram()` renders the layout as a text table — drop it into a log line at startup or paste it into a ticket:
+
+```csharp
+Console.WriteLine(FixedWidthSchema.For<EmployeeRecord>().ToDiagram());
+```
+
+```text
+Position  Field           Type    Length  Align  Pad  Format
+--------  --------------  ------  ------  -----  ---  ------
+0-9       FirstName       String  10      Left   ' '
+10-17     [skip]                  8
+18-23     EmployeeNumber  String  6       Left   ' '
+
+Total width: 24  |  Columns: 3 (2 fields + 1 skip)  |  Delimiter: none
+```
+
 ---
 
 ## ✨ Features
@@ -168,6 +204,7 @@ await loader.LoadAsync(records, CancellationToken.None);
 | **Zero-copy parsing** | `ReadOnlyMemory<char>` slicing avoids string allocations during field extraction |
 | **Span-based numerics** | `Span<char>`-based numeric parsing on net8.0+ for reduced allocation |
 | **Compiled delegates** | Field accessors use compiled delegates instead of reflection for fast property get/set |
+| **Schema introspection** | `FixedWidthSchema.For<T>()` exposes the resolved layout (positions, widths, types, skips); `ToDiagram()` renders it as a text table |
 | **Multi-TFM support** | net462, net481, netstandard2.0, net8.0, net10.0 |
 
 **Examples:**

--- a/README.md
+++ b/README.md
@@ -182,6 +182,33 @@ Position  Field           Type    Length  Align  Pad  Format
 Total width: 24  |  Columns: 3 (2 fields + 1 skip)  |  Delimiter: none
 ```
 
+### Transforming between layouts
+
+To reformat a fixed-width file from one layout to another — reordering, adding/removing, or format-converting fields (a common mainframe-migration task) — `FixedWidthTransformer<TSource, TDestination>` is the projection stage between an extractor and a loader:
+
+```csharp
+using var extractor   = new FixedWidthExtractor<LegacyRecord>(sourceReader);
+using var transformer = new FixedWidthTransformer<LegacyRecord, ModernRecord>(
+    legacy => new ModernRecord
+    {
+        Id   = legacy.OldId,
+        Name = legacy.FullName.Trim(),
+    });
+using var loader      = new FixedWidthLoader<ModernRecord>(destinationWriter);
+
+// Extract → transform → load in a single streaming pass.
+var modern = transformer.TransformAsync(extractor.ExtractAsync(token), token);
+await loader.LoadAsync(modern, token);
+```
+
+The projection delegate handles every reformatting case. When source and destination differ only in layout — the same property names and compatible types — use the auto-mapping factory instead of writing the copy by hand:
+
+```csharp
+using var transformer = FixedWidthTransformer<LegacyRecord, ModernRecord>.ByMatchingProperties();
+```
+
+`ByMatchingProperties()` copies every source property to the destination property of the same name and an assignable type, and requires a public parameterless constructor on the destination.
+
 ---
 
 ## ✨ Features
@@ -205,6 +232,7 @@ Total width: 24  |  Columns: 3 (2 fields + 1 skip)  |  Delimiter: none
 | **Span-based numerics** | `Span<char>`-based numeric parsing on net8.0+ for reduced allocation |
 | **Compiled delegates** | Field accessors use compiled delegates instead of reflection for fast property get/set |
 | **Schema introspection** | `FixedWidthSchema.For<T>()` exposes the resolved layout (positions, widths, types, skips); `ToDiagram()` renders it as a text table |
+| **Format transformation** | `FixedWidthTransformer<TSource, TDestination>` projects one layout to another in a single streaming pass, with optional `ByMatchingProperties()` auto-mapping |
 | **Multi-TFM support** | net462, net481, netstandard2.0, net8.0, net10.0 |
 
 **Examples:**

--- a/docfx_project/docs/getting-started.md
+++ b/docfx_project/docs/getting-started.md
@@ -139,6 +139,22 @@ Console.WriteLine(FixedWidthSchema.For<EmployeeRecord>().ToDiagram());
 // Total width: 24  |  Columns: 3 (2 fields + 1 skip)  |  Delimiter: none
 ```
 
+### Transforming between layouts
+
+`FixedWidthTransformer<TSource, TDestination>` reformats records from one layout to another (reorder, add/remove, or format-convert fields) as the projection stage between an extractor and a loader:
+
+```csharp
+using var extractor   = new FixedWidthExtractor<LegacyRecord>(sourceReader);
+using var transformer = new FixedWidthTransformer<LegacyRecord, ModernRecord>(
+    legacy => new ModernRecord { Id = legacy.OldId, Name = legacy.FullName.Trim() });
+using var loader      = new FixedWidthLoader<ModernRecord>(destinationWriter);
+
+var modern = transformer.TransformAsync(extractor.ExtractAsync(token), token);
+await loader.LoadAsync(modern, token);
+```
+
+When source and destination share property names and compatible types, `FixedWidthTransformer<LegacyRecord, ModernRecord>.ByMatchingProperties()` builds the copy automatically (the destination needs a public parameterless constructor).
+
 ## Next Steps
 
 - Browse the [Examples](examples.md) for more detailed scenarios

--- a/docfx_project/docs/getting-started.md
+++ b/docfx_project/docs/getting-started.md
@@ -109,6 +109,36 @@ await loader.LoadAsync(recordsAsyncEnumerable, CancellationToken.None);
 
 `NewLine` accepts any string; the default is `Environment.NewLine`.
 
+### Inspecting the layout
+
+`FixedWidthSchema.For<T>()` exposes the resolved field layout as a read-only view — handy for generating documentation, building validation tooling, or debugging a mapping. It runs the same validation as extraction, so an invalid layout throws here too.
+
+```csharp
+var schema = FixedWidthSchema.For<PersonRecord>();
+
+foreach (var field in schema.Fields)   // includes skip columns (field.IsSkip)
+{
+    Console.WriteLine($"{field.StartPosition}-{field.EndPosition}  {field.Name}  ({field.Length})");
+}
+
+Console.WriteLine($"Line width: {schema.ExpectedLineWidth}, fields: {schema.FieldCount}, skips: {schema.SkipCount}");
+```
+
+Each `FixedWidthFieldInfo` carries `Name`, `StartPosition`/`EndPosition`, `Length`, `ColumnIndex`, `PropertyType`, `Alignment`, `Pad`, `Format`, `Header`, and `NumberStyles`. Skipped columns have `IsSkip == true` and a `SkipMessage`.
+
+`ToDiagram()` renders the layout as a text table for logs, tickets, or docs:
+
+```csharp
+Console.WriteLine(FixedWidthSchema.For<EmployeeRecord>().ToDiagram());
+// Position  Field           Type    Length  Align  Pad  Format
+// --------  --------------  ------  ------  -----  ---  ------
+// 0-9       FirstName       String  10      Left   ' '
+// 10-17     [skip]                  8
+// 18-23     EmployeeNumber  String  6       Left   ' '
+//
+// Total width: 24  |  Columns: 3 (2 fields + 1 skip)  |  Delimiter: none
+```
+
 ## Next Steps
 
 - Browse the [Examples](examples.md) for more detailed scenarios


### PR DESCRIPTION
Documents all of the 0.6.0 new API (from #254/#255/#257) in the README (packaged into the NuGet) and the docfx getting-started guide:

- **Inspecting the layout** — `FixedWidthSchema.For<T>()`, `FixedWidthFieldInfo`, `ToDiagram()` with sample output (#22, #24).
- **Transforming between layouts** — `FixedWidthTransformer<TSource, TDestination>` extract → transform → load, projection ctor + `ByMatchingProperties()` (#14).
- Two new **Features-table** rows (schema introspection, format transformation).

Docs-only (README + docfx markdown) — no build/test surface. Examples reference only the 0.6.0 API landing via #254/#255/#257.

🤖 Generated with [Claude Code](https://claude.com/claude-code)