### PR TITLE
chore: bump PackageValidation baseline to 0.6.0 (post-release)

### DIFF
--- a/src/Wolfgang.Etl.FixedWidth/Wolfgang.Etl.FixedWidth.csproj
+++ b/src/Wolfgang.Etl.FixedWidth/Wolfgang.Etl.FixedWidth.csproj
@@ -22,7 +22,7 @@
          Intentional breaks in a MAJOR bump are recorded via a generated
          CompatibilitySuppressions.xml. -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.5.1</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.6.0</PackageValidationBaselineVersion>
     <Title>Wolfgang.Etl.FixedWidth</Title>
     <Description>Extractor and Loader implementations for reading and writing fixed-width text files, built on Wolfgang.Etl.Abstractions.</Description>
     <PackageProjectUrl>https://github.com/Chris-Wolfgang/ETL-FixedWidth</PackageProjectUrl>


### PR DESCRIPTION
Routine post-release step: advance `PackageValidationBaselineVersion` **0.5.1 → 0.6.0** now that 0.6.0 is live on NuGet, so the next release's ABI gate diffs against 0.6.0.

Timed after publish (NU1102 rule). Verified locally: `dotnet pack` downloads 0.6.0 and PackageValidation passes clean. Single non-protected csproj change → full CI, no bypass.