### PR TITLE
feat: FixedWidthTransformer for single-pass record projection (#14)

### DIFF
--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthTransformer.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthTransformer.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+
+namespace Wolfgang.Etl.FixedWidth;
+
+/// <summary>
+/// Transforms a stream of <typeparamref name="TSource"/> records into
+/// <typeparamref name="TDestination"/> records in a single streaming pass (#14) —
+/// the middle stage of an extract → transform → load pipeline. Compose it between
+/// a <see cref="FixedWidthExtractor{TRecord}"/> reading one fixed-width layout and
+/// a <see cref="FixedWidthLoader{TRecord}"/> writing another to reformat a file
+/// (reorder, add/remove, or reformat fields).
+/// </summary>
+/// <typeparam name="TSource">The source record type.</typeparam>
+/// <typeparam name="TDestination">The destination record type.</typeparam>
+/// <example>
+/// <code>
+/// using var extractor = new FixedWidthExtractor&lt;LegacyRecord&gt;(sourceReader);
+/// using var transformer = new FixedWidthTransformer&lt;LegacyRecord, ModernRecord&gt;(
+///     legacy =&gt; new ModernRecord { Id = legacy.OldId, Name = legacy.FullName });
+/// using var loader = new FixedWidthLoader&lt;ModernRecord&gt;(destinationWriter);
+///
+/// var modern = transformer.TransformAsync(extractor.ExtractAsync(token), token);
+/// await loader.LoadAsync(modern, token);
+/// </code>
+/// </example>
+public sealed class FixedWidthTransformer<TSource, TDestination> : TransformerBase<TSource, TDestination, FixedWidthReport>
+    where TSource : notnull
+    where TDestination : notnull
+{
+    private readonly Func<TSource, TDestination> _transform;
+
+    private readonly IProgressTimer? _progressTimer;
+
+    private bool _progressTimerWired;
+
+    private static Func<TSource, TDestination>? _propertyMapper;
+
+
+
+    /// <summary>
+    /// Creates a transformer that projects each source record with <paramref name="transform"/>.
+    /// The projection handles every reformatting case — reordered, added, removed, or
+    /// format-converted fields.
+    /// </summary>
+    /// <param name="transform">The per-record projection.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="transform"/> is <see langword="null"/>.</exception>
+    public FixedWidthTransformer(Func<TSource, TDestination> transform)
+    {
+        _transform = transform ?? throw new ArgumentNullException(nameof(transform));
+    }
+
+
+
+    // Test-only constructor that injects a deterministic progress timer.
+    internal FixedWidthTransformer(Func<TSource, TDestination> transform, IProgressTimer timer)
+        : this(transform)
+    {
+        _progressTimer = timer ?? throw new ArgumentNullException(nameof(timer));
+    }
+
+
+
+    /// <summary>
+    /// Creates a transformer that copies every source property to the destination
+    /// property of the same name and an assignable type. <typeparamref name="TDestination"/>
+    /// must have a public parameterless constructor. Use the projection constructor for
+    /// anything beyond a straight same-name copy (reordering, format conversion, combining
+    /// fields).
+    /// </summary>
+#pragma warning disable CA1000 // static factory on a generic type is the natural call site — both type args are required regardless
+    public static FixedWidthTransformer<TSource, TDestination> ByMatchingProperties()
+        => new(_propertyMapper ??= BuildPropertyMapper());
+#pragma warning restore CA1000
+
+
+
+    /// <inheritdoc/>
+    protected override async IAsyncEnumerable<TDestination> TransformWorkerAsync
+    (
+        IAsyncEnumerable<TSource> source,
+        [EnumeratorCancellation] CancellationToken cancellationToken
+    )
+    {
+        if (source == null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (EqualityComparer<TSource>.Default.Equals(item, default!))
+            {
+                throw new InvalidOperationException("Cannot transform a null source record.");
+            }
+
+            if (CurrentSkippedItemCount < SkipItemCount)
+            {
+                IncrementCurrentSkippedItemCount();
+                continue;
+            }
+
+            if (CurrentItemCount >= MaximumItemCount)
+            {
+                break;
+            }
+
+            var result = _transform(item);
+            IncrementCurrentItemCount();
+            yield return result;
+        }
+    }
+
+
+
+    /// <inheritdoc/>
+    protected override FixedWidthReport CreateProgressReport()
+    {
+        return new FixedWidthReport
+        (
+            CurrentItemCount,
+            CurrentSkippedItemCount,
+            currentRejectedItemCount: 0,
+            currentFilteredLineCount: 0,
+            currentLineNumber: CurrentItemCount + CurrentSkippedItemCount
+        );
+    }
+
+
+
+    /// <inheritdoc/>
+    protected override IProgressTimer CreateProgressTimer(IProgress<FixedWidthReport> progress)
+    {
+        if (_progressTimer != null)
+        {
+            if (!_progressTimerWired)
+            {
+                _progressTimerWired = true;
+                _progressTimer.Elapsed += () => progress.Report(CreateProgressReport());
+            }
+
+            return _progressTimer;
+        }
+
+        return base.CreateProgressTimer(progress);
+    }
+
+
+
+    private static Func<TSource, TDestination> BuildPropertyMapper()
+    {
+        var constructor = typeof(TDestination).GetConstructor(Type.EmptyTypes)
+            ?? throw new InvalidOperationException
+            (
+                $"Type '{typeof(TDestination).FullName}' needs a public parameterless constructor " +
+                "for FixedWidthTransformer.ByMatchingProperties()."
+            );
+
+        var destinationProperties = typeof(TDestination).GetProperties()
+            .Where(p => p.SetMethod != null && p.SetMethod.IsPublic)
+            .ToDictionary(p => p.Name, StringComparer.Ordinal);
+
+        var source = Expression.Parameter(typeof(TSource), "source");
+        var destination = Expression.Variable(typeof(TDestination), "destination");
+
+        var body = new List<Expression> { Expression.Assign(destination, Expression.New(constructor)) };
+
+        foreach (var sourceProperty in typeof(TSource).GetProperties()
+                     .Where(p => p.GetMethod != null && p.GetMethod.IsPublic))
+        {
+            if (destinationProperties.TryGetValue(sourceProperty.Name, out var destinationProperty)
+                && destinationProperty.PropertyType.IsAssignableFrom(sourceProperty.PropertyType))
+            {
+                body.Add
+                (
+                    Expression.Assign
+                    (
+                        Expression.Property(destination, destinationProperty),
+                        Expression.Property(source, sourceProperty)
+                    )
+                );
+            }
+        }
+
+        body.Add(destination);
+
+        var block = Expression.Block(new[] { destination }, body);
+        return Expression.Lambda<Func<TSource, TDestination>>(block, source).Compile();
+    }
+}

--- a/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
@@ -21,5 +21,8 @@ Wolfgang.Etl.FixedWidth.FixedWidthSchema.RecordType.get -> System.Type
 Wolfgang.Etl.FixedWidth.FixedWidthSchema.SkipCount.get -> int
 Wolfgang.Etl.FixedWidth.FixedWidthSchema.ToDiagram() -> string
 Wolfgang.Etl.FixedWidth.FixedWidthSchema.TotalColumnCount.get -> int
+Wolfgang.Etl.FixedWidth.FixedWidthTransformer<TSource, TDestination>
+Wolfgang.Etl.FixedWidth.FixedWidthTransformer<TSource, TDestination>.FixedWidthTransformer(System.Func<TSource, TDestination> transform) -> void
 static Wolfgang.Etl.FixedWidth.FixedWidthSchema.For(System.Type recordType) -> Wolfgang.Etl.FixedWidth.FixedWidthSchema
 static Wolfgang.Etl.FixedWidth.FixedWidthSchema.For<T>() -> Wolfgang.Etl.FixedWidth.FixedWidthSchema
+static Wolfgang.Etl.FixedWidth.FixedWidthTransformer<TSource, TDestination>.ByMatchingProperties() -> Wolfgang.Etl.FixedWidth.FixedWidthTransformer<TSource, TDestination>

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthTransformerContractTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthTransformerContractTests.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.TestKit.Xunit;
+
+namespace Wolfgang.Etl.FixedWidth.Tests.Unit;
+
+/// <summary>
+/// Runs the <see cref="TransformerBase{TSource, TDestination, TProgress}"/> contract
+/// suite (TransformAsync, counters, progress reporting, cancellation) against
+/// <see cref="FixedWidthTransformer{TSource, TDestination}"/> using an identity
+/// projection, so source and expected items coincide.
+/// </summary>
+public class FixedWidthTransformerContractTests
+    : TransformerBaseContractTests
+    <
+        FixedWidthTransformer<PersonRecord, PersonRecord>,
+        PersonRecord,
+        FixedWidthReport
+    >
+{
+    /// <inheritdoc/>
+    protected override FixedWidthTransformer<PersonRecord, PersonRecord> CreateSut(int itemCount)
+        => new(record => record);
+
+
+
+    /// <inheritdoc/>
+    protected override IReadOnlyList<PersonRecord> CreateExpectedItems() => new[]
+    {
+        new PersonRecord { FirstName = "Alice", LastName = "Anderson", Age = 25 },
+        new PersonRecord { FirstName = "Bob", LastName = "Brown", Age = 30 },
+        new PersonRecord { FirstName = "Carol", LastName = "Clark", Age = 35 },
+        new PersonRecord { FirstName = "Dan", LastName = "Davis", Age = 40 },
+        new PersonRecord { FirstName = "Eve", LastName = "Evans", Age = 45 },
+    };
+
+
+
+    /// <inheritdoc/>
+    protected override FixedWidthTransformer<PersonRecord, PersonRecord> CreateSutWithTimer(IProgressTimer timer)
+        => new(record => record, timer);
+}

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthTransformerTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthTransformerTests.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Wolfgang.Etl.FixedWidth.Tests.Unit;
+
+/// <summary>
+/// Covers <see cref="FixedWidthTransformer{TSource, TDestination}"/> (#14).
+/// </summary>
+public class FixedWidthTransformerTests
+{
+    [ExcludeFromCodeCoverage]
+    private sealed record Src
+    {
+        public string Name { get; set; } = string.Empty;
+
+        public int Value { get; set; }
+    }
+
+
+
+    [ExcludeFromCodeCoverage]
+    private sealed record Dst
+    {
+        public string Name { get; set; } = string.Empty;
+
+        public int Value { get; set; }
+
+        public string Extra { get; set; } = "unset";
+    }
+
+
+
+    [ExcludeFromCodeCoverage]
+    private sealed class NoParameterlessCtor
+    {
+        public NoParameterlessCtor(string name) => Name = name;
+
+        public string Name { get; }
+    }
+
+
+
+    private static readonly IReadOnlyList<Src> Sources = new[]
+    {
+        new Src { Name = "alice", Value = 1 },
+        new Src { Name = "bob", Value = 2 },
+        new Src { Name = "carol", Value = 3 },
+    };
+
+
+
+    private static async IAsyncEnumerable<T> ToAsync<T>(IEnumerable<T> items)
+    {
+        foreach (var item in items)
+        {
+            yield return item;
+        }
+
+        await Task.CompletedTask;
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_projects_each_record()
+    {
+        using var transformer = new FixedWidthTransformer<Src, Dst>
+        (
+            s => new Dst { Name = s.Name.ToUpperInvariant(), Value = s.Value * 10, Extra = "mapped" }
+        );
+
+        var results = await transformer.TransformAsync(ToAsync(Sources), CancellationToken.None).ToListAsync();
+
+        Assert.Equal(new[] { "ALICE", "BOB", "CAROL" }, results.Select(r => r.Name));
+        Assert.Equal(new[] { 10, 20, 30 }, results.Select(r => r.Value));
+        Assert.All(results, r => Assert.Equal("mapped", r.Extra));
+        Assert.Equal(3, transformer.CurrentItemCount);
+    }
+
+
+
+    [Fact]
+    public async Task ByMatchingProperties_copies_same_named_assignable_properties()
+    {
+        using var transformer = FixedWidthTransformer<Src, Dst>.ByMatchingProperties();
+
+        var result = Assert.Single(await transformer.TransformAsync(ToAsync(Sources.Take(1)), CancellationToken.None).ToListAsync());
+
+        Assert.Equal("alice", result.Name);   // copied
+        Assert.Equal(1, result.Value);         // copied
+        Assert.Equal("unset", result.Extra);   // no source property -> left at default
+    }
+
+
+
+    [Fact]
+    public async Task SkipItemCount_and_MaximumItemCount_are_honored()
+    {
+        using var transformer = new FixedWidthTransformer<Src, Dst>(s => new Dst { Name = s.Name })
+        {
+            SkipItemCount = 1,
+            MaximumItemCount = 1,
+        };
+
+        var results = await transformer.TransformAsync(ToAsync(Sources), CancellationToken.None).ToListAsync();
+
+        // First skipped by the budget, then exactly one emitted.
+        Assert.Equal(new[] { "bob" }, results.Select(r => r.Name));
+        Assert.Equal(1, transformer.CurrentItemCount);
+        Assert.Equal(1, transformer.CurrentSkippedItemCount);
+    }
+
+
+
+    [Fact]
+    public void Constructor_null_transform_throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => new FixedWidthTransformer<Src, Dst>(null!));
+    }
+
+
+
+    [Fact]
+    public async Task Transforming_a_null_source_record_throws()
+    {
+        using var transformer = new FixedWidthTransformer<Src, Dst>(s => new Dst { Name = s.Name });
+
+        async IAsyncEnumerable<Src> WithNull()
+        {
+            yield return new Src { Name = "alice" };
+            yield return null!;
+            await Task.CompletedTask;
+        }
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await transformer.TransformAsync(WithNull(), CancellationToken.None).ToListAsync());
+    }
+
+
+
+    [Fact]
+    public void ByMatchingProperties_without_parameterless_ctor_throws()
+    {
+        // The mapper is compiled eagerly by the factory, so it throws here.
+        Assert.Throws<InvalidOperationException>(FixedWidthTransformer<Src, NoParameterlessCtor>.ByMatchingProperties);
+    }
+}


