### PR TITLE
docs: consumer-side reproducible-build verification (#165)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -561,6 +561,60 @@ jobs:
           }
 
 
+      - name: Generate reproducible-build manifest
+        if: steps.check-packages.outputs.has-packages == 'true'
+        shell: pwsh
+        # Consumer-side reproducibility (#165): record the expected SHA-256 of each
+        # per-framework assembly (the byte-reproducible artifact) plus the toolchain
+        # that produced them, so a third party can rebuild the tag and compare. The
+        # .nupkg hashes are reference only — a .nupkg is a ZIP with per-entry
+        # timestamps and is not byte-reproducible. See docs/REPRODUCIBLE-BUILD.md.
+        run: |
+          $dir = Join-Path $PWD 'nuget-packages'
+
+          # Hash our per-TFM assembly (the byte-reproducible artifact). Skip the
+          # reference assemblies under each <tfm>/ref/ folder.
+          $binRoot = 'src/Wolfgang.Etl.FixedWidth/bin/Release'
+          $assemblies = Get-ChildItem -Path $binRoot -Recurse -Filter 'Wolfgang.Etl.FixedWidth.dll' |
+            Where-Object { $_.Directory.Name -ne 'ref' } |
+            ForEach-Object {
+              [ordered]@{
+                tfm    = $_.Directory.Name
+                file   = $_.Name
+                sha256 = (Get-FileHash -Algorithm SHA256 -Path $_.FullName).Hash.ToLowerInvariant()
+                bytes  = $_.Length
+              }
+            } | Sort-Object { $_.tfm }
+
+          $packages = Get-ChildItem -Path $dir -File |
+            Where-Object { $_.Extension -in '.nupkg', '.snupkg' } |
+            ForEach-Object {
+              [ordered]@{
+                file   = $_.Name
+                sha256 = (Get-FileHash -Algorithm SHA256 -Path $_.FullName).Hash.ToLowerInvariant()
+                bytes  = $_.Length
+              }
+            }
+
+          $manifest = [ordered]@{
+            repository         = "https://github.com/$env:GITHUB_REPOSITORY"
+            tag                = $env:GITHUB_REF_NAME
+            commit             = $env:GITHUB_SHA
+            dotnetSdk          = (dotnet --version)
+            runnerOs           = $env:RUNNER_OS
+            buildConfiguration = 'Release'
+            deterministic      = $true
+            buildCommand       = 'dotnet build -c Release -p:ContinuousIntegrationBuild=true'
+            note               = 'Verify the per-framework assembly hashes; .nupkg files embed timestamps and are not byte-reproducible. See docs/REPRODUCIBLE-BUILD.md.'
+            assemblies         = @($assemblies)
+            packages           = @($packages)
+          }
+
+          $path = Join-Path $dir 'reproducible-build-manifest.json'
+          $manifest | ConvertTo-Json -Depth 6 | Set-Content -Path $path -Encoding utf8
+          Write-Host "Wrote $path"
+          Get-Content $path
+
       - name: Upload NuGet packages
         uses: actions/upload-artifact@v7
         with:
