### PR TITLE
perf: make metrics opt-in via EnableMetrics (default off) (#275)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `EnableMetrics` property on `FixedWidthExtractor<T>` and `FixedWidthLoader<T>`
+  (default `false`) that turns the #30 metrics on. Metrics are now **opt-in**:
+  when off — the default — the extract/load hot loop executes no metric code at
+  all, restoring the pre-metrics throughput. Set `EnableMetrics = true` (and
+  subscribe via `AddMeter("Wolfgang.Etl.FixedWidth")` or a `MeterListener`) to
+  collect the counters and duration histogram ([#275]).
+
 ### Changed
+
+- The metrics added in 0.7.0 (#30) no longer emit unless `EnableMetrics` is set.
+  This removes the always-on per-line/per-record overhead that made extraction
+  ~1.5–1.95× slower in 0.7.0 regardless of whether a listener was attached
+  ([#275]).
 
 ### Deprecated
 
@@ -265,6 +277,7 @@ changes** — the shipped library is unchanged from 0.5.0.
 [#22]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/22
 [#24]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/24
 [#30]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/30
+[#275]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/275
 [#253]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/253
 [Unreleased]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.7.0...HEAD
 [0.7.0]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.6.0...v0.7.0

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ See the [PipelineExtensions](examples/PipelineExtensions) example for a complete
 
 ### Metrics and observability
 
-The extractor and loader emit standard [`System.Diagnostics.Metrics`](https://learn.microsoft.com/dotnet/core/diagnostics/metrics) instruments from the meter **`Wolfgang.Etl.FixedWidth`**, so throughput and error rates flow to OpenTelemetry, Prometheus, Grafana, Application Insights, or any `MeterListener` with no code changes. Metrics are a no-op when nothing is listening, so there is no overhead in the default case.
+The extractor and loader can emit standard [`System.Diagnostics.Metrics`](https://learn.microsoft.com/dotnet/core/diagnostics/metrics) instruments from the meter **`Wolfgang.Etl.FixedWidth`**, so throughput and error rates flow to OpenTelemetry, Prometheus, Grafana, Application Insights, or any `MeterListener`. Metrics are **opt-in**: set `EnableMetrics = true` on the extractor/loader to turn them on. When left off (the default), the extract/load loop runs **no** metric code at all, so telemetry adds zero overhead for callers that don't use it.
 
 | Instrument | Type | Description |
 |---|---|---|
@@ -262,7 +262,10 @@ The extractor and loader emit standard [`System.Diagnostics.Metrics`](https://le
 Every measurement is tagged `etl.operation` (`extract` or `load`) and `etl.record_type` (`typeof(TRecord).Name`).
 
 ```csharp
-// OpenTelemetry — one line, zero library changes:
+// 1. Opt in on the extractor/loader (default is off):
+var extractor = new FixedWidthExtractor<Order>(reader) { EnableMetrics = true };
+
+// 2. Subscribe once at startup — OpenTelemetry, zero per-call code:
 builder.Services.AddOpenTelemetry()
     .WithMetrics(m => m.AddMeter("Wolfgang.Etl.FixedWidth"));
 ```

--- a/docfx_project/docs/getting-started.md
+++ b/docfx_project/docs/getting-started.md
@@ -177,14 +177,16 @@ Every source and sink has **path**, `Stream`, and `TextReader`/`TextWriter` over
 
 ### Metrics and observability
 
-The extractor and loader emit `System.Diagnostics.Metrics` instruments from the meter `Wolfgang.Etl.FixedWidth` — counters (`items.extracted`, `items.loaded`, `items.skipped`, `lines.read`) and a duration histogram (`operation.duration`), each tagged with `etl.operation` and `etl.record_type`. Subscribe with OpenTelemetry and the telemetry flows to Prometheus, Grafana, Application Insights, and so on, with no changes to your extraction/loading code:
+The extractor and loader can emit `System.Diagnostics.Metrics` instruments from the meter `Wolfgang.Etl.FixedWidth` — counters (`items.extracted`, `items.loaded`, `items.skipped`, `lines.read`) and a duration histogram (`operation.duration`), each tagged with `etl.operation` and `etl.record_type`. Metrics are **opt-in**: set `EnableMetrics = true` on the extractor/loader, then subscribe with OpenTelemetry so the telemetry flows to Prometheus, Grafana, Application Insights, and so on:
 
 ```csharp
+var extractor = new FixedWidthExtractor<PersonRecord>(reader) { EnableMetrics = true };
+
 builder.Services.AddOpenTelemetry()
     .WithMetrics(m => m.AddMeter("Wolfgang.Etl.FixedWidth"));
 ```
 
-Metrics are a no-op when nothing is listening. See the [Metrics example](examples.md#metrics) for a raw `MeterListener` walk-through.
+When `EnableMetrics` is left off (the default), the extract/load loop runs no metric code, so there is no overhead. See the [Metrics example](examples.md#metrics) for a raw `MeterListener` walk-through.
 
 ## Next Steps
 

--- a/examples/Metrics/Program.cs
+++ b/examples/Metrics/Program.cs
@@ -70,7 +70,8 @@ var input =
     "Bob       Jones     025\n" +
     "Carol     White     035\n";
 
-var extractor = new FixedWidthExtractor<Person>(new StringReader(input)) { SkipItemCount = 1 };
+// Metrics are opt-in (default off) — set EnableMetrics to emit them.
+var extractor = new FixedWidthExtractor<Person>(new StringReader(input)) { EnableMetrics = true, SkipItemCount = 1 };
 
 var people = new List<Person>();
 await foreach (var person in extractor.ExtractAsync(CancellationToken.None))
@@ -79,7 +80,7 @@ await foreach (var person in extractor.ExtractAsync(CancellationToken.None))
 }
 
 var writer = new StringWriter();
-var loader = new FixedWidthLoader<Person>(writer);
+var loader = new FixedWidthLoader<Person>(writer) { EnableMetrics = true };
 await loader.LoadAsync(ToAsyncEnumerable(people), CancellationToken.None);
 
 // ---------------------------------------------------------------------------

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
@@ -491,6 +491,19 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
 
 
     /// <summary>
+    /// When <see langword="true"/>, the extractor emits the <c>Wolfgang.Etl.FixedWidth</c> metrics
+    /// (#30) as it runs. Defaults to <see langword="false"/> — metrics are <b>opt-in</b>. When off, the
+    /// extract loop executes no metric code at all (no per-line/record calls, no tag or duration
+    /// allocation), so telemetry adds no measurable overhead for callers that do not use it. Set to
+    /// <see langword="true"/> — and subscribe with OpenTelemetry (<c>AddMeter("Wolfgang.Etl.FixedWidth")</c>)
+    /// or a <see cref="System.Diagnostics.Metrics.MeterListener"/> — to collect the counters and the
+    /// duration histogram.
+    /// </summary>
+    public bool EnableMetrics { get; set; }
+
+
+
+    /// <summary>
     /// The 1-based physical line number of the line most recently read from the file.
     /// Updated before each line is parsed so that if an exception is thrown,
     /// this value points to the offending line. Matches the line number shown
@@ -633,10 +646,18 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
             ? HeaderLineCount + 1
             : -1;
 
-        // Metrics (#30): records the operation duration when the enumerator completes, ends early, or
-        // throws; the per-item/line counters below are no-ops unless a MeterListener is subscribed.
-        var metricTags = FixedWidthMetrics.CreateTags(FixedWidthMetrics.ExtractOperation, typeof(TRecord));
-        using var operationScope = FixedWidthMetrics.MeasureDuration(metricTags);
+        // Metrics (#30, #275): opt-in via EnableMetrics. When off (the default) the extract loop runs
+        // no metric code — the per-line/record calls below are skipped and neither the tag set nor the
+        // duration scope is allocated — so telemetry adds no measurable overhead unless the caller opts
+        // in. When on, RecordLineRead / RecordExtracted / RecordSkipped fire but are themselves no-ops
+        // unless a MeterListener is subscribed.
+        var metricsEnabled = EnableMetrics;
+        var metricTags = metricsEnabled
+            ? FixedWidthMetrics.CreateTags(FixedWidthMetrics.ExtractOperation, typeof(TRecord))
+            : default;
+        using var operationScope = metricsEnabled
+            ? FixedWidthMetrics.MeasureDuration(metricTags)
+            : null;
 
         LogExtractionStarted(fieldMap);
 
@@ -652,7 +673,10 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
             // Update before any processing so that if an exception is thrown,
             // CurrentLineNumber points to the offending line in the file.
             Interlocked.Increment(ref _currentLineNumber);
-            FixedWidthMetrics.RecordLineRead(metricTags);
+            if (metricsEnabled)
+            {
+                FixedWidthMetrics.RecordLineRead(metricTags);
+            }
 
             if (IsStructuralLine(separatorLineNo))
             {
@@ -676,7 +700,10 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
                 {
                     dataLinesSkipped++;
                     IncrementCurrentSkippedItemCount();
-                    FixedWidthMetrics.RecordSkipped(metricTags);
+                    if (metricsEnabled)
+                    {
+                        FixedWidthMetrics.RecordSkipped(metricTags);
+                    }
                     LogDebugBlankLineInSkipBudget(dataLinesSkipped);
                     continue;
                 }
@@ -691,7 +718,10 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
 
                 LogDebugBlankLineYieldedAsDefault();
                 IncrementCurrentItemCount();
-                FixedWidthMetrics.RecordExtracted(metricTags);
+                if (metricsEnabled)
+                {
+                    FixedWidthMetrics.RecordExtracted(metricTags);
+                }
                 yield return defaultRecord;
                 continue;
             }
@@ -715,7 +745,10 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
             {
                 dataLinesSkipped++;
                 IncrementCurrentSkippedItemCount();
-                FixedWidthMetrics.RecordSkipped(metricTags);
+                if (metricsEnabled)
+                {
+                    FixedWidthMetrics.RecordSkipped(metricTags);
+                }
                 LogDebugDataLineSkipped(dataLinesSkipped);
                 continue;
             }
@@ -747,7 +780,10 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
 
             LogDebugRecordParsed();
             IncrementCurrentItemCount();
-            FixedWidthMetrics.RecordExtracted(metricTags);
+            if (metricsEnabled)
+            {
+                FixedWidthMetrics.RecordExtracted(metricTags);
+            }
             yield return record;
         }
 

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthLoader.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthLoader.cs
@@ -389,6 +389,19 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
 
 
     /// <summary>
+    /// When <see langword="true"/>, the loader emits the <c>Wolfgang.Etl.FixedWidth</c> metrics (#30)
+    /// as it runs. Defaults to <see langword="false"/> — metrics are <b>opt-in</b>. When off, the load
+    /// loop executes no metric code at all (no per-record calls, no tag or duration allocation), so
+    /// telemetry adds no measurable overhead for callers that do not use it. Set to
+    /// <see langword="true"/> — and subscribe with OpenTelemetry (<c>AddMeter("Wolfgang.Etl.FixedWidth")</c>)
+    /// or a <see cref="System.Diagnostics.Metrics.MeterListener"/> — to collect the counters and the
+    /// duration histogram.
+    /// </summary>
+    public bool EnableMetrics { get; set; }
+
+
+
+    /// <summary>
     /// The 1-based physical line number of the line most recently written to the output.
     /// Updated after each line is written. Includes the header line and separator line
     /// if written. Matches the line number shown in a text editor.
@@ -471,6 +484,7 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
 
 
     /// <inheritdoc/>
+#pragma warning disable MA0051 // hot-path load loop; the metric guards (#275) are inlined intentionally so the default metrics-off path calls and allocates nothing
     protected override async Task LoadWorkerAsync
     (
         IAsyncEnumerable<TRecord> items,
@@ -480,9 +494,16 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
         var fieldMap = FieldMap.GetResult<TRecord>();
         LogLoadingStarted(fieldMap);
 
-        // Metrics (#30): duration recorded on completion/throw; counters are no-ops without a listener.
-        var metricTags = FixedWidthMetrics.CreateTags(FixedWidthMetrics.LoadOperation, typeof(TRecord));
-        using var operationScope = FixedWidthMetrics.MeasureDuration(metricTags);
+        // Metrics (#30, #275): opt-in via EnableMetrics. When off (the default) the load loop runs no
+        // metric code — the per-record calls below are skipped and neither the tag set nor the duration
+        // scope is allocated — so telemetry adds no measurable overhead unless the caller opts in.
+        var metricsEnabled = EnableMetrics;
+        var metricTags = metricsEnabled
+            ? FixedWidthMetrics.CreateTags(FixedWidthMetrics.LoadOperation, typeof(TRecord))
+            : default;
+        using var operationScope = metricsEnabled
+            ? FixedWidthMetrics.MeasureDuration(metricTags)
+            : null;
 
         // In dry-run mode, route all formatting through a throwaway writer so the
         // pipeline — including field-width validation — still runs, but nothing
@@ -507,7 +528,10 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
             if (CurrentSkippedItemCount < SkipItemCount)
             {
                 IncrementCurrentSkippedItemCount();
-                FixedWidthMetrics.RecordSkipped(metricTags);
+                if (metricsEnabled)
+                {
+                    FixedWidthMetrics.RecordSkipped(metricTags);
+                }
                 LogDebugItemSkipped();
                 continue;
             }
@@ -529,7 +553,10 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
             Interlocked.Increment(ref _currentLineNumber);
             await target.WriteLineAsync().ConfigureAwait(false);
             IncrementCurrentItemCount();
-            FixedWidthMetrics.RecordLoaded(metricTags);
+            if (metricsEnabled)
+            {
+                FixedWidthMetrics.RecordLoaded(metricTags);
+            }
             LogDebugRecordWritten();
         }
 
@@ -537,6 +564,7 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
 
         LogLoadingCompleted();
     }
+#pragma warning restore MA0051
 
 
 

--- a/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
@@ -1,1 +1,5 @@
 #nullable enable
+Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.EnableMetrics.get -> bool
+Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.EnableMetrics.set -> void
+Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.EnableMetrics.get -> bool
+Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.EnableMetrics.set -> void

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthMetricsTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthMetricsTests.cs
@@ -48,7 +48,10 @@ public sealed class FixedWidthMetricsTests
         var extractor = new FixedWidthExtractor<MetricsSample>
         (
             new StringReader(Content(("Alice", "Smith", 30), ("Bob", "Jones", 25), ("Carol", "White", 35)))
-        );
+        )
+        {
+            EnableMetrics = true,
+        };
 
         await DrainAsync(extractor);
 
@@ -75,6 +78,7 @@ public sealed class FixedWidthMetricsTests
             new StringReader(Content(("Alice", "Smith", 30), ("Bob", "Jones", 25), ("Carol", "White", 35)))
         )
         {
+            EnableMetrics = true,
             SkipItemCount = 2,
         };
 
@@ -91,7 +95,7 @@ public sealed class FixedWidthMetricsTests
         using var capture = new MetricCapture();
 
         var writer = new StringWriter();
-        var loader = new FixedWidthLoader<MetricsSample>(writer);
+        var loader = new FixedWidthLoader<MetricsSample>(writer) { EnableMetrics = true };
 
         await loader.LoadAsync(SampleAsync(), CancellationToken.None);
 
@@ -103,6 +107,27 @@ public sealed class FixedWidthMetricsTests
 
         Assert.All(capture.All, m => Assert.Equal("load", m.Tags["etl.operation"]));
         Assert.All(capture.All, m => Assert.Equal(RecordTypeName, m.Tags["etl.record_type"]));
+    }
+
+
+    [Fact]
+    public async Task Metrics_are_off_by_default_even_with_a_subscribed_listener()
+    {
+        using var capture = new MetricCapture();
+
+        // EnableMetrics defaults to false — metrics are opt-in (#275), so nothing is emitted even
+        // though a MeterListener is active.
+        var extractor = new FixedWidthExtractor<MetricsSample>
+        (
+            new StringReader(Content(("Alice", "Smith", 30), ("Bob", "Jones", 25)))
+        );
+        await DrainAsync(extractor);
+
+        var writer = new StringWriter();
+        var loader = new FixedWidthLoader<MetricsSample>(writer);
+        await loader.LoadAsync(SampleAsync(), CancellationToken.None);
+
+        Assert.Empty(capture.All);
     }
 
 


### PR DESCRIPTION
Fixes the 0.7.0 performance regression flagged by the BDN delta on #273.

## Problem
The #30 metrics instrumentation was **always on**: per-line/per-record helper calls plus a per-operation `TagList` + `Stopwatch` fired **even with no `MeterListener` subscribed**. The benchmarks (which subscribe nothing) showed the extract/load hot path was **~1.5×–1.95× slower** than 0.6.0 — a cost **every** consumer paid, not just telemetry users.

## Fix
New **`EnableMetrics`** property (default **`false`**) on `FixedWidthExtractor<T>` / `FixedWidthLoader<T>` that gates all metric code:
- **Off (default):** the extract/load loop allocates nothing and calls no metric helper — pre-metrics throughput restored, so BDN returns to baseline.
- **On:** metrics fire (and remain internally no-op unless a `MeterListener` is subscribed, via the existing `Instrument.Enabled` guard).

So metrics only fire when the caller explicitly opts in.

## Testing
- The 3 behavioural metrics tests now set `EnableMetrics = true`.
- New test: **zero measurements by default** even with an active `MeterListener` (proves the opt-in).
- Full suite **402/402**; Release clean on all TFMs; `Metrics` example verified still emitting with `EnableMetrics = true`.
- Docs (README + docfx + `Metrics` example) and CHANGELOG updated for the opt-in.

## Notes
- Public API addition (`EnableMetrics.get/set` ×2) — `PublicAPI.Unshipped` updated.
- Behaviour change vs 0.7.0: anyone who subscribed a listener in 0.7.0 and got metrics must now set `EnableMetrics = true`. Called out in the CHANGELOG `Changed`.
- First feature of the 0.8.0 cycle (alongside the deferred #23 schema builder).

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)