### PR TITLE
ci: cross-platform-differential zero-outcome hardening (#261)

### DIFF
--- a/.github/workflows/cross-platform-differential.yaml
+++ b/.github/workflows/cross-platform-differential.yaml
@@ -91,6 +91,22 @@ jobs:
 
       - name: Compare against linux-x64
         run: |
+          # A zero-outcome leg means its `dotnet test` produced no .trx — the run
+          # step's `|| true` masks a failed/empty test run. Report that as its own
+          # failure, not a misleading "all outcomes diverge" against an empty
+          # reference. This is almost always a transient runner flake: re-run first.
+          empty=0
+          for file in outcomes/outcomes-*/outcomes-*.txt; do
+            label=$(basename "$file" .txt | sed 's/^outcomes-//')
+            if [ ! -s "$file" ]; then
+              echo "::error::Leg '$label' produced no test outcomes — its test run failed to emit a .trx. Re-run the workflow; if it persists, investigate that leg."
+              empty=1
+            fi
+          done
+          if [ "$empty" = "1" ]; then
+            exit 1
+          fi
+
           ref="outcomes/outcomes-linux-x64/outcomes-linux-x64.txt"
           if [ ! -f "$ref" ]; then
             echo "::error::reference outcomes (linux-x64) missing"


### PR DESCRIPTION
Protected-only companion to the 0.7.0 release PR. Brings the `cross-platform-differential.yaml` zero-outcome-leg hardening (#261 / #149) — which reached vNext but not main — plus main's github-actions dependabot action-pin bumps.

**This is the protected-file half of the release split** → the `Detect .NET Projects` guard fails by design, so it needs an **admin-bypass merge**. It contains ONLY the workflow file (no src/test), so nothing skips CI.

Merge order: the [release PR](../pull/273) (normal, full CI) first, this one (admin-bypass) second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)