@@ -795,5 +849,6 @@ jobs:
             ./nuget-packages/*.nupkg
             ./nuget-packages/*.snupkg
             ./nuget-packages/*.bom.json
+            ./nuget-packages/reproducible-build-manifest.json
             release-coverage.zip
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- Consumer-side reproducible-build verification ([#165]): each release now
+  attaches a `reproducible-build-manifest.json` (expected per-framework assembly
+  SHA-256 hashes + the exact toolchain), and `docs/REPRODUCIBLE-BUILD.md` plus a
+  README "Verify the build" section document how a third party rebuilds the tag,
+  compares hashes, files a discrepancy, and publishes an independent verification
+  attestation.
+
 ## [0.7.0] - 2026-07-24
 
 Pipeline composition and observability. Additive — no breaking changes.
@@ -277,6 +284,7 @@ changes** — the shipped library is unchanged from 0.5.0.
 [#22]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/22
 [#24]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/24
 [#30]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/30
+[#165]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/165
 [#275]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/275
 [#253]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/253
 [Unreleased]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.7.0...HEAD

--- a/README.md
+++ b/README.md
@@ -439,6 +439,28 @@ docfx build --serve
 
 ---
 
+## 🔐 Verify the build
+
+The library is built **deterministically**, so you can rebuild the exact
+assemblies from the tagged source and confirm a NuGet release was built from that
+source and nothing else. Every GitHub release attaches a
+`reproducible-build-manifest.json` with the expected per-framework assembly
+hashes and the toolchain that produced them.
+
+```bash
+# Download the manifest for a release, rebuild at the tag, and compare hashes.
+gh release download v0.8.0 --repo Chris-Wolfgang/ETL-FixedWidth --pattern reproducible-build-manifest.json
+git clone --depth 1 --branch v0.8.0 https://github.com/Chris-Wolfgang/ETL-FixedWidth
+dotnet build ETL-FixedWidth/src/Wolfgang.Etl.FixedWidth/Wolfgang.Etl.FixedWidth.csproj -c Release -p:ContinuousIntegrationBuild=true
+find ETL-FixedWidth/src/Wolfgang.Etl.FixedWidth/bin/Release -name 'Wolfgang.Etl.FixedWidth.dll' -exec sha256sum {} \;
+```
+
+See **[docs/REPRODUCIBLE-BUILD.md](docs/REPRODUCIBLE-BUILD.md)** for the full
+procedure — which SDK version to use, how to file a discrepancy, and how to
+publish a third-party verification attestation.
+
+---
+
 ## 🤝 Contributing
 
 Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for:

--- a/docs/REPRODUCIBLE-BUILD.md
+++ b/docs/REPRODUCIBLE-BUILD.md
@@ -1,0 +1,108 @@
+# Reproducible builds — verify it yourself
+
+`Wolfgang.Etl.FixedWidth` is built deterministically, so anyone can rebuild the
+exact same compiled assemblies from the tagged source and confirm the release on
+NuGet was built from that source and nothing else. This page is the **consumer
+side** of that guarantee: how *you* independently verify a release.
+
+> Related: [`reproducible-build.yaml`](../.github/workflows/reproducible-build.yaml)
+> proves the build is reproducible on every PR (it builds the same commit twice in
+> different paths and fails if the assemblies differ). This document is about a
+> third party reproducing it out-of-band.
+
+## What is reproducible
+
+The unit of verification is the **compiled assembly** — one
+`Wolfgang.Etl.FixedWidth.dll` per target framework
+(`net462`, `net481`, `netstandard2.0`, `net8.0`, `net10.0`). These are
+byte-for-byte reproducible because the build sets:
+
+- `Deterministic` (default) — no timestamps or random GUIDs baked into the IL;
+- `ContinuousIntegrationBuild=true` on CI — normalizes source paths to `/_/` so
+  the checkout directory doesn't affect output;
+- `EmbedUntrackedSources` + SourceLink — provenance is embedded deterministically.
+
+> **NuGet packages (`.nupkg`) are *not* byte-for-byte reproducible.** A `.nupkg`
+> is a ZIP and records per-entry timestamps, so its hash varies between builds.
+> The manifest lists the package hashes for reference, but **verify the
+> assemblies**, not the package.
+
+## The per-release manifest
+
+Every GitHub release attaches **`reproducible-build-manifest.json`**, produced by
+[`release.yaml`](../.github/workflows/release.yaml) from the exact build that was
+published. It records the expected assembly hashes plus the toolchain that
+produced them:
+
+```jsonc
+{
+  "tag": "v0.8.0",
+  "commit": "…",
+  "dotnetSdk": "10.0.100",          // the SDK you must use to reproduce
+  "runnerOs": "Windows",
+  "buildConfiguration": "Release",
+  "assemblies": [
+    { "tfm": "net10.0", "file": "Wolfgang.Etl.FixedWidth.dll", "sha256": "…" },
+    …
+  ],
+  "packages": [                      // reference only — not byte-reproducible
+    { "file": "Wolfgang.Etl.FixedWidth.0.8.0.nupkg", "sha256": "…" }
+  ]
+}
+```
+
+Download it from the release page, or with the CLI:
+
+```bash
+gh release download v0.8.0 --repo Chris-Wolfgang/ETL-FixedWidth --pattern reproducible-build-manifest.json
+```
+
+## Reproduce it
+
+You need the **same .NET SDK version** the manifest records in `dotnetSdk`
+(a different SDK ships a different Roslyn and may emit different IL). Install it
+from <https://dotnet.microsoft.com/download/dotnet>.
+
+```bash
+# 1. Clone the source at the exact published tag.
+git clone --depth 1 --branch v0.8.0 https://github.com/Chris-Wolfgang/ETL-FixedWidth
+cd ETL-FixedWidth
+
+# 2. Build Release with the CI determinism flag (matches the release build).
+dotnet build src/Wolfgang.Etl.FixedWidth/Wolfgang.Etl.FixedWidth.csproj \
+  -c Release -p:ContinuousIntegrationBuild=true
+
+# 3. Hash each per-TFM assembly and compare against the manifest.
+find src/Wolfgang.Etl.FixedWidth/bin/Release -name 'Wolfgang.Etl.FixedWidth.dll' \
+  -exec sha256sum {} \;
+```
+
+If your `sha256` values match the manifest's `assemblies[].sha256`, the published
+release is reproducible from source on your machine.
+
+## If a hash does not match
+
+A mismatch is worth reporting — it may be a determinism regression, a
+toolchain difference, or something more serious.
+
+1. Double-check you used the **exact** `dotnetSdk` from the manifest
+   (`dotnet --version` must match) and passed `-p:ContinuousIntegrationBuild=true`.
+2. [Open an issue](https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/new)
+   titled `reproducible-build discrepancy: <tag>` and include: the tag, your
+   `dotnet --version`, your OS, and the assembly hashes you got versus the
+   manifest's. Label it `maintenance - security`.
+
+## Publish a third-party verification attestation
+
+Independent verifications make the guarantee stronger than a single publisher's
+claim. If you reproduced a release, you can publish an attestation others can
+find:
+
+- **Reproducible Builds conventions** — follow
+  <https://reproducible-builds.org/docs/> to record your environment and result.
+- **[vouchsafe.io](https://vouchsafe.io/)** (or a similar attestation service) —
+  publish a signed statement that tag `vX.Y.Z` reproduced to the manifest hashes
+  in your environment, and link it back on the release discussion.
+
+Link your attestation in a comment on the release so future consumers can find
+corroborating verifications.


### PR DESCRIPTION
Closes #165. The round-3 reproducible-build work proved *our* build is reproducible; this is the consumer-side flip — how a third party independently verifies a release was built from the tagged source.

## What
- **`release.yaml`** — after pack, emits **`reproducible-build-manifest.json`** (per-TFM assembly SHA-256 + `tag`/`commit`/`dotnetSdk`/`runnerOs` + build command; `.nupkg` hashes for reference) and attaches it to the GitHub Release.
- **`docs/REPRODUCIBLE-BUILD.md`** — full procedure: which SDK to use, clone-at-tag + `dotnet build -p:ContinuousIntegrationBuild=true`, compare assembly hashes, file a discrepancy, and publish a third-party attestation (Reproducible Builds / vouchsafe.io).
- **README** — a "Verify the build" section linking the doc.

## Design note
The **assembly** is the unit of verification — deterministic + `ContinuousIntegrationBuild` + SourceLink make the per-TFM `.dll` byte-reproducible. `.nupkg` files are ZIPs with per-entry timestamps and are **not** byte-reproducible, so the manifest lists their hashes for reference only and the docs point verifiers at the assemblies.

## Verified
- `release.yaml` is valid YAML; the manifest-generation PowerShell was run locally against a Release build — produces valid JSON with correct per-TFM hashes for all 5 TFMs (net462/net481/netstandard2.0/net8.0/net10.0).

## Note
- **Protected file:** `release.yaml` changes, so the `Detect .NET Projects` guard will flag this PR — needs the protected-file split / admin-bypass at merge. Docs + README are non-protected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)