### PR TITLE
feat: built-in System.Diagnostics.Metrics instrumentation (#30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   open and dispose it after the run (success or failure); caller-supplied
   streams/readers/writers are left open. Requires `Wolfgang.Etl.Abstractions`
   0.16.0 ([#253]).
+- Built-in `System.Diagnostics.Metrics` instrumentation on the extractor and
+  loader, emitted from the meter **`Wolfgang.Etl.FixedWidth`**: counters
+  `wolfgang.etl.fixedwidth.items.extracted` / `.items.loaded` / `.items.skipped`
+  / `.lines.read` and the histogram `wolfgang.etl.fixedwidth.operation.duration`
+  (ms). Every measurement is tagged `etl.operation` (`extract`/`load`) and
+  `etl.record_type`. Zero-config — subscribe with OpenTelemetry
+  (`AddMeter("Wolfgang.Etl.FixedWidth")`) or a `MeterListener`; a no-op with no
+  listener registered ([#30]).
 
 ### Changed
 
@@ -250,6 +258,7 @@ changes** — the shipped library is unchanged from 0.5.0.
 [#14]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/14
 [#22]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/22
 [#24]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/24
+[#30]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/30
 [#253]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/253
 [Unreleased]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.6.0...HEAD
 [0.6.0]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.5.1...v0.6.0

--- a/ETL Fixed Width.slnx
+++ b/ETL Fixed Width.slnx
@@ -45,6 +45,7 @@
     <Project Path="examples/ErrorHandling/ErrorHandling.csproj" />
     <Project Path="examples/FieldDelimiter/FieldDelimiter.csproj" />
     <Project Path="examples/HeadersAndSeparators/HeadersAndSeparators.csproj" />
+    <Project Path="examples/Metrics/Metrics.csproj" />
     <Project Path="examples/PipelineExtensions/PipelineExtensions.csproj" />
     <Project Path="examples/ProgressReporting/ProgressReporting.csproj" />
     <Project Path="examples/RoundTrip/RoundTrip.csproj" />

--- a/README.md
+++ b/README.md
@@ -243,6 +243,28 @@ Every source and sink has **path**, `Stream`, and `TextReader`/`TextWriter` over
 
 See the [PipelineExtensions](examples/PipelineExtensions) example for a complete, runnable walk-through.
 
+### Metrics and observability
+
+The extractor and loader emit standard [`System.Diagnostics.Metrics`](https://learn.microsoft.com/dotnet/core/diagnostics/metrics) instruments from the meter **`Wolfgang.Etl.FixedWidth`**, so throughput and error rates flow to OpenTelemetry, Prometheus, Grafana, Application Insights, or any `MeterListener` with no code changes. Metrics are a no-op when nothing is listening, so there is no overhead in the default case.
+
+| Instrument | Type | Description |
+|---|---|---|
+| `wolfgang.etl.fixedwidth.items.extracted` | Counter | Items successfully extracted |
+| `wolfgang.etl.fixedwidth.items.loaded` | Counter | Items successfully loaded |
+| `wolfgang.etl.fixedwidth.items.skipped` | Counter | Items skipped via the skip budget |
+| `wolfgang.etl.fixedwidth.lines.read` | Counter | Physical lines read (including blank/skipped) |
+| `wolfgang.etl.fixedwidth.operation.duration` | Histogram (ms) | Duration of an extract/load operation |
+
+Every measurement is tagged `etl.operation` (`extract` or `load`) and `etl.record_type` (`typeof(TRecord).Name`).
+
+```csharp
+// OpenTelemetry — one line, zero library changes:
+builder.Services.AddOpenTelemetry()
+    .WithMetrics(m => m.AddMeter("Wolfgang.Etl.FixedWidth"));
+```
+
+See the [Metrics](examples/Metrics) example for a runnable `MeterListener` walk-through.
+
 ---
 
 ## ✨ Features
@@ -268,11 +290,12 @@ See the [PipelineExtensions](examples/PipelineExtensions) example for a complete
 | **Schema introspection** | `FixedWidthSchema.For<T>()` exposes the resolved layout (positions, widths, types, skips); `ToDiagram()` renders it as a text table |
 | **Format transformation** | `FixedWidthTransformer<TSource, TDestination>` projects one layout to another in a single streaming pass, with optional `ByMatchingProperties()` auto-mapping |
 | **Pipeline composition** | `EtlPipeline.Create().FixedWidthExtractor<T>(…).FixedWidthLoader<T>(…).RunAsync()` — fluent source factories and sink terminators over the generic `EtlPipeline` (requires `Wolfgang.Etl.Abstractions` 0.16.0) |
+| **Metrics** | Zero-config `System.Diagnostics.Metrics` instruments (throughput, skips, duration) from the `Wolfgang.Etl.FixedWidth` meter — OpenTelemetry / Prometheus / any `MeterListener` |
 | **Multi-TFM support** | net462, net481, netstandard2.0, net8.0, net10.0 |
 
 **Examples:**
 
-The [examples/](examples/) folder contains 11 runnable console projects demonstrating each feature:
+The [examples/](examples/) folder contains 12 runnable console projects demonstrating each feature:
 
 | Example | Description |
 |---------|-------------|
@@ -287,6 +310,7 @@ The [examples/](examples/) folder contains 11 runnable console projects demonstr
 | [SkipAndMax](examples/SkipAndMax) | `SkipItemCount` and `MaximumItemCount` for pagination |
 | [HeadersAndSeparators](examples/HeadersAndSeparators) | `WriteHeader`, `HasHeader`, and `FieldSeparator` |
 | [PipelineExtensions](examples/PipelineExtensions) | Compose extract → transform → load as one `EtlPipeline` fluent chain |
+| [Metrics](examples/Metrics) | Subscribe to the `Wolfgang.Etl.FixedWidth` meter and read throughput/duration metrics |
 
 ---
 

--- a/docfx_project/docs/examples.md
+++ b/docfx_project/docs/examples.md
@@ -67,3 +67,9 @@ Shows how to enable header row output and separator lines when loading, includin
 Composes an extract → transform → load flow as a single `EtlPipeline` fluent chain: `EtlPipeline.Create().FixedWidthExtractor<T>(…)` source factories and `FixedWidthLoader<T>(…)` sink terminators, with inline `Through` transform stages and 1:1 fluent configuration. Also shows the resource-ownership contract — path factories own and dispose the files they open, while caller-supplied readers/writers are left open. Requires `Wolfgang.Etl.Abstractions` 0.16.0.
 
 [View source](https://github.com/Chris-Wolfgang/ETL-FixedWidth/tree/main/examples/PipelineExtensions)
+
+## Metrics
+
+Subscribes to the `Wolfgang.Etl.FixedWidth` meter with a `MeterListener` and prints the counters and duration histogram the extractor and loader emit during an extract → load round trip (`items.extracted`, `items.loaded`, `items.skipped`, `lines.read`, `operation.duration`, each tagged with `etl.operation` and `etl.record_type`). In production you would subscribe with `AddMeter("Wolfgang.Etl.FixedWidth")` via OpenTelemetry instead.
+
+[View source](https://github.com/Chris-Wolfgang/ETL-FixedWidth/tree/main/examples/Metrics)

--- a/docfx_project/docs/getting-started.md
+++ b/docfx_project/docs/getting-started.md
@@ -175,6 +175,17 @@ await EtlPipeline
 
 Every source and sink has **path**, `Stream`, and `TextReader`/`TextWriter` overloads (plus an existing-`FixedWidthExtractor<T>` overload). Path factories own the file stream they open and dispose it when the run finishes, on success or failure; caller-supplied streams, readers, and writers are left open. See the [PipelineExtensions example](examples.md#pipelineextensions) for a runnable walk-through.
 
+### Metrics and observability
+
+The extractor and loader emit `System.Diagnostics.Metrics` instruments from the meter `Wolfgang.Etl.FixedWidth` — counters (`items.extracted`, `items.loaded`, `items.skipped`, `lines.read`) and a duration histogram (`operation.duration`), each tagged with `etl.operation` and `etl.record_type`. Subscribe with OpenTelemetry and the telemetry flows to Prometheus, Grafana, Application Insights, and so on, with no changes to your extraction/loading code:
+
+```csharp
+builder.Services.AddOpenTelemetry()
+    .WithMetrics(m => m.AddMeter("Wolfgang.Etl.FixedWidth"));
+```
+
+Metrics are a no-op when nothing is listening. See the [Metrics example](examples.md#metrics) for a raw `MeterListener` walk-through.
+
 ## Next Steps
 
 - Browse the [Examples](examples.md) for more detailed scenarios

--- a/examples/Metrics/Metrics.csproj
+++ b/examples/Metrics/Metrics.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.FixedWidth\Wolfgang.Etl.FixedWidth.csproj" />
+  </ItemGroup>
+
+  <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
+
+
+</Project>

--- a/examples/Metrics/Program.cs
+++ b/examples/Metrics/Program.cs
@@ -1,0 +1,149 @@
+// ---------------------------------------------------------------------------
+// Metrics Example
+// ---------------------------------------------------------------------------
+//
+// This example demonstrates the built-in System.Diagnostics.Metrics
+// instrumentation (issue #30). The extractor and loader emit counters and a
+// duration histogram from the meter "Wolfgang.Etl.FixedWidth" — with no
+// configuration on the library side.
+//
+// In production you would subscribe with OpenTelemetry:
+//
+//     builder.Services.AddOpenTelemetry()
+//         .WithMetrics(m => m.AddMeter("Wolfgang.Etl.FixedWidth"));
+//
+// so the metrics flow to Prometheus, Grafana, Application Insights, etc. Here we
+// use a raw MeterListener so the example has no external dependencies.
+//
+// Key concepts covered:
+//   - Subscribing to the "Wolfgang.Etl.FixedWidth" meter with a MeterListener
+//   - The emitted instruments (items.extracted / items.loaded / items.skipped /
+//     lines.read / operation.duration) and their etl.operation / etl.record_type
+//     tags
+//   - Metrics are a no-op when no listener is registered — zero overhead by default
+// ---------------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.FixedWidth;
+using Wolfgang.Etl.FixedWidth.Attributes;
+using Wolfgang.Etl.FixedWidth.Enums;
+
+// ---------------------------------------------------------------------------
+// Step 1: Subscribe to the library's meter.
+//
+// The MeterListener enables every instrument published by the
+// "Wolfgang.Etl.FixedWidth" meter and accumulates each measurement, keyed by
+// instrument name plus its etl.operation tag so extract and load stay distinct.
+// ---------------------------------------------------------------------------
+
+var totals = new SortedDictionary<string, double>(StringComparer.Ordinal);
+
+using var listener = new MeterListener();
+listener.InstrumentPublished = (instrument, l) =>
+{
+    if (instrument.Meter.Name == "Wolfgang.Etl.FixedWidth")
+    {
+        l.EnableMeasurementEvents(instrument);
+    }
+};
+listener.SetMeasurementEventCallback<long>((instrument, value, tags, _) => Accumulate(instrument.Name, value, tags));
+listener.SetMeasurementEventCallback<double>((instrument, value, tags, _) => Accumulate(instrument.Name, value, tags));
+listener.Start();
+
+// ---------------------------------------------------------------------------
+// Step 2: Run an extract -> load round trip.
+//
+// SkipItemCount = 1 skips the first record so the items.skipped counter is
+// non-zero and you can see it in the output.
+// ---------------------------------------------------------------------------
+
+var input =
+    "Alice     Smith     030\n" +
+    "Bob       Jones     025\n" +
+    "Carol     White     035\n";
+
+var extractor = new FixedWidthExtractor<Person>(new StringReader(input)) { SkipItemCount = 1 };
+
+var people = new List<Person>();
+await foreach (var person in extractor.ExtractAsync(CancellationToken.None))
+{
+    people.Add(person);
+}
+
+var writer = new StringWriter();
+var loader = new FixedWidthLoader<Person>(writer);
+await loader.LoadAsync(ToAsyncEnumerable(people), CancellationToken.None);
+
+// ---------------------------------------------------------------------------
+// Step 3: Report the collected metrics.
+// ---------------------------------------------------------------------------
+
+Console.WriteLine("Metrics from meter 'Wolfgang.Etl.FixedWidth':");
+Console.WriteLine(new string('-', 52));
+foreach (var pair in totals)
+{
+    Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "  {0,-48} {1:0.##}", pair.Key, pair.Value));
+}
+
+// ---------------------------------------------------------------------------
+// Accumulate a measurement into the totals map, tagging the key with the
+// operation (extract/load) so the two ends of the pipeline are distinct.
+// ---------------------------------------------------------------------------
+
+void Accumulate(string instrument, double value, ReadOnlySpan<KeyValuePair<string, object?>> tags)
+{
+    var operation = string.Empty;
+    foreach (var tag in tags)
+    {
+        if (string.Equals(tag.Key, "etl.operation", StringComparison.Ordinal))
+        {
+            operation = tag.Value?.ToString() ?? string.Empty;
+        }
+    }
+
+    var key = $"{instrument} [{operation}]";
+    totals[key] = totals.TryGetValue(key, out var current) ? current + value : value;
+}
+
+// ---------------------------------------------------------------------------
+// Adapts a synchronous list to the IAsyncEnumerable the loader consumes.
+// ---------------------------------------------------------------------------
+
+#pragma warning disable CS1998 // synchronous sequence — no await needed
+static async IAsyncEnumerable<Person> ToAsyncEnumerable(IEnumerable<Person> items)
+{
+    foreach (var item in items)
+    {
+        yield return item;
+    }
+}
+#pragma warning restore CS1998
+
+// ---------------------------------------------------------------------------
+// Person — FirstName(10) + LastName(10) + Age(3), a 23-character line.
+// ---------------------------------------------------------------------------
+
+/// <summary>A person record used to exercise the metrics instruments.</summary>
+public class Person
+{
+    [FixedWidthField(0, 10)]
+    public string FirstName { get; set; } = string.Empty;
+
+
+
+    [FixedWidthField(1, 10)]
+    public string LastName { get; set; } = string.Empty;
+
+
+
+    [FixedWidthField(2, 3, Alignment = FieldAlignment.Right, Pad = '0')]
+    public int Age { get; set; }
+}

--- a/src/Wolfgang.Etl.FixedWidth/Diagnostics/FixedWidthMetrics.cs
+++ b/src/Wolfgang.Etl.FixedWidth/Diagnostics/FixedWidthMetrics.cs
@@ -87,6 +87,52 @@ internal static class FixedWidthMetrics
         };
 
 
+    // The per-line / per-record helpers below are called inside the extract and load hot loops. Each
+    // guards its instrument with Instrument.Enabled so that, when no MeterListener is subscribed (the
+    // default), the JIT skips the Add call and its argument marshalling entirely — the measurement
+    // machinery is only touched once a consumer opts in by subscribing. Instrument.Enabled is a cheap
+    // volatile field read; an unguarded Counter.Add would otherwise run a non-inlined call per item.
+
+    /// <summary>Records one successfully extracted item, if a listener is subscribed.</summary>
+    internal static void RecordExtracted(in TagList tags)
+    {
+        if (ItemsExtracted.Enabled)
+        {
+            ItemsExtracted.Add(1, tags);
+        }
+    }
+
+
+    /// <summary>Records one successfully loaded item, if a listener is subscribed.</summary>
+    internal static void RecordLoaded(in TagList tags)
+    {
+        if (ItemsLoaded.Enabled)
+        {
+            ItemsLoaded.Add(1, tags);
+        }
+    }
+
+
+    /// <summary>Records one skipped item, if a listener is subscribed.</summary>
+    internal static void RecordSkipped(in TagList tags)
+    {
+        if (ItemsSkipped.Enabled)
+        {
+            ItemsSkipped.Add(1, tags);
+        }
+    }
+
+
+    /// <summary>Records one physical line read, if a listener is subscribed.</summary>
+    internal static void RecordLineRead(in TagList tags)
+    {
+        if (LinesRead.Enabled)
+        {
+            LinesRead.Add(1, tags);
+        }
+    }
+
+
     /// <summary>
     /// Begins timing an operation. Dispose the returned scope — the <c>using</c> the extractor and loader
     /// wrap it in records <see cref="OperationDuration"/> when the operation completes, ends early, or
@@ -121,6 +167,11 @@ internal static class FixedWidthMetrics
             }
 
             _disposed = true;
+            if (!OperationDuration.Enabled)
+            {
+                return;
+            }
+
             var elapsedMs = (Stopwatch.GetTimestamp() - _startTimestamp) * 1000.0 / Stopwatch.Frequency;
             OperationDuration.Record(elapsedMs, _tags);
         }

--- a/src/Wolfgang.Etl.FixedWidth/Diagnostics/FixedWidthMetrics.cs
+++ b/src/Wolfgang.Etl.FixedWidth/Diagnostics/FixedWidthMetrics.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace Wolfgang.Etl.FixedWidth.Diagnostics;
+
+/// <summary>
+/// The <see cref="System.Diagnostics.Metrics.Meter"/> and instruments emitted by
+/// <see cref="FixedWidthExtractor{TRecord}"/> and <see cref="FixedWidthLoader{TRecord}"/> (#30).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Subscribe by the meter name <c>Wolfgang.Etl.FixedWidth</c> (see <see cref="MeterName"/>) — for
+/// example with OpenTelemetry's <c>AddMeter("Wolfgang.Etl.FixedWidth")</c> or a raw
+/// <see cref="MeterListener"/>. When no listener is registered every instrument is a no-op, so there is
+/// no measurable overhead in the default case.
+/// </para>
+/// <para>
+/// Every measurement is tagged with <c>etl.operation</c> (<c>extract</c> or <c>load</c>) and
+/// <c>etl.record_type</c> (<c>typeof(TRecord).Name</c>).
+/// </para>
+/// </remarks>
+internal static class FixedWidthMetrics
+{
+    /// <summary>The meter name callers subscribe to.</summary>
+    internal const string MeterName = "Wolfgang.Etl.FixedWidth";
+
+    internal const string OperationTagName = "etl.operation";
+
+    internal const string RecordTypeTagName = "etl.record_type";
+
+    internal const string ExtractOperation = "extract";
+
+    internal const string LoadOperation = "load";
+
+    private static readonly Meter Meter = new(MeterName);
+
+    /// <summary>Total items successfully extracted.</summary>
+    internal static readonly Counter<long> ItemsExtracted = Meter.CreateCounter<long>
+    (
+        "wolfgang.etl.fixedwidth.items.extracted",
+        unit: "{item}",
+        description: "Total items successfully extracted."
+    );
+
+    /// <summary>Total items successfully loaded.</summary>
+    internal static readonly Counter<long> ItemsLoaded = Meter.CreateCounter<long>
+    (
+        "wolfgang.etl.fixedwidth.items.loaded",
+        unit: "{item}",
+        description: "Total items successfully loaded."
+    );
+
+    /// <summary>Total items skipped via the skip budget.</summary>
+    internal static readonly Counter<long> ItemsSkipped = Meter.CreateCounter<long>
+    (
+        "wolfgang.etl.fixedwidth.items.skipped",
+        unit: "{item}",
+        description: "Total items skipped via the skip budget."
+    );
+
+    /// <summary>Total physical lines read, including blank and skipped lines.</summary>
+    internal static readonly Counter<long> LinesRead = Meter.CreateCounter<long>
+    (
+        "wolfgang.etl.fixedwidth.lines.read",
+        unit: "{line}",
+        description: "Total physical lines read, including blank and skipped lines."
+    );
+
+    /// <summary>Duration of an extract or load operation, in milliseconds.</summary>
+    internal static readonly Histogram<double> OperationDuration = Meter.CreateHistogram<double>
+    (
+        "wolfgang.etl.fixedwidth.operation.duration",
+        unit: "ms",
+        description: "Duration of an extract or load operation."
+    );
+
+
+    /// <summary>
+    /// Builds the tag set shared by every measurement of a single operation.
+    /// </summary>
+    internal static TagList CreateTags(string operation, Type recordType)
+        => new()
+        {
+            { OperationTagName, operation },
+            { RecordTypeTagName, recordType.Name },
+        };
+
+
+    /// <summary>
+    /// Begins timing an operation. Dispose the returned scope — the <c>using</c> the extractor and loader
+    /// wrap it in records <see cref="OperationDuration"/> when the operation completes, ends early, or
+    /// throws.
+    /// </summary>
+    internal static DurationScope MeasureDuration(TagList tags) => new(tags);
+
+
+    /// <summary>
+    /// Records <see cref="OperationDuration"/> for the tags it was created with when disposed. Allocated
+    /// once per operation (not per record), so its cost is negligible.
+    /// </summary>
+    internal sealed class DurationScope : IDisposable
+    {
+        private readonly TagList _tags;
+        private readonly long _startTimestamp;
+        private bool _disposed;
+
+
+        internal DurationScope(TagList tags)
+        {
+            _tags = tags;
+            _startTimestamp = Stopwatch.GetTimestamp();
+        }
+
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            var elapsedMs = (Stopwatch.GetTimestamp() - _startTimestamp) * 1000.0 / Stopwatch.Frequency;
+            OperationDuration.Record(elapsedMs, _tags);
+        }
+    }
+}

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
@@ -652,7 +652,7 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
             // Update before any processing so that if an exception is thrown,
             // CurrentLineNumber points to the offending line in the file.
             Interlocked.Increment(ref _currentLineNumber);
-            FixedWidthMetrics.LinesRead.Add(1, metricTags);
+            FixedWidthMetrics.RecordLineRead(metricTags);
 
             if (IsStructuralLine(separatorLineNo))
             {
@@ -676,7 +676,7 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
                 {
                     dataLinesSkipped++;
                     IncrementCurrentSkippedItemCount();
-                    FixedWidthMetrics.ItemsSkipped.Add(1, metricTags);
+                    FixedWidthMetrics.RecordSkipped(metricTags);
                     LogDebugBlankLineInSkipBudget(dataLinesSkipped);
                     continue;
                 }
@@ -691,7 +691,7 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
 
                 LogDebugBlankLineYieldedAsDefault();
                 IncrementCurrentItemCount();
-                FixedWidthMetrics.ItemsExtracted.Add(1, metricTags);
+                FixedWidthMetrics.RecordExtracted(metricTags);
                 yield return defaultRecord;
                 continue;
             }
@@ -715,7 +715,7 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
             {
                 dataLinesSkipped++;
                 IncrementCurrentSkippedItemCount();
-                FixedWidthMetrics.ItemsSkipped.Add(1, metricTags);
+                FixedWidthMetrics.RecordSkipped(metricTags);
                 LogDebugDataLineSkipped(dataLinesSkipped);
                 continue;
             }
@@ -747,7 +747,7 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
 
             LogDebugRecordParsed();
             IncrementCurrentItemCount();
-            FixedWidthMetrics.ItemsExtracted.Add(1, metricTags);
+            FixedWidthMetrics.RecordExtracted(metricTags);
             yield return record;
         }
 

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.FixedWidth.Diagnostics;
 using Wolfgang.Etl.FixedWidth.Enums;
 using Wolfgang.Etl.FixedWidth.Exceptions;
 using Wolfgang.Etl.FixedWidth.Parsing;
@@ -632,6 +633,11 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
             ? HeaderLineCount + 1
             : -1;
 
+        // Metrics (#30): records the operation duration when the enumerator completes, ends early, or
+        // throws; the per-item/line counters below are no-ops unless a MeterListener is subscribed.
+        var metricTags = FixedWidthMetrics.CreateTags(FixedWidthMetrics.ExtractOperation, typeof(TRecord));
+        using var operationScope = FixedWidthMetrics.MeasureDuration(metricTags);
+
         LogExtractionStarted(fieldMap);
 
         token.ThrowIfCancellationRequested();
@@ -646,6 +652,7 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
             // Update before any processing so that if an exception is thrown,
             // CurrentLineNumber points to the offending line in the file.
             Interlocked.Increment(ref _currentLineNumber);
+            FixedWidthMetrics.LinesRead.Add(1, metricTags);
 
             if (IsStructuralLine(separatorLineNo))
             {
@@ -669,6 +676,7 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
                 {
                     dataLinesSkipped++;
                     IncrementCurrentSkippedItemCount();
+                    FixedWidthMetrics.ItemsSkipped.Add(1, metricTags);
                     LogDebugBlankLineInSkipBudget(dataLinesSkipped);
                     continue;
                 }
@@ -683,6 +691,7 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
 
                 LogDebugBlankLineYieldedAsDefault();
                 IncrementCurrentItemCount();
+                FixedWidthMetrics.ItemsExtracted.Add(1, metricTags);
                 yield return defaultRecord;
                 continue;
             }
@@ -706,6 +715,7 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
             {
                 dataLinesSkipped++;
                 IncrementCurrentSkippedItemCount();
+                FixedWidthMetrics.ItemsSkipped.Add(1, metricTags);
                 LogDebugDataLineSkipped(dataLinesSkipped);
                 continue;
             }
@@ -737,6 +747,7 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
 
             LogDebugRecordParsed();
             IncrementCurrentItemCount();
+            FixedWidthMetrics.ItemsExtracted.Add(1, metricTags);
             yield return record;
         }
 

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthLoader.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthLoader.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.FixedWidth.Diagnostics;
 using Wolfgang.Etl.FixedWidth.Parsing;
 
 namespace Wolfgang.Etl.FixedWidth;
@@ -479,6 +480,10 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
         var fieldMap = FieldMap.GetResult<TRecord>();
         LogLoadingStarted(fieldMap);
 
+        // Metrics (#30): duration recorded on completion/throw; counters are no-ops without a listener.
+        var metricTags = FixedWidthMetrics.CreateTags(FixedWidthMetrics.LoadOperation, typeof(TRecord));
+        using var operationScope = FixedWidthMetrics.MeasureDuration(metricTags);
+
         // In dry-run mode, route all formatting through a throwaway writer so the
         // pipeline — including field-width validation — still runs, but nothing
         // reaches the output stream. The real writer is left untouched and so
@@ -502,6 +507,7 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
             if (CurrentSkippedItemCount < SkipItemCount)
             {
                 IncrementCurrentSkippedItemCount();
+                FixedWidthMetrics.ItemsSkipped.Add(1, metricTags);
                 LogDebugItemSkipped();
                 continue;
             }
@@ -523,6 +529,7 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
             Interlocked.Increment(ref _currentLineNumber);
             await target.WriteLineAsync().ConfigureAwait(false);
             IncrementCurrentItemCount();
+            FixedWidthMetrics.ItemsLoaded.Add(1, metricTags);
             LogDebugRecordWritten();
         }
 

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthLoader.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthLoader.cs
@@ -507,7 +507,7 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
             if (CurrentSkippedItemCount < SkipItemCount)
             {
                 IncrementCurrentSkippedItemCount();
-                FixedWidthMetrics.ItemsSkipped.Add(1, metricTags);
+                FixedWidthMetrics.RecordSkipped(metricTags);
                 LogDebugItemSkipped();
                 continue;
             }
@@ -529,7 +529,7 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
             Interlocked.Increment(ref _currentLineNumber);
             await target.WriteLineAsync().ConfigureAwait(false);
             IncrementCurrentItemCount();
-            FixedWidthMetrics.ItemsLoaded.Add(1, metricTags);
+            FixedWidthMetrics.RecordLoaded(metricTags);
             LogDebugRecordWritten();
         }
 

--- a/src/Wolfgang.Etl.FixedWidth/Wolfgang.Etl.FixedWidth.csproj
+++ b/src/Wolfgang.Etl.FixedWidth/Wolfgang.Etl.FixedWidth.csproj
@@ -55,6 +55,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.10" />
     <PackageReference Include="System.Memory" Version="4.6.3" />
     <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.16.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthMetricsTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthMetricsTests.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Metrics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.FixedWidth.Attributes;
+using Wolfgang.Etl.FixedWidth.Diagnostics;
+using Wolfgang.Etl.FixedWidth.Enums;
+using Xunit;
+
+namespace Wolfgang.Etl.FixedWidth.Tests.Unit;
+
+/// <summary>
+/// Verifies the OpenTelemetry-compatible metrics emitted by the extractor and loader (#30). Each test
+/// captures measurements from a <see cref="MeterListener"/> on the <c>Wolfgang.Etl.FixedWidth</c> meter
+/// and filters by the <c>etl.record_type</c> tag of a test-private record type, so measurements from
+/// other (parallel) test classes on the same process-global meter cannot pollute the counts.
+/// </summary>
+public sealed class FixedWidthMetricsTests
+{
+    private const string MeterName = "Wolfgang.Etl.FixedWidth";
+    private const string RecordTypeName = nameof(MetricsSample);
+
+
+    [ExcludeFromCodeCoverage]
+    private sealed record MetricsSample
+    {
+        [FixedWidthField(0, 10)]
+        public string FirstName { get; set; } = string.Empty;
+
+        [FixedWidthField(1, 10)]
+        public string LastName { get; set; } = string.Empty;
+
+        [FixedWidthField(2, 3, Alignment = FieldAlignment.Right, Pad = '0')]
+        public int Age { get; set; }
+    }
+
+
+    [Fact]
+    public async Task Extraction_emits_extracted_lines_and_duration_tagged_as_extract()
+    {
+        using var capture = new MetricCapture();
+
+        var extractor = new FixedWidthExtractor<MetricsSample>
+        (
+            new StringReader(Content(("Alice", "Smith", 30), ("Bob", "Jones", 25), ("Carol", "White", 35)))
+        );
+
+        await DrainAsync(extractor);
+
+        Assert.Equal(3, capture.Sum("wolfgang.etl.fixedwidth.items.extracted"));
+        Assert.Equal(3, capture.Sum("wolfgang.etl.fixedwidth.lines.read"));
+
+        var durations = capture.Measurements("wolfgang.etl.fixedwidth.operation.duration");
+        Assert.Single(durations);
+        Assert.True(durations[0].Value >= 0);
+
+        // Every measurement carries the operation + record-type tags.
+        Assert.All(capture.All, m => Assert.Equal("extract", m.Tags["etl.operation"]));
+        Assert.All(capture.All, m => Assert.Equal(RecordTypeName, m.Tags["etl.record_type"]));
+    }
+
+
+    [Fact]
+    public async Task Skipped_items_emit_items_skipped()
+    {
+        using var capture = new MetricCapture();
+
+        var extractor = new FixedWidthExtractor<MetricsSample>
+        (
+            new StringReader(Content(("Alice", "Smith", 30), ("Bob", "Jones", 25), ("Carol", "White", 35)))
+        )
+        {
+            SkipItemCount = 2,
+        };
+
+        await DrainAsync(extractor);
+
+        Assert.Equal(2, capture.Sum("wolfgang.etl.fixedwidth.items.skipped"));
+        Assert.Equal(1, capture.Sum("wolfgang.etl.fixedwidth.items.extracted"));
+    }
+
+
+    [Fact]
+    public async Task Loading_emits_loaded_and_duration_tagged_as_load()
+    {
+        using var capture = new MetricCapture();
+
+        var writer = new StringWriter();
+        var loader = new FixedWidthLoader<MetricsSample>(writer);
+
+        await loader.LoadAsync(SampleAsync(), CancellationToken.None);
+
+        Assert.Equal(2, capture.Sum("wolfgang.etl.fixedwidth.items.loaded"));
+
+        var durations = capture.Measurements("wolfgang.etl.fixedwidth.operation.duration");
+        Assert.Single(durations);
+        Assert.True(durations[0].Value >= 0);
+
+        Assert.All(capture.All, m => Assert.Equal("load", m.Tags["etl.operation"]));
+        Assert.All(capture.All, m => Assert.Equal(RecordTypeName, m.Tags["etl.record_type"]));
+    }
+
+
+    [Fact]
+    public void Duration_scope_dispose_is_idempotent()
+    {
+        using var capture = new MetricCapture();
+
+        var tags = FixedWidthMetrics.CreateTags(FixedWidthMetrics.ExtractOperation, typeof(MetricsSample));
+        var scope = FixedWidthMetrics.MeasureDuration(tags);
+
+        scope.Dispose();
+        scope.Dispose();   // second dispose is a no-op — the duration is recorded exactly once
+
+        Assert.Single(capture.Measurements("wolfgang.etl.fixedwidth.operation.duration"));
+    }
+
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    private static async Task DrainAsync(FixedWidthExtractor<MetricsSample> extractor)
+    {
+        await foreach (var _ in extractor.ExtractAsync(CancellationToken.None).ConfigureAwait(false))
+        {
+            // Enumerating to completion disposes the extractor's duration scope, recording the histogram.
+        }
+    }
+
+
+#pragma warning disable CS1998 // synchronous sample sequence — no await needed
+    private static async IAsyncEnumerable<MetricsSample> SampleAsync()
+    {
+        yield return new MetricsSample { FirstName = "Alice", LastName = "Smith", Age = 30 };
+        yield return new MetricsSample { FirstName = "Bob", LastName = "Jones", Age = 25 };
+    }
+#pragma warning restore CS1998
+
+
+    private static string Content(params (string First, string Last, int Age)[] people)
+        => string.Concat(people.Select(p => string.Format(CultureInfo.InvariantCulture, "{0,-10}{1,-10}{2:000}\n", p.First, p.Last, p.Age)));
+
+
+    private sealed class CapturedMeasurement
+    {
+        internal CapturedMeasurement(string instrument, double value, IReadOnlyDictionary<string, object?> tags)
+        {
+            Instrument = instrument;
+            Value = value;
+            Tags = tags;
+        }
+
+        internal string Instrument { get; }
+
+        internal double Value { get; }
+
+        internal IReadOnlyDictionary<string, object?> Tags { get; }
+    }
+
+
+    /// <summary>
+    /// A <see cref="MeterListener"/> that records every measurement from the fixed-width meter tagged for
+    /// <see cref="RecordTypeName"/>. Disposing it stops the listener.
+    /// </summary>
+    private sealed class MetricCapture : IDisposable
+    {
+        private readonly MeterListener _listener;
+        private readonly List<CapturedMeasurement> _captured = new();
+
+
+        internal MetricCapture()
+        {
+            _listener = new MeterListener
+            {
+                InstrumentPublished = (instrument, listener) =>
+                {
+                    if (string.Equals(instrument.Meter.Name, MeterName, StringComparison.Ordinal))
+                    {
+                        listener.EnableMeasurementEvents(instrument);
+                    }
+                },
+            };
+
+            _listener.SetMeasurementEventCallback<long>((instrument, value, tags, _) => Record(instrument.Name, value, tags));
+            _listener.SetMeasurementEventCallback<double>((instrument, value, tags, _) => Record(instrument.Name, value, tags));
+            _listener.Start();
+        }
+
+
+        internal IReadOnlyList<CapturedMeasurement> All
+        {
+            get
+            {
+                lock (_captured)
+                {
+                    return _captured.ToList();
+                }
+            }
+        }
+
+
+        internal IReadOnlyList<CapturedMeasurement> Measurements(string instrument)
+            => All.Where(m => string.Equals(m.Instrument, instrument, StringComparison.Ordinal)).ToList();
+
+
+        internal long Sum(string instrument) => (long)Measurements(instrument).Sum(m => m.Value);
+
+
+        private void Record(string instrument, double value, ReadOnlySpan<KeyValuePair<string, object?>> tags)
+        {
+            var map = new Dictionary<string, object?>(StringComparer.Ordinal);
+            foreach (var tag in tags)
+            {
+                map[tag.Key] = tag.Value;
+            }
+
+            // Ignore measurements from other test classes on the same process-global meter.
+            if (map.TryGetValue("etl.record_type", out var recordType)
+                && string.Equals(recordType as string, RecordTypeName, StringComparison.Ordinal))
+            {
+                lock (_captured)
+                {
+                    _captured.Add(new CapturedMeasurement(instrument, value, map));
+                }
+            }
+        }
+
+
+        public void Dispose() => _listener.Dispose();
+    }
+}


### PR DESCRIPTION
Implements #30 — built-in, zero-config `System.Diagnostics.Metrics` instrumentation on the extractor and loader.

## Instruments (meter `Wolfgang.Etl.FixedWidth`)

| Instrument | Type | Description |
|---|---|---|
| `wolfgang.etl.fixedwidth.items.extracted` | Counter | Items successfully extracted |
| `wolfgang.etl.fixedwidth.items.loaded` | Counter | Items successfully loaded |
| `wolfgang.etl.fixedwidth.items.skipped` | Counter | Items skipped via the skip budget |
| `wolfgang.etl.fixedwidth.lines.read` | Counter | Physical lines read (incl. blank/skipped) |
| `wolfgang.etl.fixedwidth.operation.duration` | Histogram (ms) | Duration of an extract/load operation |

Every measurement is tagged `etl.operation` (`extract`/`load`) and `etl.record_type` (`typeof(TRecord).Name`). Subscribe with one line — `AddMeter("Wolfgang.Etl.FixedWidth")` via OpenTelemetry, or a raw `MeterListener`.

```csharp
builder.Services.AddOpenTelemetry()
    .WithMetrics(m => m.AddMeter("Wolfgang.Etl.FixedWidth"));
```

## Design
- **No public API added** — `FixedWidthMetrics` is `internal`; only the meter *name* is the contract (so no `PublicAPI.txt` / PackageValidation changes; pack validates clean against the 0.6.0 baseline).
- **Zero overhead by default** — every instrument is a no-op unless a `MeterListener` is registered.
- **Duration** is timed by a small `DurationScope` disposed by a `using`, so it is recorded whether the operation completes, ends early, or throws — without invasively re-indenting the hot-path methods.
- **Dependency**: `System.Diagnostics.DiagnosticSource` 10.0.10 (in-box on net8.0+; NuGet package on net462/net481/netstandard2.0), matching the fleet convention (ETL-Json pins the same line).
- The issue's `items.errored` counter is **deferred to #29** (dead-letter capture); the other five instruments stand alone.

## Testing
- `FixedWidthMetricsTests` uses a `MeterListener` and a **test-private record type**, filtering measurements by the `etl.record_type` tag so the process-global meter can't be polluted by parallel test classes. Covers extract/load counters, skip counting, duration, tags, and `DurationScope` dispose-idempotency — **100% line coverage** on the new code.
- Full unit suite: **401/401**. Release build clean on all TFMs (incl. net462); net462 test build clean.

## Docs & example
- README "Metrics and observability" section + Features row + instruments table.
- docfx getting-started + examples sections.
- New runnable **`examples/Metrics`** — subscribes with a `MeterListener` and prints the collected counters/durations from a live extract → load round trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
