### PR TITLE
ci: fail loudly on a zero-outcome leg in the cross-platform differential (#149)

### DIFF
--- a/.github/workflows/cross-platform-differential.yaml
+++ b/.github/workflows/cross-platform-differential.yaml
@@ -91,6 +91,22 @@ jobs:
 
       - name: Compare against linux-x64
         run: |
+          # A zero-outcome leg means its `dotnet test` produced no .trx — the run
+          # step's `|| true` masks a failed/empty test run. Report that as its own
+          # failure, not a misleading "all outcomes diverge" against an empty
+          # reference. This is almost always a transient runner flake: re-run first.
+          empty=0
+          for file in outcomes/outcomes-*/outcomes-*.txt; do
+            label=$(basename "$file" .txt | sed 's/^outcomes-//')
+            if [ ! -s "$file" ]; then
+              echo "::error::Leg '$label' produced no test outcomes — its test run failed to emit a .trx. Re-run the workflow; if it persists, investigate that leg."
+              empty=1
+            fi
+          done
+          if [ "$empty" = "1" ]; then
+            exit 1
+          fi
+
           ref="outcomes/outcomes-linux-x64/outcomes-linux-x64.txt"
           if [ ! -f "$ref" ]; then
             echo "::error::reference outcomes (linux-x64) missing"


### PR DESCRIPTION
Hardens the #149 cross-platform-differential workflow after it false-alarmed on #260.

## What happened
On #260 (a csproj-only PR), the diff job reported "**all** test outcomes diverge from linux-x64." Root cause: the linux-x64 leg's `dotnet test` produced **no .trx** (a transient runner flake), the run step's `|| true` masked it, and normalize-trx wrote an **empty** outcomes file. The diff then compared an empty reference against the other legs' full 380-outcome lists → every test flagged as "divergent." A real per-platform bug would be 1–2 tests, not all of them. A re-run passed.

## Fix
Before diffing, check each leg's outcomes file is non-empty. A zero-outcome leg now **fails with its own clear message** — "Leg 'X' produced no test outcomes … re-run; if it persists, investigate" — instead of a misleading "all outcomes diverge." Distinguishes *a leg failed to run* from *outcomes genuinely differ*.

Verified: `actionlint` + `shellcheck` clean.