### PR DESCRIPTION
Closes #14. Independent feature on the 0.6.0 vNext (sibling of the #22/#24 schema work + the docs PR #256).

Adds **`FixedWidthTransformer<TSource, TDestination>` : `TransformerBase`** — the *transform* stage of extract → transform → load, for reformatting a fixed-width file (reorder / add / remove / format-convert fields):

```csharp
using var extractor   = new FixedWidthExtractor<LegacyRecord>(sourceReader);
using var transformer = new FixedWidthTransformer<LegacyRecord, ModernRecord>(
    legacy => new ModernRecord { Id = legacy.OldId, Name = legacy.FullName });
using var loader      = new FixedWidthLoader<ModernRecord>(destinationWriter);

var modern = transformer.TransformAsync(extractor.ExtractAsync(token), token);
await loader.LoadAsync(modern, token);
```

## API
- **projection ctor** `new(Func<TSource, TDestination>)` — handles every reformatting case.
- **`ByMatchingProperties()`** — auto-maps same-named, assignable properties (compiled delegate; needs a public parameterless `TDestination` ctor).
- Honors `SkipItemCount` / `MaximumItemCount`, throws on a null source record, progress via `FixedWidthReport`.

## Design note
The issue sketches a `(sourceReader, destinationWriter)` constructor, but `TransformerBase` operates on `IAsyncEnumerable<TSource> → IAsyncEnumerable<TDestination>` — it's the projection stage; the extractor/loader own the fixed-width I/O. Building it as a projection keeps the three stages cleanly separable (and composable exactly as the issue's pipeline example intends).

## Local gate ✅
- Build all TFMs, **0 warnings**.
- **380 tests pass** net462–net10.0, including the full **`TransformerBase` contract suite** (counters, progress, cancellation) via `FixedWidthTransformerContractTests`.
- `FixedWidthTransformer` **100% line coverage**.

Follow-up: a README/docfx "Transforming" section (I'll fold it into the schema docs pass so all of 0.6.0's new API is documented together).

🤖 Generated with [Claude Code](https://claude.com/claude-code)