### PR TITLE
release: 0.7.0 → main (pipeline extensions + metrics)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.7.0] - 2026-07-24
+
+Pipeline composition and observability. Additive — no breaking changes.
+
+### Added
+
+- Fixed-width source factories and sink terminators for the generic `EtlPipeline`
+  fluent chain: `EtlPipeline.Create().FixedWidthExtractor<T>(path | stream | reader | extractor)`
+  and `… .FixedWidthLoader<T>(path | stream | writer)`. The returned
+  `IFixedWidthExtractorBuilder<T>` / `IFixedWidthLoaderBuilder<T>` expose every
+  extractor/loader setting as inline fluent methods (`HeaderLineCount`,
+  `MalformedLineHandling`, `FieldDelimiter`, `Encoding`, `WriteHeader`,
+  `ValueConverter`, `IsDryRun`, …). Path-based factories own the file stream they
+  open and dispose it after the run (success or failure); caller-supplied
+  streams/readers/writers are left open. Requires `Wolfgang.Etl.Abstractions`
+  0.16.0 ([#253]).
+- Built-in `System.Diagnostics.Metrics` instrumentation on the extractor and
+  loader, emitted from the meter **`Wolfgang.Etl.FixedWidth`**: counters
+  `wolfgang.etl.fixedwidth.items.extracted` / `.items.loaded` / `.items.skipped`
+  / `.lines.read` and the histogram `wolfgang.etl.fixedwidth.operation.duration`
+  (ms). Every measurement is tagged `etl.operation` (`extract`/`load`) and
+  `etl.record_type`. Zero-config — subscribe with OpenTelemetry
+  (`AddMeter("Wolfgang.Etl.FixedWidth")`) or a `MeterListener`; a no-op with no
+  listener registered ([#30]).
+
 ## [0.6.0] - 2026-07-18
 
 Layout introspection and format transformation. Additive — no breaking changes.
@@ -239,7 +264,10 @@ changes** — the shipped library is unchanged from 0.5.0.
 [#14]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/14
 [#22]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/22
 [#24]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/24
-[Unreleased]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.6.0...HEAD
+[#30]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/30
+[#253]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/253
+[Unreleased]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.4.0...v0.5.0

--- a/ETL Fixed Width.slnx
+++ b/ETL Fixed Width.slnx
@@ -45,6 +45,8 @@
     <Project Path="examples/ErrorHandling/ErrorHandling.csproj" />
     <Project Path="examples/FieldDelimiter/FieldDelimiter.csproj" />
     <Project Path="examples/HeadersAndSeparators/HeadersAndSeparators.csproj" />
+    <Project Path="examples/Metrics/Metrics.csproj" />
+    <Project Path="examples/PipelineExtensions/PipelineExtensions.csproj" />
     <Project Path="examples/ProgressReporting/ProgressReporting.csproj" />
     <Project Path="examples/RoundTrip/RoundTrip.csproj" />
     <Project Path="examples/SkipAndMax/SkipAndMax.csproj" />

--- a/README.md
+++ b/README.md
@@ -213,6 +213,62 @@ using var transformer = FixedWidthTransformer<LegacyRecord, ModernRecord>.ByMatc
 
 `ByMatchingProperties()` copies every source property to the destination property of the same name and an assignable type, and requires a public parameterless constructor on the destination.
 
+### Composing an ETL pipeline
+
+Rather than wiring an extractor, transformer, and loader together by hand, the whole extract → transform → load flow can be expressed as one fluent chain on the generic `EtlPipeline` (from `Wolfgang.Etl.Abstractions` 0.16.0). `FixedWidthExtractor<T>` source factories hang off `EtlPipeline.Create()` and `FixedWidthLoader<T>` sink terminators hang off the pipeline, with the extractor/loader configuration exposed as inline setters:
+
+```csharp
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.FixedWidth;
+
+// Fixed-width in, human-readable table out — path factories own the files they open.
+await EtlPipeline
+    .Create()
+    .FixedWidthExtractor<PersonRecord>("people.dat")
+    .FixedWidthLoader<PersonRecord>("people.txt")
+    .WriteHeader(true)
+    .FieldSeparator('-')
+    .FieldDelimiter(" | ")
+    .RunAsync();
+```
+
+Insert transform stages with `Through` — an inline `Func<IAsyncEnumerable<T>, IAsyncEnumerable<TOut>>` stage needs no reference to the operators package:
+
+```csharp
+await EtlPipeline
+    .Create()
+    .FixedWidthExtractor<PersonRecord>(sourceReader)
+    .Through(KeepAdults)                 // a stream-to-stream transform delegate
+    .FixedWidthLoader<PersonRecord>(destinationWriter)
+    .RunAsync();
+```
+
+Every source and sink has **path**, `Stream`, and `TextReader`/`TextWriter` overloads (plus an existing-`FixedWidthExtractor<T>` overload). **Path** factories own the file stream they open and dispose it when the run finishes, on success or failure; caller-supplied streams, readers, and writers are always left open. The builder methods (`HeaderLineCount`, `MalformedLineHandling`, `FieldDelimiter`, `Encoding`, `WriteHeader`, `ValueConverter`, `IsDryRun`, …) map 1:1 to the `FixedWidthExtractor<T>` / `FixedWidthLoader<T>` properties.
+
+See the [PipelineExtensions](examples/PipelineExtensions) example for a complete, runnable walk-through.
+
+### Metrics and observability
+
+The extractor and loader emit standard [`System.Diagnostics.Metrics`](https://learn.microsoft.com/dotnet/core/diagnostics/metrics) instruments from the meter **`Wolfgang.Etl.FixedWidth`**, so throughput and error rates flow to OpenTelemetry, Prometheus, Grafana, Application Insights, or any `MeterListener` with no code changes. Metrics are a no-op when nothing is listening, so there is no overhead in the default case.
+
+| Instrument | Type | Description |
+|---|---|---|
+| `wolfgang.etl.fixedwidth.items.extracted` | Counter | Items successfully extracted |
+| `wolfgang.etl.fixedwidth.items.loaded` | Counter | Items successfully loaded |
+| `wolfgang.etl.fixedwidth.items.skipped` | Counter | Items skipped via the skip budget |
+| `wolfgang.etl.fixedwidth.lines.read` | Counter | Physical lines read (including blank/skipped) |
+| `wolfgang.etl.fixedwidth.operation.duration` | Histogram (ms) | Duration of an extract/load operation |
+
+Every measurement is tagged `etl.operation` (`extract` or `load`) and `etl.record_type` (`typeof(TRecord).Name`).
+
+```csharp
+// OpenTelemetry — one line, zero library changes:
+builder.Services.AddOpenTelemetry()
+    .WithMetrics(m => m.AddMeter("Wolfgang.Etl.FixedWidth"));
+```
+
+See the [Metrics](examples/Metrics) example for a runnable `MeterListener` walk-through.
+
 ---
 
 ## ✨ Features
@@ -237,11 +293,13 @@ using var transformer = FixedWidthTransformer<LegacyRecord, ModernRecord>.ByMatc
 | **Compiled delegates** | Field accessors use compiled delegates instead of reflection for fast property get/set |
 | **Schema introspection** | `FixedWidthSchema.For<T>()` exposes the resolved layout (positions, widths, types, skips); `ToDiagram()` renders it as a text table |
 | **Format transformation** | `FixedWidthTransformer<TSource, TDestination>` projects one layout to another in a single streaming pass, with optional `ByMatchingProperties()` auto-mapping |
+| **Pipeline composition** | `EtlPipeline.Create().FixedWidthExtractor<T>(…).FixedWidthLoader<T>(…).RunAsync()` — fluent source factories and sink terminators over the generic `EtlPipeline` (requires `Wolfgang.Etl.Abstractions` 0.16.0) |
+| **Metrics** | Zero-config `System.Diagnostics.Metrics` instruments (throughput, skips, duration) from the `Wolfgang.Etl.FixedWidth` meter — OpenTelemetry / Prometheus / any `MeterListener` |
 | **Multi-TFM support** | net462, net481, netstandard2.0, net8.0, net10.0 |
 
 **Examples:**
 
-The [examples/](examples/) folder contains 10 runnable console projects demonstrating each feature:
+The [examples/](examples/) folder contains 12 runnable console projects demonstrating each feature:
 
 | Example | Description |
 |---------|-------------|
@@ -255,6 +313,8 @@ The [examples/](examples/) folder contains 10 runnable console projects demonstr
 | [FieldDelimiter](examples/FieldDelimiter) | Delimited output (e.g. `" \| "`) for human-readable tables |
 | [SkipAndMax](examples/SkipAndMax) | `SkipItemCount` and `MaximumItemCount` for pagination |
 | [HeadersAndSeparators](examples/HeadersAndSeparators) | `WriteHeader`, `HasHeader`, and `FieldSeparator` |
+| [PipelineExtensions](examples/PipelineExtensions) | Compose extract → transform → load as one `EtlPipeline` fluent chain |
+| [Metrics](examples/Metrics) | Subscribe to the `Wolfgang.Etl.FixedWidth` meter and read throughput/duration metrics |
 
 ---
 

--- a/docfx_project/docs/examples.md
+++ b/docfx_project/docs/examples.md
@@ -61,3 +61,15 @@ Demonstrates `SkipItemCount` and `MaximumItemCount` for pagination — skipping 
 Shows how to enable header row output and separator lines when loading, including custom header text via the `Header` property on `[FixedWidthField]`.
 
 [View source](https://github.com/Chris-Wolfgang/ETL-FixedWidth/tree/main/examples/HeadersAndSeparators)
+
+## PipelineExtensions
+
+Composes an extract → transform → load flow as a single `EtlPipeline` fluent chain: `EtlPipeline.Create().FixedWidthExtractor<T>(…)` source factories and `FixedWidthLoader<T>(…)` sink terminators, with inline `Through` transform stages and 1:1 fluent configuration. Also shows the resource-ownership contract — path factories own and dispose the files they open, while caller-supplied readers/writers are left open. Requires `Wolfgang.Etl.Abstractions` 0.16.0.
+
+[View source](https://github.com/Chris-Wolfgang/ETL-FixedWidth/tree/main/examples/PipelineExtensions)
+
+## Metrics
+
+Subscribes to the `Wolfgang.Etl.FixedWidth` meter with a `MeterListener` and prints the counters and duration histogram the extractor and loader emit during an extract → load round trip (`items.extracted`, `items.loaded`, `items.skipped`, `lines.read`, `operation.duration`, each tagged with `etl.operation` and `etl.record_type`). In production you would subscribe with `AddMeter("Wolfgang.Etl.FixedWidth")` via OpenTelemetry instead.
+
+[View source](https://github.com/Chris-Wolfgang/ETL-FixedWidth/tree/main/examples/Metrics)

--- a/docfx_project/docs/getting-started.md
+++ b/docfx_project/docs/getting-started.md
@@ -155,6 +155,37 @@ await loader.LoadAsync(modern, token);
 
 When source and destination share property names and compatible types, `FixedWidthTransformer<LegacyRecord, ModernRecord>.ByMatchingProperties()` builds the copy automatically (the destination needs a public parameterless constructor).
 
+### Composing an ETL pipeline
+
+The whole extract → transform → load flow can be written as one fluent chain on the generic `EtlPipeline` (from `Wolfgang.Etl.Abstractions` 0.16.0). `FixedWidthExtractor<T>` source factories hang off `EtlPipeline.Create()` and `FixedWidthLoader<T>` sink terminators hang off the pipeline, with the extractor/loader configuration exposed as inline setters:
+
+```csharp
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.FixedWidth;
+
+await EtlPipeline
+    .Create()
+    .FixedWidthExtractor<PersonRecord>("people.dat")
+    .Through(KeepAdults)                 // optional stream-to-stream transform delegate
+    .FixedWidthLoader<PersonRecord>("people.txt")
+    .WriteHeader(true)
+    .FieldDelimiter(" | ")
+    .RunAsync();
+```
+
+Every source and sink has **path**, `Stream`, and `TextReader`/`TextWriter` overloads (plus an existing-`FixedWidthExtractor<T>` overload). Path factories own the file stream they open and dispose it when the run finishes, on success or failure; caller-supplied streams, readers, and writers are left open. See the [PipelineExtensions example](examples.md#pipelineextensions) for a runnable walk-through.
+
+### Metrics and observability
+
+The extractor and loader emit `System.Diagnostics.Metrics` instruments from the meter `Wolfgang.Etl.FixedWidth` — counters (`items.extracted`, `items.loaded`, `items.skipped`, `lines.read`) and a duration histogram (`operation.duration`), each tagged with `etl.operation` and `etl.record_type`. Subscribe with OpenTelemetry and the telemetry flows to Prometheus, Grafana, Application Insights, and so on, with no changes to your extraction/loading code:
+
+```csharp
+builder.Services.AddOpenTelemetry()
+    .WithMetrics(m => m.AddMeter("Wolfgang.Etl.FixedWidth"));
+```
+
+Metrics are a no-op when nothing is listening. See the [Metrics example](examples.md#metrics) for a raw `MeterListener` walk-through.
+
 ## Next Steps
 
 - Browse the [Examples](examples.md) for more detailed scenarios

--- a/examples/Metrics/Metrics.csproj
+++ b/examples/Metrics/Metrics.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.FixedWidth\Wolfgang.Etl.FixedWidth.csproj" />
+  </ItemGroup>
+
+  <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
+
+
+</Project>

--- a/examples/Metrics/Program.cs
+++ b/examples/Metrics/Program.cs
@@ -1,0 +1,149 @@
+// ---------------------------------------------------------------------------
+// Metrics Example
+// ---------------------------------------------------------------------------
+//
+// This example demonstrates the built-in System.Diagnostics.Metrics
+// instrumentation (issue #30). The extractor and loader emit counters and a
+// duration histogram from the meter "Wolfgang.Etl.FixedWidth" — with no
+// configuration on the library side.
+//
+// In production you would subscribe with OpenTelemetry:
+//
+//     builder.Services.AddOpenTelemetry()
+//         .WithMetrics(m => m.AddMeter("Wolfgang.Etl.FixedWidth"));
+//
+// so the metrics flow to Prometheus, Grafana, Application Insights, etc. Here we
+// use a raw MeterListener so the example has no external dependencies.
+//
+// Key concepts covered:
+//   - Subscribing to the "Wolfgang.Etl.FixedWidth" meter with a MeterListener
+//   - The emitted instruments (items.extracted / items.loaded / items.skipped /
+//     lines.read / operation.duration) and their etl.operation / etl.record_type
+//     tags
+//   - Metrics are a no-op when no listener is registered — zero overhead by default
+// ---------------------------------------------------------------------------
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.FixedWidth;
+using Wolfgang.Etl.FixedWidth.Attributes;
+using Wolfgang.Etl.FixedWidth.Enums;
+
+// ---------------------------------------------------------------------------
+// Step 1: Subscribe to the library's meter.
+//
+// The MeterListener enables every instrument published by the
+// "Wolfgang.Etl.FixedWidth" meter and accumulates each measurement, keyed by
+// instrument name plus its etl.operation tag so extract and load stay distinct.
+// ---------------------------------------------------------------------------
+
+var totals = new SortedDictionary<string, double>(StringComparer.Ordinal);
+
+using var listener = new MeterListener();
+listener.InstrumentPublished = (instrument, l) =>
+{
+    if (instrument.Meter.Name == "Wolfgang.Etl.FixedWidth")
+    {
+        l.EnableMeasurementEvents(instrument);
+    }
+};
+listener.SetMeasurementEventCallback<long>((instrument, value, tags, _) => Accumulate(instrument.Name, value, tags));
+listener.SetMeasurementEventCallback<double>((instrument, value, tags, _) => Accumulate(instrument.Name, value, tags));
+listener.Start();
+
+// ---------------------------------------------------------------------------
+// Step 2: Run an extract -> load round trip.
+//
+// SkipItemCount = 1 skips the first record so the items.skipped counter is
+// non-zero and you can see it in the output.
+// ---------------------------------------------------------------------------
+
+var input =
+    "Alice     Smith     030\n" +
+    "Bob       Jones     025\n" +
+    "Carol     White     035\n";
+
+var extractor = new FixedWidthExtractor<Person>(new StringReader(input)) { SkipItemCount = 1 };
+
+var people = new List<Person>();
+await foreach (var person in extractor.ExtractAsync(CancellationToken.None))
+{
+    people.Add(person);
+}
+
+var writer = new StringWriter();
+var loader = new FixedWidthLoader<Person>(writer);
+await loader.LoadAsync(ToAsyncEnumerable(people), CancellationToken.None);
+
+// ---------------------------------------------------------------------------
+// Step 3: Report the collected metrics.
+// ---------------------------------------------------------------------------
+
+Console.WriteLine("Metrics from meter 'Wolfgang.Etl.FixedWidth':");
+Console.WriteLine(new string('-', 52));
+foreach (var pair in totals)
+{
+    Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "  {0,-48} {1:0.##}", pair.Key, pair.Value));
+}
+
+// ---------------------------------------------------------------------------
+// Accumulate a measurement into the totals map, tagging the key with the
+// operation (extract/load) so the two ends of the pipeline are distinct.
+// ---------------------------------------------------------------------------
+
+void Accumulate(string instrument, double value, ReadOnlySpan<KeyValuePair<string, object?>> tags)
+{
+    var operation = string.Empty;
+    foreach (var tag in tags)
+    {
+        if (string.Equals(tag.Key, "etl.operation", StringComparison.Ordinal))
+        {
+            operation = tag.Value?.ToString() ?? string.Empty;
+        }
+    }
+
+    var key = $"{instrument} [{operation}]";
+    totals[key] = totals.TryGetValue(key, out var current) ? current + value : value;
+}
+
+// ---------------------------------------------------------------------------
+// Adapts a synchronous list to the IAsyncEnumerable the loader consumes.
+// ---------------------------------------------------------------------------
+
+#pragma warning disable CS1998 // synchronous sequence — no await needed
+static async IAsyncEnumerable<Person> ToAsyncEnumerable(IEnumerable<Person> items)
+{
+    foreach (var item in items)
+    {
+        yield return item;
+    }
+}
+#pragma warning restore CS1998
+
+// ---------------------------------------------------------------------------
+// Person — FirstName(10) + LastName(10) + Age(3), a 23-character line.
+// ---------------------------------------------------------------------------
+
+/// <summary>A person record used to exercise the metrics instruments.</summary>
+public class Person
+{
+    [FixedWidthField(0, 10)]
+    public string FirstName { get; set; } = string.Empty;
+
+
+
+    [FixedWidthField(1, 10)]
+    public string LastName { get; set; } = string.Empty;
+
+
+
+    [FixedWidthField(2, 3, Alignment = FieldAlignment.Right, Pad = '0')]
+    public int Age { get; set; }
+}

--- a/examples/PipelineExtensions/PipelineExtensions.csproj
+++ b/examples/PipelineExtensions/PipelineExtensions.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.FixedWidth\Wolfgang.Etl.FixedWidth.csproj" />
+  </ItemGroup>
+
+  <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
+
+
+</Project>

--- a/examples/PipelineExtensions/Program.cs
+++ b/examples/PipelineExtensions/Program.cs
@@ -1,0 +1,184 @@
+// ---------------------------------------------------------------------------
+// PipelineExtensions Example
+// ---------------------------------------------------------------------------
+//
+// This example demonstrates the class-named fixed-width source factories and
+// sink terminators that hang off the generic EtlPipeline fluent chain
+// (issue #253, requires Wolfgang.Etl.Abstractions 0.16.0):
+//
+//   EtlPipeline.Create()
+//       .FixedWidthExtractor<T>(path | stream | reader | extractor)
+//       .Through(...)                       // optional transform stages
+//       .FixedWidthLoader<T>(path | stream | writer)
+//       .RunAsync();
+//
+// Instead of wiring an extractor, transformer, and loader together by hand
+// (see the RoundTrip example), the whole extract -> transform -> load flow is
+// expressed as one readable statement, with the extractor/loader configuration
+// exposed as inline fluent setters (HasHeader, FieldDelimiter, WriteHeader, ...).
+//
+// Key concepts covered:
+//   - EtlPipeline.Create() as the entry point
+//   - FixedWidthExtractor<T> source factories and FixedWidthLoader<T> sink
+//     terminators as extension methods on the pipeline
+//   - Inline Through stages (a stream-to-stream transform supplied as a
+//     delegate — no dependency on the Wolfgang.Etl.Transformers operators)
+//   - Fluent configuration that maps 1:1 to the extractor/loader properties
+//   - Resource ownership: path-based factories own and dispose the files they
+//     open; caller-supplied readers/writers are left open
+// ---------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.FixedWidth;
+using Wolfgang.Etl.FixedWidth.Attributes;
+using Wolfgang.Etl.FixedWidth.Enums;
+
+// ===========================================================================
+// Scenario 1: reader -> inline transform -> writer, as a single chain.
+//
+// The extractor reads from a StringReader (stand-in for a file), an inline
+// Through stage keeps only the adults and upper-cases their surnames, and the
+// loader writes to a StringWriter. The caller owns both the reader and the
+// writer, so the pipeline leaves them open.
+// ===========================================================================
+
+var inputReader = new StringReader
+(
+    "Alice     Smith     030\n" +
+    "Bob       Jones     025\n" +
+    "Carol     White     035\n"
+);
+var outputWriter = new StringWriter();
+
+await EtlPipeline
+    .Create()
+    .FixedWidthExtractor<Person>(inputReader)
+    .Through(KeepAdults)
+    .FixedWidthLoader<Person>(outputWriter)
+    .RunAsync();
+
+Console.WriteLine("Scenario 1 — filter (age >= 30) + upper-case surnames:");
+Console.WriteLine(new string('-', 40));
+Console.Write(outputWriter.ToString());
+Console.WriteLine(new string('-', 40));
+Console.WriteLine();
+
+// ===========================================================================
+// Scenario 2: fluent configuration on both ends.
+//
+// Read a headerless, pure fixed-width source and write a human-readable table:
+// a header row, a '-' separator line under it, and " | " between every field.
+// Each setter maps 1:1 to a property on FixedWidthExtractor<T> /
+// FixedWidthLoader<T>; the first pipeline operator materializes the extractor.
+// ===========================================================================
+
+var plainReader = new StringReader
+(
+    "Alice     Smith     030\n" +
+    "Bob       Jones     025\n"
+);
+var tableWriter = new StringWriter();
+
+await EtlPipeline
+    .Create()
+    .FixedWidthExtractor<Person>(plainReader)
+    .FixedWidthLoader<Person>(tableWriter)
+    .WriteHeader(true)
+    .FieldSeparator('-')
+    .FieldDelimiter(" | ")
+    .RunAsync();
+
+Console.WriteLine("Scenario 2 — header + separator + delimited output:");
+Console.WriteLine(new string('-', 40));
+Console.Write(tableWriter.ToString());
+Console.WriteLine(new string('-', 40));
+Console.WriteLine();
+
+// ===========================================================================
+// Scenario 3: path-based factories own the files they open.
+//
+// The path source and path sink open their own file streams and dispose them
+// when RunAsync completes (on success or failure) — no `using` needed at the
+// call site. The files below are deleted afterward to prove the handles were
+// released.
+// ===========================================================================
+
+var sourcePath = Path.Combine(Path.GetTempPath(), $"fw-pipeline-{Guid.NewGuid():N}.txt");
+var targetPath = Path.Combine(Path.GetTempPath(), $"fw-pipeline-{Guid.NewGuid():N}.out.txt");
+await File.WriteAllTextAsync(sourcePath, "Alice     Smith     030\nBob       Jones     025\n");
+
+await EtlPipeline
+    .Create()
+    .FixedWidthExtractor<Person>(sourcePath)
+    .FixedWidthLoader<Person>(targetPath)
+    .RunAsync();
+
+Console.WriteLine("Scenario 3 — path in, path out (files owned + disposed):");
+Console.WriteLine(new string('-', 40));
+Console.Write(await File.ReadAllTextAsync(targetPath));
+Console.WriteLine(new string('-', 40));
+
+// A locked handle would throw here; the successful delete proves both files
+// were released.
+File.Delete(sourcePath);
+File.Delete(targetPath);
+Console.WriteLine("Both files deleted — handles were released.");
+
+// ---------------------------------------------------------------------------
+// Inline Through stage.
+//
+// A stream-to-stream transform supplied as a delegate: it keeps records whose
+// Age is at least 30 and upper-cases the surname. Because it is expressed as a
+// Func<IAsyncEnumerable<Person>, IAsyncEnumerable<Person>>, no reference to the
+// Wolfgang.Etl.Transformers operator package is required.
+//
+// The #pragma suppresses CS1998 because this particular stage is synchronous;
+// a stage that awaited a database or service would not need it.
+// ---------------------------------------------------------------------------
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators
+static async IAsyncEnumerable<Person> KeepAdults(IAsyncEnumerable<Person> source)
+{
+    await foreach (var person in source)
+    {
+        if (person.Age >= 30)
+        {
+            yield return new Person
+            {
+                FirstName = person.FirstName,
+                LastName = person.LastName.ToUpperInvariant(),
+                Age = person.Age,
+            };
+        }
+    }
+}
+#pragma warning restore CS1998
+
+// ---------------------------------------------------------------------------
+// Person — the record type. FirstName(10) + LastName(10) + Age(3), so each
+// data line is exactly 23 characters wide.
+// ---------------------------------------------------------------------------
+
+/// <summary>
+/// A person record: first name and last name (10 chars each) plus a
+/// right-aligned, zero-padded age (3 chars).
+/// </summary>
+public class Person
+{
+    [FixedWidthField(0, 10)]
+    public string FirstName { get; set; } = string.Empty;
+
+
+
+    [FixedWidthField(1, 10)]
+    public string LastName { get; set; } = string.Empty;
+
+
+
+    [FixedWidthField(2, 3, Alignment = FieldAlignment.Right, Pad = '0')]
+    public int Age { get; set; }
+}

--- a/src/Wolfgang.Etl.FixedWidth/Diagnostics/FixedWidthMetrics.cs
+++ b/src/Wolfgang.Etl.FixedWidth/Diagnostics/FixedWidthMetrics.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+
+namespace Wolfgang.Etl.FixedWidth.Diagnostics;
+
+/// <summary>
+/// The <see cref="System.Diagnostics.Metrics.Meter"/> and instruments emitted by
+/// <see cref="FixedWidthExtractor{TRecord}"/> and <see cref="FixedWidthLoader{TRecord}"/> (#30).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Subscribe by the meter name <c>Wolfgang.Etl.FixedWidth</c> (see <see cref="MeterName"/>) — for
+/// example with OpenTelemetry's <c>AddMeter("Wolfgang.Etl.FixedWidth")</c> or a raw
+/// <see cref="MeterListener"/>. When no listener is registered every instrument is a no-op, so there is
+/// no measurable overhead in the default case.
+/// </para>
+/// <para>
+/// Every measurement is tagged with <c>etl.operation</c> (<c>extract</c> or <c>load</c>) and
+/// <c>etl.record_type</c> (<c>typeof(TRecord).Name</c>).
+/// </para>
+/// </remarks>
+internal static class FixedWidthMetrics
+{
+    /// <summary>The meter name callers subscribe to.</summary>
+    internal const string MeterName = "Wolfgang.Etl.FixedWidth";
+
+    internal const string OperationTagName = "etl.operation";
+
+    internal const string RecordTypeTagName = "etl.record_type";
+
+    internal const string ExtractOperation = "extract";
+
+    internal const string LoadOperation = "load";
+
+    private static readonly Meter Meter = new(MeterName);
+
+    /// <summary>Total items successfully extracted.</summary>
+    internal static readonly Counter<long> ItemsExtracted = Meter.CreateCounter<long>
+    (
+        "wolfgang.etl.fixedwidth.items.extracted",
+        unit: "{item}",
+        description: "Total items successfully extracted."
+    );
+
+    /// <summary>Total items successfully loaded.</summary>
+    internal static readonly Counter<long> ItemsLoaded = Meter.CreateCounter<long>
+    (
+        "wolfgang.etl.fixedwidth.items.loaded",
+        unit: "{item}",
+        description: "Total items successfully loaded."
+    );
+
+    /// <summary>Total items skipped via the skip budget.</summary>
+    internal static readonly Counter<long> ItemsSkipped = Meter.CreateCounter<long>
+    (
+        "wolfgang.etl.fixedwidth.items.skipped",
+        unit: "{item}",
+        description: "Total items skipped via the skip budget."
+    );
+
+    /// <summary>Total physical lines read, including blank and skipped lines.</summary>
+    internal static readonly Counter<long> LinesRead = Meter.CreateCounter<long>
+    (
+        "wolfgang.etl.fixedwidth.lines.read",
+        unit: "{line}",
+        description: "Total physical lines read, including blank and skipped lines."
+    );
+
+    /// <summary>Duration of an extract or load operation, in milliseconds.</summary>
+    internal static readonly Histogram<double> OperationDuration = Meter.CreateHistogram<double>
+    (
+        "wolfgang.etl.fixedwidth.operation.duration",
+        unit: "ms",
+        description: "Duration of an extract or load operation."
+    );
+
+
+    /// <summary>
+    /// Builds the tag set shared by every measurement of a single operation.
+    /// </summary>
+    internal static TagList CreateTags(string operation, Type recordType)
+        => new()
+        {
+            { OperationTagName, operation },
+            { RecordTypeTagName, recordType.Name },
+        };
+
+
+    // The per-line / per-record helpers below are called inside the extract and load hot loops. Each
+    // guards its instrument with Instrument.Enabled so that, when no MeterListener is subscribed (the
+    // default), the JIT skips the Add call and its argument marshalling entirely — the measurement
+    // machinery is only touched once a consumer opts in by subscribing. Instrument.Enabled is a cheap
+    // volatile field read; an unguarded Counter.Add would otherwise run a non-inlined call per item.
+
+    /// <summary>Records one successfully extracted item, if a listener is subscribed.</summary>
+    internal static void RecordExtracted(in TagList tags)
+    {
+        if (ItemsExtracted.Enabled)
+        {
+            ItemsExtracted.Add(1, tags);
+        }
+    }
+
+
+    /// <summary>Records one successfully loaded item, if a listener is subscribed.</summary>
+    internal static void RecordLoaded(in TagList tags)
+    {
+        if (ItemsLoaded.Enabled)
+        {
+            ItemsLoaded.Add(1, tags);
+        }
+    }
+
+
+    /// <summary>Records one skipped item, if a listener is subscribed.</summary>
+    internal static void RecordSkipped(in TagList tags)
+    {
+        if (ItemsSkipped.Enabled)
+        {
+            ItemsSkipped.Add(1, tags);
+        }
+    }
+
+
+    /// <summary>Records one physical line read, if a listener is subscribed.</summary>
+    internal static void RecordLineRead(in TagList tags)
+    {
+        if (LinesRead.Enabled)
+        {
+            LinesRead.Add(1, tags);
+        }
+    }
+
+
+    /// <summary>
+    /// Begins timing an operation. Dispose the returned scope — the <c>using</c> the extractor and loader
+    /// wrap it in records <see cref="OperationDuration"/> when the operation completes, ends early, or
+    /// throws.
+    /// </summary>
+    internal static DurationScope MeasureDuration(TagList tags) => new(tags);
+
+
+    /// <summary>
+    /// Records <see cref="OperationDuration"/> for the tags it was created with when disposed. Allocated
+    /// once per operation (not per record), so its cost is negligible.
+    /// </summary>
+    internal sealed class DurationScope : IDisposable
+    {
+        private readonly TagList _tags;
+        private readonly long _startTimestamp;
+        private bool _disposed;
+
+
+        internal DurationScope(TagList tags)
+        {
+            _tags = tags;
+            _startTimestamp = Stopwatch.GetTimestamp();
+        }
+
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            if (!OperationDuration.Enabled)
+            {
+                return;
+            }
+
+            var elapsedMs = (Stopwatch.GetTimestamp() - _startTimestamp) * 1000.0 / Stopwatch.Frequency;
+            OperationDuration.Record(elapsedMs, _tags);
+        }
+    }
+}

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.FixedWidth.Diagnostics;
 using Wolfgang.Etl.FixedWidth.Enums;
 using Wolfgang.Etl.FixedWidth.Exceptions;
 using Wolfgang.Etl.FixedWidth.Parsing;
@@ -632,6 +633,11 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
             ? HeaderLineCount + 1
             : -1;
 
+        // Metrics (#30): records the operation duration when the enumerator completes, ends early, or
+        // throws; the per-item/line counters below are no-ops unless a MeterListener is subscribed.
+        var metricTags = FixedWidthMetrics.CreateTags(FixedWidthMetrics.ExtractOperation, typeof(TRecord));
+        using var operationScope = FixedWidthMetrics.MeasureDuration(metricTags);
+
         LogExtractionStarted(fieldMap);
 
         token.ThrowIfCancellationRequested();
@@ -646,6 +652,7 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
             // Update before any processing so that if an exception is thrown,
             // CurrentLineNumber points to the offending line in the file.
             Interlocked.Increment(ref _currentLineNumber);
+            FixedWidthMetrics.RecordLineRead(metricTags);
 
             if (IsStructuralLine(separatorLineNo))
             {
@@ -669,6 +676,7 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
                 {
                     dataLinesSkipped++;
                     IncrementCurrentSkippedItemCount();
+                    FixedWidthMetrics.RecordSkipped(metricTags);
                     LogDebugBlankLineInSkipBudget(dataLinesSkipped);
                     continue;
                 }
@@ -683,6 +691,7 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
 
                 LogDebugBlankLineYieldedAsDefault();
                 IncrementCurrentItemCount();
+                FixedWidthMetrics.RecordExtracted(metricTags);
                 yield return defaultRecord;
                 continue;
             }
@@ -706,6 +715,7 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
             {
                 dataLinesSkipped++;
                 IncrementCurrentSkippedItemCount();
+                FixedWidthMetrics.RecordSkipped(metricTags);
                 LogDebugDataLineSkipped(dataLinesSkipped);
                 continue;
             }
@@ -737,6 +747,7 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
 
             LogDebugRecordParsed();
             IncrementCurrentItemCount();
+            FixedWidthMetrics.RecordExtracted(metricTags);
             yield return record;
         }
 

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthLoader.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthLoader.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.FixedWidth.Diagnostics;
 using Wolfgang.Etl.FixedWidth.Parsing;
 
 namespace Wolfgang.Etl.FixedWidth;
@@ -479,6 +480,10 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
         var fieldMap = FieldMap.GetResult<TRecord>();
         LogLoadingStarted(fieldMap);
 
+        // Metrics (#30): duration recorded on completion/throw; counters are no-ops without a listener.
+        var metricTags = FixedWidthMetrics.CreateTags(FixedWidthMetrics.LoadOperation, typeof(TRecord));
+        using var operationScope = FixedWidthMetrics.MeasureDuration(metricTags);
+
         // In dry-run mode, route all formatting through a throwaway writer so the
         // pipeline — including field-width validation — still runs, but nothing
         // reaches the output stream. The real writer is left untouched and so
@@ -502,6 +507,7 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
             if (CurrentSkippedItemCount < SkipItemCount)
             {
                 IncrementCurrentSkippedItemCount();
+                FixedWidthMetrics.RecordSkipped(metricTags);
                 LogDebugItemSkipped();
                 continue;
             }
@@ -523,6 +529,7 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
             Interlocked.Increment(ref _currentLineNumber);
             await target.WriteLineAsync().ConfigureAwait(false);
             IncrementCurrentItemCount();
+            FixedWidthMetrics.RecordLoaded(metricTags);
             LogDebugRecordWritten();
         }
 

--- a/src/Wolfgang.Etl.FixedWidth/Pipeline/EtlPipelineFixedWidthExtensions.cs
+++ b/src/Wolfgang.Etl.FixedWidth/Pipeline/EtlPipelineFixedWidthExtensions.cs
@@ -1,0 +1,214 @@
+using System;
+using System.IO;
+using Wolfgang.Etl.Abstractions;
+
+namespace Wolfgang.Etl.FixedWidth;
+
+/// <summary>
+/// Class-named fixed-width source factories and sink terminators for the fluent <see cref="EtlPipeline"/>
+/// chain (issue #253). Source factories hang off <see cref="EtlPipeline"/> so a pipeline reads
+/// <c>EtlPipeline.Create().FixedWidthExtractor&lt;Person&gt;("people.txt")</c>; sink terminators hang off
+/// <see cref="IEtlPipeline{T}"/> so it ends
+/// <c>… .FixedWidthLoader&lt;Person&gt;("out.txt").RunAsync()</c>.
+/// </summary>
+/// <remarks>
+/// Path-based factories own the file stream they open and dispose it after the run (success or
+/// failure). Factories that accept a caller-supplied <see cref="Stream"/>, <see cref="TextReader"/>,
+/// <see cref="TextWriter"/>, or a pre-built extractor do not dispose it — the caller owns the lifecycle
+/// and, for a writer, is responsible for flushing it. The fluent setters returned by these factories map
+/// 1:1 to the underlying <c>FixedWidthExtractor&lt;T&gt;</c> / <c>FixedWidthLoader&lt;T&gt;</c>
+/// properties; encoding is set via the builder's <c>Encoding</c> method.
+/// </remarks>
+public static class EtlPipelineFixedWidthExtensions
+{
+    // ------------------------------------------------------------------
+    // Source factories (on EtlPipeline)
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Begins a pipeline that reads fixed-width records from the file at <paramref name="path"/>. The
+    /// opened file reader is owned by the pipeline and disposed when the run finishes.
+    /// </summary>
+    /// <typeparam name="T">The record type to produce.</typeparam>
+    /// <param name="pipeline">The seed returned by <see cref="EtlPipeline.Create"/>.</param>
+    /// <param name="path">The path of the fixed-width file to read.</param>
+    /// <returns>A fluent <see cref="IFixedWidthExtractorBuilder{T}"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="pipeline"/> or <paramref name="path"/> is <see langword="null"/>.</exception>
+    public static IFixedWidthExtractorBuilder<T> FixedWidthExtractor<T>(this EtlPipeline pipeline, string path)
+        where T : notnull, new()
+    {
+        if (pipeline is null)
+        {
+            throw new ArgumentNullException(nameof(pipeline));
+        }
+
+        if (path is null)
+        {
+            throw new ArgumentNullException(nameof(path));
+        }
+
+        return FixedWidthExtractorBuilder<T>.FromPath(path);
+    }
+
+
+    /// <summary>
+    /// Begins a pipeline that reads fixed-width records from <paramref name="stream"/>. The caller
+    /// retains ownership of the stream; only the extractor's internal reader is disposed.
+    /// </summary>
+    /// <typeparam name="T">The record type to produce.</typeparam>
+    /// <param name="pipeline">The seed returned by <see cref="EtlPipeline.Create"/>.</param>
+    /// <param name="stream">The stream to read from.</param>
+    /// <returns>A fluent <see cref="IFixedWidthExtractorBuilder{T}"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="pipeline"/> or <paramref name="stream"/> is <see langword="null"/>.</exception>
+    public static IFixedWidthExtractorBuilder<T> FixedWidthExtractor<T>(this EtlPipeline pipeline, Stream stream)
+        where T : notnull, new()
+    {
+        if (pipeline is null)
+        {
+            throw new ArgumentNullException(nameof(pipeline));
+        }
+
+        if (stream is null)
+        {
+            throw new ArgumentNullException(nameof(stream));
+        }
+
+        return FixedWidthExtractorBuilder<T>.FromStream(stream);
+    }
+
+
+    /// <summary>
+    /// Begins a pipeline that reads fixed-width records from <paramref name="reader"/>. The caller
+    /// retains ownership of the reader; nothing is disposed by the pipeline.
+    /// </summary>
+    /// <typeparam name="T">The record type to produce.</typeparam>
+    /// <param name="pipeline">The seed returned by <see cref="EtlPipeline.Create"/>.</param>
+    /// <param name="reader">The reader to read from.</param>
+    /// <returns>A fluent <see cref="IFixedWidthExtractorBuilder{T}"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="pipeline"/> or <paramref name="reader"/> is <see langword="null"/>.</exception>
+    public static IFixedWidthExtractorBuilder<T> FixedWidthExtractor<T>(this EtlPipeline pipeline, TextReader reader)
+        where T : notnull, new()
+    {
+        if (pipeline is null)
+        {
+            throw new ArgumentNullException(nameof(pipeline));
+        }
+
+        if (reader is null)
+        {
+            throw new ArgumentNullException(nameof(reader));
+        }
+
+        return FixedWidthExtractorBuilder<T>.FromReader(reader);
+    }
+
+
+    /// <summary>
+    /// Begins a pipeline from an already-configured <see cref="T:Wolfgang.Etl.FixedWidth.FixedWidthExtractor`1"/>.
+    /// The caller retains ownership of the instance; nothing is disposed by the pipeline. The returned
+    /// builder can still layer further configuration over the supplied extractor.
+    /// </summary>
+    /// <typeparam name="T">The record type to produce.</typeparam>
+    /// <param name="pipeline">The seed returned by <see cref="EtlPipeline.Create"/>.</param>
+    /// <param name="extractor">The extractor that seeds the pipeline.</param>
+    /// <returns>A fluent <see cref="IFixedWidthExtractorBuilder{T}"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="pipeline"/> or <paramref name="extractor"/> is <see langword="null"/>.</exception>
+    public static IFixedWidthExtractorBuilder<T> FixedWidthExtractor<T>(this EtlPipeline pipeline, FixedWidthExtractor<T> extractor)
+        where T : notnull, new()
+    {
+        if (pipeline is null)
+        {
+            throw new ArgumentNullException(nameof(pipeline));
+        }
+
+        if (extractor is null)
+        {
+            throw new ArgumentNullException(nameof(extractor));
+        }
+
+        return FixedWidthExtractorBuilder<T>.FromExtractor(extractor);
+    }
+
+
+    // ------------------------------------------------------------------
+    // Sink terminators (on IEtlPipeline<T>)
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Terminates the pipeline by writing fixed-width records to the file at <paramref name="path"/>.
+    /// The opened file writer is owned by the pipeline and disposed after the run, flushing to disk.
+    /// </summary>
+    /// <typeparam name="T">The record type to write.</typeparam>
+    /// <param name="pipeline">The pipeline to terminate.</param>
+    /// <param name="path">The path of the fixed-width file to write. An existing file is overwritten.</param>
+    /// <returns>A fluent <see cref="IFixedWidthLoaderBuilder{T}"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="pipeline"/> or <paramref name="path"/> is <see langword="null"/>.</exception>
+    public static IFixedWidthLoaderBuilder<T> FixedWidthLoader<T>(this IEtlPipeline<T> pipeline, string path)
+        where T : notnull
+    {
+        if (pipeline is null)
+        {
+            throw new ArgumentNullException(nameof(pipeline));
+        }
+
+        if (path is null)
+        {
+            throw new ArgumentNullException(nameof(path));
+        }
+
+        return FixedWidthLoaderBuilder<T>.FromPath(pipeline, path);
+    }
+
+
+    /// <summary>
+    /// Terminates the pipeline by writing fixed-width records to <paramref name="stream"/>. The caller
+    /// retains ownership of the stream; only the loader's internal writer is disposed.
+    /// </summary>
+    /// <typeparam name="T">The record type to write.</typeparam>
+    /// <param name="pipeline">The pipeline to terminate.</param>
+    /// <param name="stream">The stream to write to.</param>
+    /// <returns>A fluent <see cref="IFixedWidthLoaderBuilder{T}"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="pipeline"/> or <paramref name="stream"/> is <see langword="null"/>.</exception>
+    public static IFixedWidthLoaderBuilder<T> FixedWidthLoader<T>(this IEtlPipeline<T> pipeline, Stream stream)
+        where T : notnull
+    {
+        if (pipeline is null)
+        {
+            throw new ArgumentNullException(nameof(pipeline));
+        }
+
+        if (stream is null)
+        {
+            throw new ArgumentNullException(nameof(stream));
+        }
+
+        return FixedWidthLoaderBuilder<T>.FromStream(pipeline, stream);
+    }
+
+
+    /// <summary>
+    /// Terminates the pipeline by writing fixed-width records to <paramref name="writer"/>. The caller
+    /// retains ownership of the writer and is responsible for flushing it; nothing is disposed by the
+    /// pipeline.
+    /// </summary>
+    /// <typeparam name="T">The record type to write.</typeparam>
+    /// <param name="pipeline">The pipeline to terminate.</param>
+    /// <param name="writer">The writer to write to.</param>
+    /// <returns>A fluent <see cref="IFixedWidthLoaderBuilder{T}"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="pipeline"/> or <paramref name="writer"/> is <see langword="null"/>.</exception>
+    public static IFixedWidthLoaderBuilder<T> FixedWidthLoader<T>(this IEtlPipeline<T> pipeline, TextWriter writer)
+        where T : notnull
+    {
+        if (pipeline is null)
+        {
+            throw new ArgumentNullException(nameof(pipeline));
+        }
+
+        if (writer is null)
+        {
+            throw new ArgumentNullException(nameof(writer));
+        }
+
+        return FixedWidthLoaderBuilder<T>.FromWriter(pipeline, writer);
+    }
+}

--- a/src/Wolfgang.Etl.FixedWidth/Pipeline/FixedWidthExtractorBuilder.cs
+++ b/src/Wolfgang.Etl.FixedWidth/Pipeline/FixedWidthExtractorBuilder.cs
@@ -1,0 +1,246 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.FixedWidth.Enums;
+
+namespace Wolfgang.Etl.FixedWidth;
+
+/// <summary>
+/// Default <see cref="IFixedWidthExtractorBuilder{T}"/> implementation. Records configuration until the
+/// first pipeline operator, then materializes a <see cref="FixedWidthExtractor{T}"/> and delegates to a
+/// generic <see cref="EtlPipeline"/> built from it. Any resource the builder itself opened (a file
+/// reader for a path source, the extractor's internal reader for a stream source) is disposed once the
+/// source is drained — on success, failure, or cancellation.
+/// </summary>
+/// <typeparam name="T">The record type produced by the extractor.</typeparam>
+internal sealed class FixedWidthExtractorBuilder<T> : IFixedWidthExtractorBuilder<T>
+    where T : notnull, new()
+{
+    private readonly string? _path;
+    private readonly Stream? _stream;
+    private readonly TextReader? _reader;
+    private readonly FixedWidthExtractor<T>? _existing;
+    private readonly List<Action<FixedWidthExtractor<T>>> _mutations = new();
+
+    private Encoding _encoding = System.Text.Encoding.UTF8;
+    private IEtlPipeline<T>? _pipeline;
+
+
+    private FixedWidthExtractorBuilder
+    (
+        string? path,
+        Stream? stream,
+        TextReader? reader,
+        FixedWidthExtractor<T>? existing
+    )
+    {
+        _path = path;
+        _stream = stream;
+        _reader = reader;
+        _existing = existing;
+    }
+
+
+    internal static IFixedWidthExtractorBuilder<T> FromPath(string path)
+        => new FixedWidthExtractorBuilder<T>(path, stream: null, reader: null, existing: null);
+
+
+    internal static IFixedWidthExtractorBuilder<T> FromStream(Stream stream)
+        => new FixedWidthExtractorBuilder<T>(path: null, stream, reader: null, existing: null);
+
+
+    internal static IFixedWidthExtractorBuilder<T> FromReader(TextReader reader)
+        => new FixedWidthExtractorBuilder<T>(path: null, stream: null, reader, existing: null);
+
+
+    internal static IFixedWidthExtractorBuilder<T> FromExtractor(FixedWidthExtractor<T> extractor)
+        => new FixedWidthExtractorBuilder<T>(path: null, stream: null, reader: null, extractor);
+
+
+    public IFixedWidthExtractorBuilder<T> Encoding(Encoding encoding)
+    {
+        if (encoding is null)
+        {
+            throw new ArgumentNullException(nameof(encoding));
+        }
+
+        ThrowIfMaterialized();
+        _encoding = encoding;
+        return this;
+    }
+
+
+    public IFixedWidthExtractorBuilder<T> HeaderLineCount(int count) => Configure(e => e.HeaderLineCount = count);
+
+
+    public IFixedWidthExtractorBuilder<T> HasHeader(bool hasHeader) => Configure(e => e.HasHeader = hasHeader);
+
+
+    public IFixedWidthExtractorBuilder<T> MalformedLineHandling(MalformedLineHandling handling) => Configure(e => e.MalformedLineHandling = handling);
+
+
+    public IFixedWidthExtractorBuilder<T> BlankLineHandling(BlankLineHandling handling) => Configure(e => e.BlankLineHandling = handling);
+
+
+    public IFixedWidthExtractorBuilder<T> LineFilter(Func<string, LineAction> filter)
+    {
+        if (filter is null)
+        {
+            throw new ArgumentNullException(nameof(filter));
+        }
+
+        return Configure(e => e.LineFilter = filter);
+    }
+
+
+    public IFixedWidthExtractorBuilder<T> RecordValidator(Func<T, ValidationResult> validator)
+    {
+        if (validator is null)
+        {
+            throw new ArgumentNullException(nameof(validator));
+        }
+
+        return Configure(e => e.RecordValidator = validator);
+    }
+
+
+    public IFixedWidthExtractorBuilder<T> ValueParser(FixedWidthValueParser parser)
+    {
+        if (parser is null)
+        {
+            throw new ArgumentNullException(nameof(parser));
+        }
+
+        return Configure(e => e.ValueParser = parser);
+    }
+
+
+    public IFixedWidthExtractorBuilder<T> FieldSeparator(char? separator) => Configure(e => e.FieldSeparator = separator);
+
+
+    public IFixedWidthExtractorBuilder<T> FieldDelimiter(string? delimiter) => Configure(e => e.FieldDelimiter = delimiter);
+
+
+    public IEtlPipeline<TOut> Through<TOut>(ITransformAsync<T, TOut> transformer) where TOut : notnull => Pipeline().Through(transformer);
+
+
+    public IEtlPipeline<TOut> Through<TOut>(ITransformWithCancellationAsync<T, TOut> transformer) where TOut : notnull => Pipeline().Through(transformer);
+
+
+    public IEtlPipeline<TOut> Through<TOut>(Func<IAsyncEnumerable<T>, IAsyncEnumerable<TOut>> stage) where TOut : notnull => Pipeline().Through(stage);
+
+
+    public IEtlPipeline<TOut> Through<TOut>(Func<IAsyncEnumerable<T>, CancellationToken, IAsyncEnumerable<TOut>> stage) where TOut : notnull => Pipeline().Through(stage);
+
+
+    public IEtlPipelineSink To<TProgress>(LoaderBase<T, TProgress> loader) where TProgress : notnull => Pipeline().To(loader);
+
+
+    public IAsyncEnumerable<T> AsAsyncEnumerable(CancellationToken token = default) => Pipeline().AsAsyncEnumerable(token);
+
+
+    private IFixedWidthExtractorBuilder<T> Configure(Action<FixedWidthExtractor<T>> mutation)
+    {
+        ThrowIfMaterialized();
+        _mutations.Add(mutation);
+        return this;
+    }
+
+
+    private void ThrowIfMaterialized()
+    {
+        if (_pipeline is not null)
+        {
+            throw new InvalidOperationException
+            (
+                "The extractor has already been materialized by a pipeline operator; configuration setters can no longer be applied."
+            );
+        }
+    }
+
+
+    private IEtlPipeline<T> Pipeline()
+    {
+        if (_pipeline is null)
+        {
+            var extractor = BuildExtractor(out var ownedResources);
+            _pipeline = EtlPipeline.Create().From(DrainThenDisposeAsync(extractor, ownedResources));
+        }
+
+        return _pipeline;
+    }
+
+
+    private FixedWidthExtractor<T> BuildExtractor(out object?[] ownedResources)
+    {
+        FixedWidthExtractor<T> extractor;
+
+        if (_existing is not null)
+        {
+            // Caller-supplied instance — the caller owns its lifetime; dispose nothing.
+            extractor = _existing;
+            ownedResources = Array.Empty<object?>();
+        }
+        else if (_reader is not null)
+        {
+            // Caller owns the reader; the extractor's Dispose is a no-op. Dispose nothing.
+            extractor = new FixedWidthExtractor<T>(_reader);
+            ownedResources = Array.Empty<object?>();
+        }
+        else if (_stream is not null)
+        {
+            // The extractor wraps the caller's stream with leaveOpen:true, so dispose only the
+            // extractor (to release its internal reader); the caller retains the stream.
+            extractor = new FixedWidthExtractor<T>(_stream, _encoding);
+            ownedResources = new object?[] { extractor };
+        }
+        else
+        {
+            // Path source: the builder owns the reader it opens, so dispose it once drained.
+            var reader = new StreamReader(_path!, _encoding, detectEncodingFromByteOrderMarks: true);
+            extractor = new FixedWidthExtractor<T>(reader);
+            ownedResources = new object?[] { reader };
+        }
+
+        foreach (var mutation in _mutations)
+        {
+            mutation(extractor);
+        }
+
+        return extractor;
+    }
+
+
+    /// <summary>
+    /// Yields every record from the extractor, then disposes the owned resources in a
+    /// <see langword="finally"/> block so they are released whether the run succeeds, throws, or is
+    /// cancelled. The pipeline's cancellation token is forwarded here by the generic core.
+    /// </summary>
+    private static async IAsyncEnumerable<T> DrainThenDisposeAsync
+    (
+        FixedWidthExtractor<T> extractor,
+        object?[] ownedResources,
+        [EnumeratorCancellation] CancellationToken token = default
+    )
+    {
+        try
+        {
+            await foreach (var item in extractor.ExtractAsync(token).WithCancellation(token).ConfigureAwait(false))
+            {
+                yield return item;
+            }
+        }
+        finally
+        {
+            foreach (var resource in ownedResources)
+            {
+                (resource as IDisposable)?.Dispose();
+            }
+        }
+    }
+}

--- a/src/Wolfgang.Etl.FixedWidth/Pipeline/FixedWidthLoaderBuilder.cs
+++ b/src/Wolfgang.Etl.FixedWidth/Pipeline/FixedWidthLoaderBuilder.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+
+namespace Wolfgang.Etl.FixedWidth;
+
+/// <summary>
+/// Default <see cref="IFixedWidthLoaderBuilder{T}"/> implementation. Records configuration up front,
+/// then materializes a <see cref="FixedWidthLoader{T}"/> and terminates the upstream pipeline when
+/// <see cref="RunAsync"/> is called. Any resource the builder itself opened (a file writer for a path
+/// sink) is disposed after the run, on success or failure, flushing the output to disk.
+/// </summary>
+/// <typeparam name="T">The record type consumed by the loader.</typeparam>
+internal sealed class FixedWidthLoaderBuilder<T> : IFixedWidthLoaderBuilder<T>
+    where T : notnull
+{
+    private readonly IEtlPipeline<T> _pipeline;
+    private readonly string? _path;
+    private readonly Stream? _stream;
+    private readonly TextWriter? _writer;
+    private readonly List<Action<FixedWidthLoader<T>>> _mutations = new();
+
+    private Encoding _encoding = System.Text.Encoding.UTF8;
+
+
+    private FixedWidthLoaderBuilder
+    (
+        IEtlPipeline<T> pipeline,
+        string? path,
+        Stream? stream,
+        TextWriter? writer
+    )
+    {
+        _pipeline = pipeline;
+        _path = path;
+        _stream = stream;
+        _writer = writer;
+    }
+
+
+    internal static IFixedWidthLoaderBuilder<T> FromPath(IEtlPipeline<T> pipeline, string path)
+        => new FixedWidthLoaderBuilder<T>(pipeline, path, stream: null, writer: null);
+
+
+    internal static IFixedWidthLoaderBuilder<T> FromStream(IEtlPipeline<T> pipeline, Stream stream)
+        => new FixedWidthLoaderBuilder<T>(pipeline, path: null, stream, writer: null);
+
+
+    internal static IFixedWidthLoaderBuilder<T> FromWriter(IEtlPipeline<T> pipeline, TextWriter writer)
+        => new FixedWidthLoaderBuilder<T>(pipeline, path: null, stream: null, writer);
+
+
+    public IFixedWidthLoaderBuilder<T> Encoding(Encoding encoding)
+    {
+        if (encoding is null)
+        {
+            throw new ArgumentNullException(nameof(encoding));
+        }
+
+        _encoding = encoding;
+        return this;
+    }
+
+
+    public IFixedWidthLoaderBuilder<T> WriteHeader(bool writeHeader) => Configure(l => l.WriteHeader = writeHeader);
+
+
+    public IFixedWidthLoaderBuilder<T> ValueConverter(Func<object, FieldContext, string> converter)
+    {
+        if (converter is null)
+        {
+            throw new ArgumentNullException(nameof(converter));
+        }
+
+        return Configure(l => l.ValueConverter = converter);
+    }
+
+
+    public IFixedWidthLoaderBuilder<T> HeaderConverter(Func<string, FieldContext, string> converter)
+    {
+        if (converter is null)
+        {
+            throw new ArgumentNullException(nameof(converter));
+        }
+
+        return Configure(l => l.HeaderConverter = converter);
+    }
+
+
+    public IFixedWidthLoaderBuilder<T> FieldSeparator(char? separator) => Configure(l => l.FieldSeparator = separator);
+
+
+    public IFixedWidthLoaderBuilder<T> FieldDelimiter(string? delimiter) => Configure(l => l.FieldDelimiter = delimiter);
+
+
+    public IFixedWidthLoaderBuilder<T> IsDryRun(bool isDryRun) => Configure(l => l.IsDryRun = isDryRun);
+
+
+    public Task RunAsync(IProgress<EtlPipelineProgress>? progress = null, CancellationToken token = default)
+    {
+        FixedWidthLoader<T> loader;
+        IDisposable? owned = null;
+
+        if (_writer is not null)
+        {
+            // Caller owns the writer and flushes it; dispose nothing.
+            loader = new FixedWidthLoader<T>(_writer);
+        }
+        else if (_stream is not null)
+        {
+            // The loader wraps the caller's stream with leaveOpen:true and flushes it during the run;
+            // dispose the loader afterward to release its internal writer. The stream stays open.
+            loader = new FixedWidthLoader<T>(_stream, _encoding);
+            owned = loader;
+        }
+        else
+        {
+            // Path sink: the builder owns the writer it opens. Disposing it after the run flushes the
+            // file to disk and closes it.
+            var writer = new StreamWriter(_path!, append: false, _encoding);
+            loader = new FixedWidthLoader<T>(writer);
+            owned = writer;
+        }
+
+        foreach (var mutation in _mutations)
+        {
+            mutation(loader);
+        }
+
+        var sink = _pipeline.To(loader);
+
+        if (owned is not null)
+        {
+            sink = sink.DisposingOwned(owned);
+        }
+
+        return sink.RunAsync(progress, token);
+    }
+
+
+    private IFixedWidthLoaderBuilder<T> Configure(Action<FixedWidthLoader<T>> mutation)
+    {
+        _mutations.Add(mutation);
+        return this;
+    }
+}

--- a/src/Wolfgang.Etl.FixedWidth/Pipeline/IFixedWidthExtractorBuilder.cs
+++ b/src/Wolfgang.Etl.FixedWidth/Pipeline/IFixedWidthExtractorBuilder.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Text;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.FixedWidth.Enums;
+
+namespace Wolfgang.Etl.FixedWidth;
+
+/// <summary>
+/// A fluent builder for a fixed-width extraction stage of a generic <see cref="EtlPipeline"/>. Returned
+/// by the <c>FixedWidthExtractor</c> source factories in <see cref="EtlPipelineFixedWidthExtensions"/>.
+/// </summary>
+/// <typeparam name="T">The record type produced by the extractor.</typeparam>
+/// <remarks>
+/// Each configuration method maps one-to-one to a settable property on
+/// <see cref="T:Wolfgang.Etl.FixedWidth.FixedWidthExtractor`1"/> and returns the same builder so calls
+/// chain. Configuration is recorded and applied when the first pipeline operation — a <c>Through</c>
+/// stage, a sink terminator such as <c>FixedWidthLoader</c>, or
+/// <see cref="IEtlPipeline{T}.AsAsyncEnumerable"/> — materializes the extractor; calling a setter after
+/// that throws <see cref="InvalidOperationException"/>.
+/// </remarks>
+public interface IFixedWidthExtractorBuilder<T> : IEtlPipeline<T>
+    where T : notnull, new()
+{
+    /// <summary>
+    /// Sets the text encoding used to decode the source. Applies only to the path- and stream-based
+    /// factories; a caller-supplied reader or extractor already carries its own encoding. Defaults to
+    /// <see cref="System.Text.Encoding.UTF8"/>.
+    /// </summary>
+    /// <param name="encoding">The encoding to decode with.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    IFixedWidthExtractorBuilder<T> Encoding(Encoding encoding);
+
+
+    /// <summary>
+    /// Sets <see cref="FixedWidthExtractor{T}.HeaderLineCount"/> — the number of header lines to skip
+    /// before the first record.
+    /// </summary>
+    /// <param name="count">The number of leading lines to skip.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    IFixedWidthExtractorBuilder<T> HeaderLineCount(int count);
+
+
+    /// <summary>
+    /// Sets <see cref="FixedWidthExtractor{T}.HasHeader"/> — the single-header-line convenience over
+    /// <see cref="HeaderLineCount(int)"/>.
+    /// </summary>
+    /// <param name="hasHeader"><see langword="true"/> to skip one header line; otherwise none.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    IFixedWidthExtractorBuilder<T> HasHeader(bool hasHeader);
+
+
+    /// <summary>
+    /// Sets <see cref="FixedWidthExtractor{T}.MalformedLineHandling"/> — how a line that is too short or
+    /// cannot be converted is handled.
+    /// </summary>
+    /// <param name="handling">The malformed-line policy.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    IFixedWidthExtractorBuilder<T> MalformedLineHandling(MalformedLineHandling handling);
+
+
+    /// <summary>
+    /// Sets <see cref="FixedWidthExtractor{T}.BlankLineHandling"/> — how a zero-length line is handled.
+    /// </summary>
+    /// <param name="handling">The blank-line policy.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    IFixedWidthExtractorBuilder<T> BlankLineHandling(BlankLineHandling handling);
+
+
+    /// <summary>
+    /// Sets <see cref="FixedWidthExtractor{T}.LineFilter"/> — a per-line predicate evaluated before
+    /// parsing that can process, skip, or stop.
+    /// </summary>
+    /// <param name="filter">The line filter.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    IFixedWidthExtractorBuilder<T> LineFilter(Func<string, LineAction> filter);
+
+
+    /// <summary>
+    /// Sets <see cref="FixedWidthExtractor{T}.RecordValidator"/> — a per-record callback that can accept,
+    /// skip, or stop after parsing.
+    /// </summary>
+    /// <param name="validator">The record validator.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    IFixedWidthExtractorBuilder<T> RecordValidator(Func<T, ValidationResult> validator);
+
+
+    /// <summary>
+    /// Sets <see cref="FixedWidthExtractor{T}.ValueParser"/> — the delegate that converts a raw field
+    /// string into the target property type.
+    /// </summary>
+    /// <param name="parser">The value parser.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    IFixedWidthExtractorBuilder<T> ValueParser(FixedWidthValueParser parser);
+
+
+    /// <summary>
+    /// Sets <see cref="FixedWidthExtractor{T}.FieldSeparator"/> — when non-null, the line after the
+    /// header is treated as a separator and skipped.
+    /// </summary>
+    /// <param name="separator">The separator character, or <see langword="null"/> for none.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    IFixedWidthExtractorBuilder<T> FieldSeparator(char? separator);
+
+
+    /// <summary>
+    /// Sets <see cref="FixedWidthExtractor{T}.FieldDelimiter"/> — the delimiter present between fields in
+    /// the source, or <see langword="null"/> for pure fixed-width input.
+    /// </summary>
+    /// <param name="delimiter">The field delimiter, or <see langword="null"/> for none.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    IFixedWidthExtractorBuilder<T> FieldDelimiter(string? delimiter);
+}

--- a/src/Wolfgang.Etl.FixedWidth/Pipeline/IFixedWidthLoaderBuilder.cs
+++ b/src/Wolfgang.Etl.FixedWidth/Pipeline/IFixedWidthLoaderBuilder.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Text;
+using Wolfgang.Etl.Abstractions;
+
+namespace Wolfgang.Etl.FixedWidth;
+
+/// <summary>
+/// A fluent builder for a fixed-width loader that terminates a generic <see cref="EtlPipeline"/>.
+/// Returned by the <c>FixedWidthLoader</c> sink terminators in
+/// <see cref="EtlPipelineFixedWidthExtensions"/>.
+/// </summary>
+/// <typeparam name="T">The record type consumed by the loader.</typeparam>
+/// <remarks>
+/// Each configuration method maps one-to-one to a settable property on
+/// <see cref="T:Wolfgang.Etl.FixedWidth.FixedWidthLoader`1"/> and returns the same builder so calls
+/// chain. Because the builder <em>is</em> an <see cref="IEtlPipelineSink"/>, the loader is materialized
+/// and the pipeline runs when
+/// <see cref="IEtlPipelineSink.RunAsync(IProgress{EtlPipelineProgress}, System.Threading.CancellationToken)"/>
+/// is called.
+/// </remarks>
+public interface IFixedWidthLoaderBuilder<T> : IEtlPipelineSink
+    where T : notnull
+{
+    /// <summary>
+    /// Sets the text encoding used to encode the output. Applies only to the path- and stream-based
+    /// terminators; a caller-supplied writer already carries its own encoding. Defaults to
+    /// <see cref="System.Text.Encoding.UTF8"/>.
+    /// </summary>
+    /// <param name="encoding">The encoding to write with.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    IFixedWidthLoaderBuilder<T> Encoding(Encoding encoding);
+
+
+
+    /// <summary>
+    /// Sets <see cref="FixedWidthLoader{T}.WriteHeader"/> — whether a header line is written before the
+    /// records.
+    /// </summary>
+    /// <param name="writeHeader"><see langword="true"/> to write a header line.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    IFixedWidthLoaderBuilder<T> WriteHeader(bool writeHeader);
+
+
+    /// <summary>
+    /// Sets <see cref="FixedWidthLoader{T}.ValueConverter"/> — the delegate that renders a field value to
+    /// its string form before padding.
+    /// </summary>
+    /// <param name="converter">The value converter.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    IFixedWidthLoaderBuilder<T> ValueConverter(Func<object, FieldContext, string> converter);
+
+
+    /// <summary>
+    /// Sets <see cref="FixedWidthLoader{T}.HeaderConverter"/> — the delegate that renders a header label
+    /// to its string form. Only used when <see cref="WriteHeader(bool)"/> is enabled.
+    /// </summary>
+    /// <param name="converter">The header converter.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    IFixedWidthLoaderBuilder<T> HeaderConverter(Func<string, FieldContext, string> converter);
+
+
+    /// <summary>
+    /// Sets <see cref="FixedWidthLoader{T}.FieldSeparator"/> — when non-null (and a header is written), a
+    /// separator line of the given character is written after the header.
+    /// </summary>
+    /// <param name="separator">The separator character, or <see langword="null"/> for none.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    IFixedWidthLoaderBuilder<T> FieldSeparator(char? separator);
+
+
+    /// <summary>
+    /// Sets <see cref="FixedWidthLoader{T}.FieldDelimiter"/> — a string written between adjacent fields on
+    /// every line, or <see langword="null"/> for pure fixed-width output.
+    /// </summary>
+    /// <param name="delimiter">The field delimiter, or <see langword="null"/> for none.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    IFixedWidthLoaderBuilder<T> FieldDelimiter(string? delimiter);
+
+
+    /// <summary>
+    /// Sets <see cref="FixedWidthLoader{T}.IsDryRun"/> — when enabled the pipeline runs and validates but
+    /// writes nothing to the output.
+    /// </summary>
+    /// <param name="isDryRun"><see langword="true"/> to run without writing output.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    IFixedWidthLoaderBuilder<T> IsDryRun(bool isDryRun);
+}

--- a/src/Wolfgang.Etl.FixedWidth/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Etl.FixedWidth/PublicAPI.Shipped.txt
@@ -40,6 +40,7 @@ Wolfgang.Etl.FixedWidth.Enums.ValidationAction
 Wolfgang.Etl.FixedWidth.Enums.ValidationAction.Accept = 0 -> Wolfgang.Etl.FixedWidth.Enums.ValidationAction
 Wolfgang.Etl.FixedWidth.Enums.ValidationAction.Skip = 1 -> Wolfgang.Etl.FixedWidth.Enums.ValidationAction
 Wolfgang.Etl.FixedWidth.Enums.ValidationAction.Stop = 2 -> Wolfgang.Etl.FixedWidth.Enums.ValidationAction
+Wolfgang.Etl.FixedWidth.EtlPipelineFixedWidthExtensions
 Wolfgang.Etl.FixedWidth.Exceptions.FieldConversionException
 Wolfgang.Etl.FixedWidth.Exceptions.FieldConversionException.ExpectedType.get -> System.Type
 Wolfgang.Etl.FixedWidth.Exceptions.FieldConversionException.FieldConversionException(string message, long lineNumber, string lineContent, string fieldName, System.Type expectedType, string rawValue, System.Exception innerException) -> void
@@ -145,6 +146,25 @@ Wolfgang.Etl.FixedWidth.FixedWidthSchema.TotalColumnCount.get -> int
 Wolfgang.Etl.FixedWidth.FixedWidthTransformer<TSource, TDestination>
 Wolfgang.Etl.FixedWidth.FixedWidthTransformer<TSource, TDestination>.FixedWidthTransformer(System.Func<TSource, TDestination> transform) -> void
 Wolfgang.Etl.FixedWidth.FixedWidthValueParser
+Wolfgang.Etl.FixedWidth.IFixedWidthExtractorBuilder<T>
+Wolfgang.Etl.FixedWidth.IFixedWidthExtractorBuilder<T>.BlankLineHandling(Wolfgang.Etl.FixedWidth.Enums.BlankLineHandling handling) -> Wolfgang.Etl.FixedWidth.IFixedWidthExtractorBuilder<T>
+Wolfgang.Etl.FixedWidth.IFixedWidthExtractorBuilder<T>.Encoding(System.Text.Encoding encoding) -> Wolfgang.Etl.FixedWidth.IFixedWidthExtractorBuilder<T>
+Wolfgang.Etl.FixedWidth.IFixedWidthExtractorBuilder<T>.FieldDelimiter(string delimiter) -> Wolfgang.Etl.FixedWidth.IFixedWidthExtractorBuilder<T>
+Wolfgang.Etl.FixedWidth.IFixedWidthExtractorBuilder<T>.FieldSeparator(char? separator) -> Wolfgang.Etl.FixedWidth.IFixedWidthExtractorBuilder<T>
+Wolfgang.Etl.FixedWidth.IFixedWidthExtractorBuilder<T>.HasHeader(bool hasHeader) -> Wolfgang.Etl.FixedWidth.IFixedWidthExtractorBuilder<T>
+Wolfgang.Etl.FixedWidth.IFixedWidthExtractorBuilder<T>.HeaderLineCount(int count) -> Wolfgang.Etl.FixedWidth.IFixedWidthExtractorBuilder<T>
+Wolfgang.Etl.FixedWidth.IFixedWidthExtractorBuilder<T>.LineFilter(System.Func<string, Wolfgang.Etl.FixedWidth.Enums.LineAction> filter) -> Wolfgang.Etl.FixedWidth.IFixedWidthExtractorBuilder<T>
+Wolfgang.Etl.FixedWidth.IFixedWidthExtractorBuilder<T>.MalformedLineHandling(Wolfgang.Etl.FixedWidth.Enums.MalformedLineHandling handling) -> Wolfgang.Etl.FixedWidth.IFixedWidthExtractorBuilder<T>
+Wolfgang.Etl.FixedWidth.IFixedWidthExtractorBuilder<T>.RecordValidator(System.Func<T, Wolfgang.Etl.FixedWidth.ValidationResult> validator) -> Wolfgang.Etl.FixedWidth.IFixedWidthExtractorBuilder<T>
+Wolfgang.Etl.FixedWidth.IFixedWidthExtractorBuilder<T>.ValueParser(Wolfgang.Etl.FixedWidth.FixedWidthValueParser parser) -> Wolfgang.Etl.FixedWidth.IFixedWidthExtractorBuilder<T>
+Wolfgang.Etl.FixedWidth.IFixedWidthLoaderBuilder<T>
+Wolfgang.Etl.FixedWidth.IFixedWidthLoaderBuilder<T>.Encoding(System.Text.Encoding encoding) -> Wolfgang.Etl.FixedWidth.IFixedWidthLoaderBuilder<T>
+Wolfgang.Etl.FixedWidth.IFixedWidthLoaderBuilder<T>.FieldDelimiter(string delimiter) -> Wolfgang.Etl.FixedWidth.IFixedWidthLoaderBuilder<T>
+Wolfgang.Etl.FixedWidth.IFixedWidthLoaderBuilder<T>.FieldSeparator(char? separator) -> Wolfgang.Etl.FixedWidth.IFixedWidthLoaderBuilder<T>
+Wolfgang.Etl.FixedWidth.IFixedWidthLoaderBuilder<T>.HeaderConverter(System.Func<string, Wolfgang.Etl.FixedWidth.FieldContext, string> converter) -> Wolfgang.Etl.FixedWidth.IFixedWidthLoaderBuilder<T>
+Wolfgang.Etl.FixedWidth.IFixedWidthLoaderBuilder<T>.IsDryRun(bool isDryRun) -> Wolfgang.Etl.FixedWidth.IFixedWidthLoaderBuilder<T>
+Wolfgang.Etl.FixedWidth.IFixedWidthLoaderBuilder<T>.ValueConverter(System.Func<object, Wolfgang.Etl.FixedWidth.FieldContext, string> converter) -> Wolfgang.Etl.FixedWidth.IFixedWidthLoaderBuilder<T>
+Wolfgang.Etl.FixedWidth.IFixedWidthLoaderBuilder<T>.WriteHeader(bool writeHeader) -> Wolfgang.Etl.FixedWidth.IFixedWidthLoaderBuilder<T>
 Wolfgang.Etl.FixedWidth.ValidationResult
 Wolfgang.Etl.FixedWidth.ValidationResult.Action.get -> Wolfgang.Etl.FixedWidth.Enums.ValidationAction
 Wolfgang.Etl.FixedWidth.ValidationResult.Reason.get -> string?
@@ -154,6 +174,13 @@ override Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.ExtractWorkerAsync
 override Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.CreateProgressReport() -> Wolfgang.Etl.FixedWidth.FixedWidthReport
 override Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.CreateProgressTimer(System.IProgress<Wolfgang.Etl.FixedWidth.FixedWidthReport> progress) -> Wolfgang.Etl.Abstractions.IProgressTimer
 override Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.LoadWorkerAsync(System.Collections.Generic.IAsyncEnumerable<TRecord> items, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task
+static Wolfgang.Etl.FixedWidth.EtlPipelineFixedWidthExtensions.FixedWidthExtractor<T>(this Wolfgang.Etl.Abstractions.EtlPipeline pipeline, System.IO.Stream stream) -> Wolfgang.Etl.FixedWidth.IFixedWidthExtractorBuilder<T>
+static Wolfgang.Etl.FixedWidth.EtlPipelineFixedWidthExtensions.FixedWidthExtractor<T>(this Wolfgang.Etl.Abstractions.EtlPipeline pipeline, System.IO.TextReader reader) -> Wolfgang.Etl.FixedWidth.IFixedWidthExtractorBuilder<T>
+static Wolfgang.Etl.FixedWidth.EtlPipelineFixedWidthExtensions.FixedWidthExtractor<T>(this Wolfgang.Etl.Abstractions.EtlPipeline pipeline, Wolfgang.Etl.FixedWidth.FixedWidthExtractor<T> extractor) -> Wolfgang.Etl.FixedWidth.IFixedWidthExtractorBuilder<T>
+static Wolfgang.Etl.FixedWidth.EtlPipelineFixedWidthExtensions.FixedWidthExtractor<T>(this Wolfgang.Etl.Abstractions.EtlPipeline pipeline, string path) -> Wolfgang.Etl.FixedWidth.IFixedWidthExtractorBuilder<T>
+static Wolfgang.Etl.FixedWidth.EtlPipelineFixedWidthExtensions.FixedWidthLoader<T>(this Wolfgang.Etl.Abstractions.IEtlPipeline<T> pipeline, System.IO.Stream stream) -> Wolfgang.Etl.FixedWidth.IFixedWidthLoaderBuilder<T>
+static Wolfgang.Etl.FixedWidth.EtlPipelineFixedWidthExtensions.FixedWidthLoader<T>(this Wolfgang.Etl.Abstractions.IEtlPipeline<T> pipeline, System.IO.TextWriter writer) -> Wolfgang.Etl.FixedWidth.IFixedWidthLoaderBuilder<T>
+static Wolfgang.Etl.FixedWidth.EtlPipelineFixedWidthExtensions.FixedWidthLoader<T>(this Wolfgang.Etl.Abstractions.IEtlPipeline<T> pipeline, string path) -> Wolfgang.Etl.FixedWidth.IFixedWidthLoaderBuilder<T>
 static Wolfgang.Etl.FixedWidth.FixedWidthSchema.For(System.Type recordType) -> Wolfgang.Etl.FixedWidth.FixedWidthSchema
 static Wolfgang.Etl.FixedWidth.FixedWidthSchema.For<T>() -> Wolfgang.Etl.FixedWidth.FixedWidthSchema
 static Wolfgang.Etl.FixedWidth.FixedWidthTransformer<TSource, TDestination>.ByMatchingProperties() -> Wolfgang.Etl.FixedWidth.FixedWidthTransformer<TSource, TDestination>

--- a/src/Wolfgang.Etl.FixedWidth/Wolfgang.Etl.FixedWidth.csproj
+++ b/src/Wolfgang.Etl.FixedWidth/Wolfgang.Etl.FixedWidth.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net481;netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Version>0.6.0</Version>
+    <Version>0.7.0</Version>
     <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
          do not need to recompile / add binding redirects on every minor/patch
          bump. Bump only on a deliberate breaking API change. FileVersion +
@@ -55,6 +55,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.10" />
     <PackageReference Include="System.Memory" Version="4.6.3" />
     <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.17.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/EtlPipelineFixedWidthExtensionsTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/EtlPipelineFixedWidthExtensionsTests.cs
@@ -1,0 +1,499 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.FixedWidth.Enums;
+using Xunit;
+
+namespace Wolfgang.Etl.FixedWidth.Tests.Unit;
+
+/// <summary>
+/// Tests for the class-named <see cref="EtlPipelineFixedWidthExtensions"/> source factories and sink
+/// terminators that hang fixed-width extraction/loading off the generic <see cref="EtlPipeline"/> chain
+/// (issue #253). Pipeline operators are supplied as inline <c>Through</c> stages so the tests take no
+/// dependency on the LINQ-flavored operators shipped by <c>Wolfgang.Etl.Transformers</c>. Assertions are
+/// newline-agnostic (records are round-tripped, or text is normalized) so they hold on every platform.
+/// </summary>
+public sealed class EtlPipelineFixedWidthExtensionsTests : IDisposable
+{
+    private readonly string _tempDir;
+
+
+    public EtlPipelineFixedWidthExtensionsTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "etl-fixedwidth-pipeline-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDir);
+    }
+
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup; a leaked handle would surface as its own test failure.
+        }
+    }
+
+
+    [Fact]
+    public async Task Extractor_from_path_through_two_stages_to_Loader_path_round_trips_records()
+    {
+        var source = WriteTempFile
+        (
+            "source.txt",
+            Content(("Alice", "Smith", 30), ("Bob", "Jones", 25), ("Carol", "White", 35))
+        );
+        var target = Path.Combine(_tempDir, "target.txt");
+
+        await EtlPipeline
+            .Create()
+            .FixedWidthExtractor<PersonRecord>(source)
+            .Through(FilterAdults)
+            .Through(UppercaseLastNames)
+            .FixedWidthLoader<PersonRecord>(target)
+            .RunAsync();
+
+        var written = await ExtractAllAsync(target);
+
+        Assert.Equal
+        (
+            new[]
+            {
+                new PersonRecord { FirstName = "Alice", LastName = "SMITH", Age = 30 },
+                new PersonRecord { FirstName = "Carol", LastName = "WHITE", Age = 35 },
+            },
+            written
+        );
+    }
+
+
+    [Fact]
+    public async Task Extractor_from_stream_and_Loader_to_writer_leave_caller_resources_open()
+    {
+        using var sourceStream = StreamOver(Content(("Alice", "Smith", 30)));
+        using var targetWriter = new StringWriter();
+
+        await EtlPipeline
+            .Create()
+            .FixedWidthExtractor<PersonRecord>(sourceStream)
+            .FixedWidthLoader<PersonRecord>(targetWriter)
+            .RunAsync();
+
+        Assert.Equal("Alice     Smith     030", Normalize(targetWriter.ToString()).TrimEnd('\n'));
+
+        // Caller-owned resources are left open — the stream is still readable and the writer still writable.
+        Assert.True(sourceStream.CanRead);
+        targetWriter.Write("still-open");
+    }
+
+
+    [Fact]
+    public async Task Extractor_from_reader_and_Loader_to_stream_round_trips_and_leaves_stream_open()
+    {
+        using var reader = ReaderOver(Content(("Alice", "Smith", 30), ("Bob", "Jones", 25)));
+        using var targetStream = new MemoryStream();
+
+        await EtlPipeline
+            .Create()
+            .FixedWidthExtractor<PersonRecord>(reader)
+            .FixedWidthLoader<PersonRecord>(targetStream)
+            .Encoding(Utf8NoBom)
+            .RunAsync();
+
+        Assert.True(targetStream.CanWrite, "the loader must leave the caller-owned stream open");
+        Assert.Equal
+        (
+            "Alice     Smith     030\nBob       Jones     025",
+            Normalize(Utf8NoBom.GetString(targetStream.ToArray())).TrimEnd('\n')
+        );
+    }
+
+
+    [Fact]
+    public async Task Extractor_from_existing_instance_runs_and_is_not_disposed_by_the_pipeline()
+    {
+        using var reader = ReaderOver(Content(("Alice", "Smith", 30)));
+        var extractor = new FixedWidthExtractor<PersonRecord>(reader);
+        using var targetWriter = new StringWriter();
+
+        await EtlPipeline
+            .Create()
+            .FixedWidthExtractor<PersonRecord>(extractor)
+            .FixedWidthLoader<PersonRecord>(targetWriter)
+            .RunAsync();
+
+        Assert.Equal("Alice     Smith     030", Normalize(targetWriter.ToString()).TrimEnd('\n'));
+
+        // The caller still owns the reader — it must remain usable.
+        Assert.True(reader.BaseStream.CanRead);
+    }
+
+
+    [Fact]
+    public async Task Header_separator_and_delimiter_setters_round_trip_through_a_file()
+    {
+        // Start from a plain fixed-width source; the loader emits the header/separator/delimited form and
+        // the second extractor reads it back with matching configuration — no hand-authored layout.
+        var source = WriteTempFile("plain.txt", Content(("Alice", "Smith", 30), ("Bob", "Jones", 25)));
+        var target = Path.Combine(_tempDir, "delimited-out.txt");
+
+        await EtlPipeline
+            .Create()
+            .FixedWidthExtractor<PersonRecord>(source)
+            .FixedWidthLoader<PersonRecord>(target)
+            .WriteHeader(true)
+            .FieldSeparator('-')
+            .FieldDelimiter(" | ")
+            .RunAsync();
+
+        // Read the output back with the matching header/separator/delimiter configuration.
+        var records = await ToListAsync
+        (
+            EtlPipeline
+                .Create()
+                .FixedWidthExtractor<PersonRecord>(target)
+                .HasHeader(true)
+                .FieldSeparator('-')
+                .FieldDelimiter(" | ")
+                .AsAsyncEnumerable()
+        );
+
+        Assert.Equal
+        (
+            new[]
+            {
+                new PersonRecord { FirstName = "Alice", LastName = "Smith", Age = 30 },
+                new PersonRecord { FirstName = "Bob", LastName = "Jones", Age = 25 },
+            },
+            records
+        );
+    }
+
+
+    [Fact]
+    public async Task Extractor_MalformedLineHandling_Skip_and_BlankLineHandling_Skip_drop_bad_lines()
+    {
+        // A too-short line and a blank line sit among the valid records.
+        var source = WriteTempFile
+        (
+            "messy.txt",
+            "Alice     Smith     030\nshort\n\nCarol     White     035\n"
+        );
+        using var targetWriter = new StringWriter();
+
+        await EtlPipeline
+            .Create()
+            .FixedWidthExtractor<PersonRecord>(source)
+            .MalformedLineHandling(MalformedLineHandling.Skip)
+            .BlankLineHandling(BlankLineHandling.Skip)
+            .FixedWidthLoader<PersonRecord>(targetWriter)
+            .RunAsync();
+
+        Assert.Equal
+        (
+            "Alice     Smith     030\nCarol     White     035",
+            Normalize(targetWriter.ToString()).TrimEnd('\n')
+        );
+    }
+
+
+    [Fact]
+    public async Task Extractor_LineFilter_RecordValidator_and_ValueParser_setters_apply()
+    {
+        var source = WriteTempFile
+        (
+            "filtered.txt",
+            "#comment  ignore     000\nAlice     Smith     030\nBob       Jones     025\n"
+        );
+        using var targetWriter = new StringWriter();
+
+        await EtlPipeline
+            .Create()
+            .FixedWidthExtractor<PersonRecord>(source)
+            .LineFilter(line => line.StartsWith("#", StringComparison.Ordinal) ? LineAction.Skip : LineAction.Process)
+            .RecordValidator(p => p.Age >= 30 ? ValidationResult.Accept() : ValidationResult.Skip("under 30"))
+            .ValueParser(FixedWidthConverter.DefaultParser)
+            .FixedWidthLoader<PersonRecord>(targetWriter)
+            .RunAsync();
+
+        // The comment line is filtered, Bob is rejected by the validator; only Alice survives.
+        Assert.Equal("Alice     Smith     030", Normalize(targetWriter.ToString()).TrimEnd('\n'));
+    }
+
+
+    [Fact]
+    public async Task Loader_setters_including_dry_run_and_converters_are_applied()
+    {
+        var source = WriteTempFile("dry.txt", Content(("Alice", "Smith", 30)));
+        var target = Path.Combine(_tempDir, "dry-out.txt");
+
+        await EtlPipeline
+            .Create()
+            .FixedWidthExtractor<PersonRecord>(source)
+            .FixedWidthLoader<PersonRecord>(target)
+            .ValueConverter(FixedWidthConverter.Strict)
+            .HeaderConverter(FixedWidthConverter.StrictHeader)
+            .FieldSeparator(null)
+            .FieldDelimiter(null)
+            .IsDryRun(true)
+            .RunAsync();
+
+        // A dry run validates but writes nothing — the file is created empty.
+        Assert.Equal(string.Empty, File.ReadAllText(target));
+    }
+
+
+    [Fact]
+    public async Task Loader_Encoding_setter_binds_the_output_stream_encoding()
+    {
+        var source = WriteTempFile("enc.txt", Content(("Alice", "Smith", 30)));
+        var target = Path.Combine(_tempDir, "enc-out.txt");
+
+        await EtlPipeline
+            .Create()
+            .FixedWidthExtractor<PersonRecord>(source)
+            .FixedWidthLoader<PersonRecord>(target)
+            .Encoding(new UTF8Encoding(encoderShouldEmitUTF8Identifier: true))
+            .RunAsync();
+
+        var bytes = File.ReadAllBytes(target);
+
+        Assert.True
+        (
+            bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF,
+            "Expected a UTF-8 BOM, proving the loader used the configured encoding to open the file."
+        );
+    }
+
+
+    [Fact]
+    public async Task Extractor_Encoding_setter_binds_the_input_stream_encoding()
+    {
+        // Write the source as UTF-16 so a mismatched decode would corrupt it.
+        var utf16 = new UnicodeEncoding(bigEndian: false, byteOrderMark: true);
+        var target = Path.Combine(_tempDir, "utf16.txt");
+        File.WriteAllText(target, Content(("Alice", "Smith", 30)), utf16);
+
+        using var targetWriter = new StringWriter();
+
+        await EtlPipeline
+            .Create()
+            .FixedWidthExtractor<PersonRecord>(target)
+            .Encoding(utf16)
+            .FixedWidthLoader<PersonRecord>(targetWriter)
+            .RunAsync();
+
+        Assert.Equal("Alice     Smith     030", Normalize(targetWriter.ToString()).TrimEnd('\n'));
+    }
+
+
+    [Fact]
+    public async Task Path_based_source_and_sink_release_their_file_handles_after_a_successful_run()
+    {
+        var source = WriteTempFile("release.txt", Content(("Alice", "Smith", 30)));
+        var target = Path.Combine(_tempDir, "release-out.txt");
+
+        await EtlPipeline
+            .Create()
+            .FixedWidthExtractor<PersonRecord>(source)
+            .FixedWidthLoader<PersonRecord>(target)
+            .RunAsync();
+
+        // A locked file would throw IOException here.
+        File.Delete(source);
+        File.Delete(target);
+
+        Assert.False(File.Exists(source));
+        Assert.False(File.Exists(target));
+    }
+
+
+    [Fact]
+    public async Task Path_based_source_releases_its_file_handle_after_a_faulted_run()
+    {
+        var source = WriteTempFile("fault.txt", Content(("Alice", "Smith", 30)));
+        var target = Path.Combine(_tempDir, "fault-out.txt");
+
+        var run = EtlPipeline
+            .Create()
+            .FixedWidthExtractor<PersonRecord>(source)
+            .Through(ThrowOnFirst)
+            .FixedWidthLoader<PersonRecord>(target)
+            .RunAsync();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => run);
+
+        // The reader must have been disposed even though the pipeline threw.
+        File.Delete(source);
+        Assert.False(File.Exists(source));
+    }
+
+
+    [Fact]
+    public void First_pipeline_operator_narrows_the_builder_off_the_configuration_surface()
+    {
+        var source = WriteTempFile("narrow.txt", Content(("Alice", "Smith", 30)));
+
+        var builder = EtlPipeline.Create().FixedWidthExtractor<PersonRecord>(source);
+        IEtlPipeline<PersonRecord> narrowed = builder.Through(FilterAdults);
+
+        Assert.False(narrowed is IFixedWidthExtractorBuilder<PersonRecord>);
+    }
+
+
+    [Fact]
+    public void Configuring_the_extractor_after_it_is_materialized_throws()
+    {
+        var source = WriteTempFile("late.txt", Content(("Alice", "Smith", 30)));
+
+        var builder = EtlPipeline.Create().FixedWidthExtractor<PersonRecord>(source);
+        _ = builder.Through(FilterAdults);
+
+        Assert.Throws<InvalidOperationException>(() => builder.HeaderLineCount(1));
+        Assert.Throws<InvalidOperationException>(() => builder.Encoding(Utf8NoBom));
+    }
+
+
+    [Fact]
+    public void Extractor_factories_reject_null_arguments()
+    {
+        var pipeline = EtlPipeline.Create();
+
+        // Null receiver — every overload.
+        Assert.Throws<ArgumentNullException>(() => ((EtlPipeline)null!).FixedWidthExtractor<PersonRecord>("x.txt"));
+        Assert.Throws<ArgumentNullException>(() => ((EtlPipeline)null!).FixedWidthExtractor<PersonRecord>(Stream.Null));
+        Assert.Throws<ArgumentNullException>(() => ((EtlPipeline)null!).FixedWidthExtractor<PersonRecord>(TextReader.Null));
+        Assert.Throws<ArgumentNullException>(() => ((EtlPipeline)null!).FixedWidthExtractor<PersonRecord>(new FixedWidthExtractor<PersonRecord>(TextReader.Null)));
+
+        // Null argument — every overload.
+        Assert.Throws<ArgumentNullException>(() => pipeline.FixedWidthExtractor<PersonRecord>((string)null!));
+        Assert.Throws<ArgumentNullException>(() => pipeline.FixedWidthExtractor<PersonRecord>((Stream)null!));
+        Assert.Throws<ArgumentNullException>(() => pipeline.FixedWidthExtractor<PersonRecord>((TextReader)null!));
+        Assert.Throws<ArgumentNullException>(() => pipeline.FixedWidthExtractor<PersonRecord>((FixedWidthExtractor<PersonRecord>)null!));
+    }
+
+
+    [Fact]
+    public void Loader_terminators_reject_null_arguments()
+    {
+        var source = WriteTempFile("guard.txt", Content(("Alice", "Smith", 30)));
+        var pipeline = EtlPipeline.Create().FixedWidthExtractor<PersonRecord>(source);
+
+        // Null receiver — every overload.
+        Assert.Throws<ArgumentNullException>(() => ((IEtlPipeline<PersonRecord>)null!).FixedWidthLoader<PersonRecord>("x.txt"));
+        Assert.Throws<ArgumentNullException>(() => ((IEtlPipeline<PersonRecord>)null!).FixedWidthLoader<PersonRecord>(Stream.Null));
+        Assert.Throws<ArgumentNullException>(() => ((IEtlPipeline<PersonRecord>)null!).FixedWidthLoader<PersonRecord>(TextWriter.Null));
+
+        // Null argument — every overload.
+        Assert.Throws<ArgumentNullException>(() => pipeline.FixedWidthLoader<PersonRecord>((string)null!));
+        Assert.Throws<ArgumentNullException>(() => pipeline.FixedWidthLoader<PersonRecord>((Stream)null!));
+        Assert.Throws<ArgumentNullException>(() => pipeline.FixedWidthLoader<PersonRecord>((TextWriter)null!));
+    }
+
+
+    [Fact]
+    public void Extractor_and_loader_setters_reject_null_delegates_and_encodings()
+    {
+        var source = WriteTempFile("nulls.txt", Content(("Alice", "Smith", 30)));
+        var extractor = EtlPipeline.Create().FixedWidthExtractor<PersonRecord>(source);
+
+        Assert.Throws<ArgumentNullException>(() => extractor.Encoding(null!));
+        Assert.Throws<ArgumentNullException>(() => extractor.LineFilter(null!));
+        Assert.Throws<ArgumentNullException>(() => extractor.RecordValidator(null!));
+        Assert.Throws<ArgumentNullException>(() => extractor.ValueParser(null!));
+
+        var loader = EtlPipeline.Create().FixedWidthExtractor<PersonRecord>(source).FixedWidthLoader<PersonRecord>(new StringWriter());
+
+        Assert.Throws<ArgumentNullException>(() => loader.Encoding(null!));
+        Assert.Throws<ArgumentNullException>(() => loader.ValueConverter(null!));
+        Assert.Throws<ArgumentNullException>(() => loader.HeaderConverter(null!));
+    }
+
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    private static readonly UTF8Encoding Utf8NoBom = new(encoderShouldEmitUTF8Identifier: false);
+
+
+    private static string Line(string first, string last, int age)
+        => string.Format(CultureInfo.InvariantCulture, "{0,-10}{1,-10}{2:000}", first, last, age);
+
+
+    private static string Content(params (string First, string Last, int Age)[] people)
+        => string.Concat(people.Select(p => Line(p.First, p.Last, p.Age) + "\n"));
+
+
+    private static string Normalize(string text) => text.Replace("\r\n", "\n").Replace("\r", "\n");
+
+
+    private async Task<IReadOnlyList<PersonRecord>> ExtractAllAsync(string path)
+        => await ToListAsync(EtlPipeline.Create().FixedWidthExtractor<PersonRecord>(path).AsAsyncEnumerable());
+
+
+    private static async Task<IReadOnlyList<PersonRecord>> ToListAsync(IAsyncEnumerable<PersonRecord> source)
+    {
+        var list = new List<PersonRecord>();
+        await foreach (var item in source.ConfigureAwait(false))
+        {
+            list.Add(item);
+        }
+
+        return list;
+    }
+
+
+    private static async IAsyncEnumerable<PersonRecord> FilterAdults(IAsyncEnumerable<PersonRecord> source)
+    {
+        await foreach (var person in source.ConfigureAwait(false))
+        {
+            if (person.Age >= 30)
+            {
+                yield return person;
+            }
+        }
+    }
+
+
+    private static async IAsyncEnumerable<PersonRecord> UppercaseLastNames(IAsyncEnumerable<PersonRecord> source)
+    {
+        await foreach (var person in source.ConfigureAwait(false))
+        {
+            yield return person with { LastName = person.LastName.ToUpperInvariant() };
+        }
+    }
+
+
+    private static async IAsyncEnumerable<PersonRecord> ThrowOnFirst(IAsyncEnumerable<PersonRecord> source)
+    {
+        await foreach (var _ in source.ConfigureAwait(false))
+        {
+            throw new InvalidOperationException("boom");
+        }
+
+        yield break;
+    }
+
+
+    private string WriteTempFile(string name, string content)
+    {
+        var path = Path.Combine(_tempDir, name);
+        File.WriteAllText(path, content, Utf8NoBom);
+        return path;
+    }
+
+
+    private static MemoryStream StreamOver(string content) => new(Utf8NoBom.GetBytes(content));
+
+
+    private static StreamReader ReaderOver(string content) => new(StreamOver(content), Utf8NoBom);
+}

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthMetricsTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthMetricsTests.cs
@@ -1,0 +1,237 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Metrics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.FixedWidth.Attributes;
+using Wolfgang.Etl.FixedWidth.Diagnostics;
+using Wolfgang.Etl.FixedWidth.Enums;
+using Xunit;
+
+namespace Wolfgang.Etl.FixedWidth.Tests.Unit;
+
+/// <summary>
+/// Verifies the OpenTelemetry-compatible metrics emitted by the extractor and loader (#30). Each test
+/// captures measurements from a <see cref="MeterListener"/> on the <c>Wolfgang.Etl.FixedWidth</c> meter
+/// and filters by the <c>etl.record_type</c> tag of a test-private record type, so measurements from
+/// other (parallel) test classes on the same process-global meter cannot pollute the counts.
+/// </summary>
+public sealed class FixedWidthMetricsTests
+{
+    private const string MeterName = "Wolfgang.Etl.FixedWidth";
+    private const string RecordTypeName = nameof(MetricsSample);
+
+
+    [ExcludeFromCodeCoverage]
+    private sealed record MetricsSample
+    {
+        [FixedWidthField(0, 10)]
+        public string FirstName { get; set; } = string.Empty;
+
+        [FixedWidthField(1, 10)]
+        public string LastName { get; set; } = string.Empty;
+
+        [FixedWidthField(2, 3, Alignment = FieldAlignment.Right, Pad = '0')]
+        public int Age { get; set; }
+    }
+
+
+    [Fact]
+    public async Task Extraction_emits_extracted_lines_and_duration_tagged_as_extract()
+    {
+        using var capture = new MetricCapture();
+
+        var extractor = new FixedWidthExtractor<MetricsSample>
+        (
+            new StringReader(Content(("Alice", "Smith", 30), ("Bob", "Jones", 25), ("Carol", "White", 35)))
+        );
+
+        await DrainAsync(extractor);
+
+        Assert.Equal(3, capture.Sum("wolfgang.etl.fixedwidth.items.extracted"));
+        Assert.Equal(3, capture.Sum("wolfgang.etl.fixedwidth.lines.read"));
+
+        var durations = capture.Measurements("wolfgang.etl.fixedwidth.operation.duration");
+        Assert.Single(durations);
+        Assert.True(durations[0].Value >= 0);
+
+        // Every measurement carries the operation + record-type tags.
+        Assert.All(capture.All, m => Assert.Equal("extract", m.Tags["etl.operation"]));
+        Assert.All(capture.All, m => Assert.Equal(RecordTypeName, m.Tags["etl.record_type"]));
+    }
+
+
+    [Fact]
+    public async Task Skipped_items_emit_items_skipped()
+    {
+        using var capture = new MetricCapture();
+
+        var extractor = new FixedWidthExtractor<MetricsSample>
+        (
+            new StringReader(Content(("Alice", "Smith", 30), ("Bob", "Jones", 25), ("Carol", "White", 35)))
+        )
+        {
+            SkipItemCount = 2,
+        };
+
+        await DrainAsync(extractor);
+
+        Assert.Equal(2, capture.Sum("wolfgang.etl.fixedwidth.items.skipped"));
+        Assert.Equal(1, capture.Sum("wolfgang.etl.fixedwidth.items.extracted"));
+    }
+
+
+    [Fact]
+    public async Task Loading_emits_loaded_and_duration_tagged_as_load()
+    {
+        using var capture = new MetricCapture();
+
+        var writer = new StringWriter();
+        var loader = new FixedWidthLoader<MetricsSample>(writer);
+
+        await loader.LoadAsync(SampleAsync(), CancellationToken.None);
+
+        Assert.Equal(2, capture.Sum("wolfgang.etl.fixedwidth.items.loaded"));
+
+        var durations = capture.Measurements("wolfgang.etl.fixedwidth.operation.duration");
+        Assert.Single(durations);
+        Assert.True(durations[0].Value >= 0);
+
+        Assert.All(capture.All, m => Assert.Equal("load", m.Tags["etl.operation"]));
+        Assert.All(capture.All, m => Assert.Equal(RecordTypeName, m.Tags["etl.record_type"]));
+    }
+
+
+    [Fact]
+    public void Duration_scope_dispose_is_idempotent()
+    {
+        using var capture = new MetricCapture();
+
+        var tags = FixedWidthMetrics.CreateTags(FixedWidthMetrics.ExtractOperation, typeof(MetricsSample));
+        var scope = FixedWidthMetrics.MeasureDuration(tags);
+
+        scope.Dispose();
+        scope.Dispose();   // second dispose is a no-op — the duration is recorded exactly once
+
+        Assert.Single(capture.Measurements("wolfgang.etl.fixedwidth.operation.duration"));
+    }
+
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    private static async Task DrainAsync(FixedWidthExtractor<MetricsSample> extractor)
+    {
+        await foreach (var _ in extractor.ExtractAsync(CancellationToken.None).ConfigureAwait(false))
+        {
+            // Enumerating to completion disposes the extractor's duration scope, recording the histogram.
+        }
+    }
+
+
+#pragma warning disable CS1998 // synchronous sample sequence — no await needed
+    private static async IAsyncEnumerable<MetricsSample> SampleAsync()
+    {
+        yield return new MetricsSample { FirstName = "Alice", LastName = "Smith", Age = 30 };
+        yield return new MetricsSample { FirstName = "Bob", LastName = "Jones", Age = 25 };
+    }
+#pragma warning restore CS1998
+
+
+    private static string Content(params (string First, string Last, int Age)[] people)
+        => string.Concat(people.Select(p => string.Format(CultureInfo.InvariantCulture, "{0,-10}{1,-10}{2:000}\n", p.First, p.Last, p.Age)));
+
+
+    private sealed class CapturedMeasurement
+    {
+        internal CapturedMeasurement(string instrument, double value, IReadOnlyDictionary<string, object?> tags)
+        {
+            Instrument = instrument;
+            Value = value;
+            Tags = tags;
+        }
+
+        internal string Instrument { get; }
+
+        internal double Value { get; }
+
+        internal IReadOnlyDictionary<string, object?> Tags { get; }
+    }
+
+
+    /// <summary>
+    /// A <see cref="MeterListener"/> that records every measurement from the fixed-width meter tagged for
+    /// <see cref="RecordTypeName"/>. Disposing it stops the listener.
+    /// </summary>
+    private sealed class MetricCapture : IDisposable
+    {
+        private readonly MeterListener _listener;
+        private readonly List<CapturedMeasurement> _captured = new();
+
+
+        internal MetricCapture()
+        {
+            _listener = new MeterListener
+            {
+                InstrumentPublished = (instrument, listener) =>
+                {
+                    if (string.Equals(instrument.Meter.Name, MeterName, StringComparison.Ordinal))
+                    {
+                        listener.EnableMeasurementEvents(instrument);
+                    }
+                },
+            };
+
+            _listener.SetMeasurementEventCallback<long>((instrument, value, tags, _) => Record(instrument.Name, value, tags));
+            _listener.SetMeasurementEventCallback<double>((instrument, value, tags, _) => Record(instrument.Name, value, tags));
+            _listener.Start();
+        }
+
+
+        internal IReadOnlyList<CapturedMeasurement> All
+        {
+            get
+            {
+                lock (_captured)
+                {
+                    return _captured.ToList();
+                }
+            }
+        }
+
+
+        internal IReadOnlyList<CapturedMeasurement> Measurements(string instrument)
+            => All.Where(m => string.Equals(m.Instrument, instrument, StringComparison.Ordinal)).ToList();
+
+
+        internal long Sum(string instrument) => (long)Measurements(instrument).Sum(m => m.Value);
+
+
+        private void Record(string instrument, double value, ReadOnlySpan<KeyValuePair<string, object?>> tags)
+        {
+            var map = new Dictionary<string, object?>(StringComparer.Ordinal);
+            foreach (var tag in tags)
+            {
+                map[tag.Key] = tag.Value;
+            }
+
+            // Ignore measurements from other test classes on the same process-global meter.
+            if (map.TryGetValue("etl.record_type", out var recordType)
+                && string.Equals(recordType as string, RecordTypeName, StringComparison.Ordinal))
+            {
+                lock (_captured)
+                {
+                    _captured.Add(new CapturedMeasurement(instrument, value, map));
+                }
+            }
+        }
+
+
+        public void Dispose() => _listener.Dispose();
+    }
+}


### PR DESCRIPTION
The **0.7.0** release to `main` — full-CI path of the protected-file split (the one protected workflow file ships separately in #274).

## What's in 0.7.0
- **#253** — pipeline extensions: `EtlPipeline.Create().FixedWidthExtractor/FixedWidthLoader` fluent chain
- **#30** — OpenTelemetry `System.Diagnostics.Metrics` instrumentation + the `Instrument.Enabled` hot-path guard
- Version 0.6.0 → **0.7.0**, CHANGELOG `[0.7.0]`, PublicAPI promoted to Shipped, **Abstractions 0.17.0** (picked up from main's dependabot bump)

## Split rationale
Built off `main` so it carries main's dependabot updates and contains **no protected files** → the `Detect .NET Projects` guard passes and **full CI validates the code**. The lone protected change (`cross-platform-differential.yaml`, #261 hardening) is in its own admin-bypass PR so it can't skip CI on the release code.

## Sequence
1. Merge **this** (normal, full CI)
2. Merge the workflow PR (admin-bypass)
3. Tag **v0.7.0** → `release.yaml` publishes to NuGet + docs
4. After live: bump `PackageValidationBaselineVersion` → 0.7.0

`#23` schema builder (PR #264) is deferred to 0.8.0.

Closes #253
Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)