### PR TITLE
test: sustained-load GC / allocation profiling (#152)

### DIFF
--- a/.github/workflows/gc-profile.yaml
+++ b/.github/workflows/gc-profile.yaml
@@ -1,0 +1,69 @@
+name: GC Profile
+
+# Sustained-load GC / allocation profiling (#152).
+#
+# BDN micro-benchmarks measure single-call cost; this measures what only shows up
+# under long-running server / ETL load. tools/GcProfile runs extract -> transform
+# -> load in a tight loop for GC_PROFILE_SECONDS, then reports allocated bytes per
+# record and gen2 collections per million records. The run is gated against
+# docs/gc-baseline.json: a per-record allocation jump (hot-path regression) or any
+# meaningful gen2 promotion (retention leak) fails the job.
+
+on:
+  schedule:
+    - cron: '23 5 1 * *'   # 1st of each month, 05:23 UTC (runs from the default branch)
+  workflow_dispatch:
+    inputs:
+      seconds:
+        description: 'GC_PROFILE_SECONDS (sustained-load duration)'
+        required: false
+        default: '600'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gc-profile-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gc-profile:
+    name: Sustained-load GC profile
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      GC_PROFILE_SECONDS: ${{ github.event.inputs.seconds || '600' }}
+      GC_PROFILE_OUT: gc-run.json
+      PROJ: tools/GcProfile/Wolfgang.Etl.FixedWidth.GcProfile.csproj
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Run sustained-load profiler
+        run: dotnet run --project "$PROJ" -c Release
+
+      - name: Summarize
+        if: always()
+        run: |
+          echo '### Sustained-load GC profile' >> "$GITHUB_STEP_SUMMARY"
+          echo '```json' >> "$GITHUB_STEP_SUMMARY"
+          cat gc-run.json >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || echo '(no run produced)' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload GC run
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: gc-run
+          path: gc-run.json
+          if-no-files-found: warn
+
+      - name: Compare against baseline
+        run: python3 tools/GcProfile/compare.py gc-run.json docs/gc-baseline.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   all, restoring the pre-metrics throughput. Set `EnableMetrics = true` (and
   subscribe via `AddMeter("Wolfgang.Etl.FixedWidth")` or a `MeterListener`) to
   collect the counters and duration histogram ([#275]).
+- Sustained-load GC / allocation profiling ([#152]): `tools/GcProfile` runs
+  extract → transform → load in a tight loop for a configurable duration and
+  reports allocated bytes per record and gen2 collections per million records.
+  A monthly `gc-profile.yaml` sweep gates the run against `docs/gc-baseline.json`
+  — a per-record allocation jump (hot-path regression) or gen2 promotion
+  (retention leak) fails the job. Complements the per-call allocation snapshot in
+  `docs/ALLOCATION-PROFILE.md` (#157).
 
 ### Changed
 
@@ -277,6 +284,7 @@ changes** — the shipped library is unchanged from 0.5.0.
 [#22]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/22
 [#24]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/24
 [#30]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/30
+[#152]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/152
 [#275]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/275
 [#253]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/253
 [Unreleased]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.7.0...HEAD

--- a/docs/gc-baseline.json
+++ b/docs/gc-baseline.json
@@ -1,0 +1,6 @@
+{
+  "_comment": "Sustained-load GC baseline for #152. Regenerate by running tools/GcProfile and updating these references in a reviewed PR. allocatedBytesPerRecord is environment-sensitive (GC mode, JIT version) so it carries a wide tolerance and only catches a gross hot-path allocation regression; gen2CollectionsPerMillion is the environment-robust retention-leak gate (a materializing streaming library should promote ~nothing to gen2).",
+  "capturedOn": "windows-local, ServerGC, net10.0, 15s (~49.5M records)",
+  "allocatedBytesPerRecord": { "reference": 340.0, "tolerancePercent": 25 },
+  "gen2CollectionsPerMillion": { "max": 1.0 }
+}

--- a/tools/GcProfile/Program.cs
+++ b/tools/GcProfile/Program.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.FixedWidth;
+using Wolfgang.Etl.FixedWidth.Attributes;
+using Wolfgang.Etl.FixedWidth.Enums;
+
+namespace Wolfgang.Etl.FixedWidth.GcProfile;
+
+// Sustained-load GC / allocation profiler (#152). Runs extract -> transform ->
+// load in a tight loop for a configurable duration, then reports the two metrics
+// that actually matter for a materializing streaming library under long-running
+// server / ETL load:
+//   * allocatedBytesPerRecord      — catches a hot-path allocation regression;
+//   * gen2CollectionsPerMillion    — catches a retention leak (records or state
+//                                     surviving into gen2 when they shouldn't).
+// Emits JSON to stdout and (if GC_PROFILE_OUT is set) to that file. The scheduled
+// workflow compares against docs/gc-baseline.json and fails on regression.
+internal static class Program
+{
+    private const int BatchLines = 1000;
+
+    private static async Task<int> Main(string[] args)
+    {
+        var seconds = ResolveSeconds(args);
+        var batch = BuildBatch(BatchLines);
+
+        // Warm up: JIT the paths and populate the process-global caches so the
+        // measured window reflects steady state, not first-use cost.
+        await ProcessOnceAsync(batch).ConfigureAwait(false);
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        var json = await MeasureAsync(batch, seconds).ConfigureAwait(false);
+
+        Console.WriteLine(json);
+
+        var outPath = Environment.GetEnvironmentVariable("GC_PROFILE_OUT");
+        if (!string.IsNullOrEmpty(outPath))
+        {
+            await File.WriteAllTextAsync(outPath, json, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)).ConfigureAwait(false);
+        }
+
+        return 0;
+    }
+
+
+    private static async Task<string> MeasureAsync(string batch, int seconds)
+    {
+        var allocStart = GC.GetTotalAllocatedBytes(precise: true);
+        var g0 = GC.CollectionCount(0);
+        var g1 = GC.CollectionCount(1);
+        var g2 = GC.CollectionCount(2);
+
+        long records = 0;
+        var sw = Stopwatch.StartNew();
+        var deadline = TimeSpan.FromSeconds(seconds);
+        while (sw.Elapsed < deadline)
+        {
+            records += await ProcessOnceAsync(batch).ConfigureAwait(false);
+        }
+
+        sw.Stop();
+
+        var allocated = GC.GetTotalAllocatedBytes(precise: true) - allocStart;
+        var gen2 = GC.CollectionCount(2) - g2;
+        var mem = GC.GetGCMemoryInfo();
+        var perRecord = records == 0 ? 0d : (double)allocated / records;
+        var gen2PerMillion = records == 0 ? 0d : gen2 / (records / 1_000_000d);
+
+        return new StringBuilder()
+            .Append('{').Append('\n')
+            .AppendField("recordsProcessed", records).Append(",\n")
+            .AppendField("elapsedSeconds", Math.Round(sw.Elapsed.TotalSeconds, 2)).Append(",\n")
+            .AppendField("recordsPerSecond", Math.Round(records / sw.Elapsed.TotalSeconds, 0)).Append(",\n")
+            .AppendField("allocatedBytesTotal", allocated).Append(",\n")
+            .AppendField("allocatedBytesPerRecord", Math.Round(perRecord, 1)).Append(",\n")
+            .AppendField("gen0Collections", GC.CollectionCount(0) - g0).Append(",\n")
+            .AppendField("gen1Collections", GC.CollectionCount(1) - g1).Append(",\n")
+            .AppendField("gen2Collections", gen2).Append(",\n")
+            .AppendField("gen2CollectionsPerMillion", Math.Round(gen2PerMillion, 3)).Append(",\n")
+            .AppendField("heapSizeBytes", mem.HeapSizeBytes).Append(",\n")
+            .AppendField("fragmentedBytes", mem.FragmentedBytes).Append('\n')
+            .Append('}')
+            .ToString();
+    }
+
+
+    private static async Task<int> ProcessOnceAsync(string batch)
+    {
+        var people = new List<PersonRecord>(BatchLines);
+        using (var extractor = new FixedWidthExtractor<PersonRecord>(new StringReader(batch)))
+        {
+            await foreach (var r in extractor.ExtractAsync(CancellationToken.None).ConfigureAwait(false))
+            {
+                people.Add(r);
+            }
+        }
+
+        var transformer = FixedWidthTransformer<PersonRecord, PersonRecord>.ByMatchingProperties();
+        var transformed = new List<PersonRecord>(people.Count);
+        await foreach (var r in transformer.TransformAsync(ToAsync(people), CancellationToken.None).ConfigureAwait(false))
+        {
+            transformed.Add(r);
+        }
+
+        using (var loader = new FixedWidthLoader<PersonRecord>(TextWriter.Null))
+        {
+            await loader.LoadAsync(ToAsync(transformed), CancellationToken.None).ConfigureAwait(false);
+        }
+
+        return transformed.Count;
+    }
+
+
+    private static int ResolveSeconds(string[] args)
+    {
+        if (args.Length > 0 && int.TryParse(args[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var a) && a > 0)
+        {
+            return a;
+        }
+
+        return int.TryParse(Environment.GetEnvironmentVariable("GC_PROFILE_SECONDS"), NumberStyles.Integer, CultureInfo.InvariantCulture, out var e) && e > 0
+            ? e
+            : 10;
+    }
+
+
+    private static string BuildBatch(int lines)
+    {
+        var sb = new StringBuilder(lines * 24);
+        for (var i = 0; i < lines; i++)
+        {
+            sb.AppendFormat(CultureInfo.InvariantCulture, "{0,-10}{1,-10}{2:000}\n", $"First{i % 997}", $"Last{i % 991}", i % 120);
+        }
+
+        return sb.ToString();
+    }
+
+
+#pragma warning disable CS1998
+    private static async IAsyncEnumerable<PersonRecord> ToAsync(IEnumerable<PersonRecord> items)
+    {
+        foreach (var item in items)
+        {
+            yield return item;
+        }
+    }
+#pragma warning restore CS1998
+
+
+    private sealed class PersonRecord
+    {
+        [FixedWidthField(0, 10)]
+        public string FirstName { get; set; } = string.Empty;
+
+        [FixedWidthField(1, 10)]
+        public string LastName { get; set; } = string.Empty;
+
+        [FixedWidthField(2, 3, Alignment = FieldAlignment.Right, Pad = '0')]
+        public int Age { get; set; }
+    }
+
+
+    private static StringBuilder AppendField(this StringBuilder sb, string name, long value)
+        => sb.Append("  \"").Append(name).Append("\": ").Append(value.ToString(CultureInfo.InvariantCulture));
+
+
+    private static StringBuilder AppendField(this StringBuilder sb, string name, double value)
+        => sb.Append("  \"").Append(name).Append("\": ").Append(value.ToString(CultureInfo.InvariantCulture));
+}

--- a/tools/GcProfile/Wolfgang.Etl.FixedWidth.GcProfile.csproj
+++ b/tools/GcProfile/Wolfgang.Etl.FixedWidth.GcProfile.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Sustained-load GC / allocation profiler (#152). Deliberately NOT in
+    "ETL Fixed Width.slnx": it is a long-running console harness driven by the
+    scheduled gc-profile.yaml workflow, not a unit test. It runs extract ->
+    transform -> load in a tight loop for a configurable duration and emits GC
+    metrics as JSON; the workflow compares them against docs/gc-baseline.json and
+    fails on a per-record allocation or gen2-retention regression.
+  -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.FixedWidth\Wolfgang.Etl.FixedWidth.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/GcProfile/compare.py
+++ b/tools/GcProfile/compare.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Gate a sustained-load GC run against the committed baseline (#152).
+
+Usage: compare.py <run.json> <baseline.json>
+
+Fails (exit 1) when the per-record allocation exceeds the baseline reference by
+more than its tolerance, or when gen2 collections per million records exceed the
+baseline max (a retention leak). Prints a summary either way.
+"""
+import json
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: compare.py <run.json> <baseline.json>", file=sys.stderr)
+        return 2
+
+    with open(sys.argv[1], encoding="utf-8-sig") as f:
+        run = json.load(f)
+    with open(sys.argv[2], encoding="utf-8-sig") as f:
+        base = json.load(f)
+
+    failures = []
+
+    per_record = float(run["allocatedBytesPerRecord"])
+    ref = float(base["allocatedBytesPerRecord"]["reference"])
+    tol = float(base["allocatedBytesPerRecord"]["tolerancePercent"]) / 100.0
+    ceiling = ref * (1.0 + tol)
+    ok = per_record <= ceiling
+    print(f"allocatedBytesPerRecord: {per_record:.1f}  (baseline {ref:.1f}, ceiling {ceiling:.1f})  {'OK' if ok else 'REGRESSION'}")
+    if not ok:
+        failures.append(f"allocatedBytesPerRecord {per_record:.1f} > ceiling {ceiling:.1f}")
+
+    gen2 = float(run["gen2CollectionsPerMillion"])
+    gen2_max = float(base["gen2CollectionsPerMillion"]["max"])
+    ok = gen2 <= gen2_max
+    print(f"gen2CollectionsPerMillion: {gen2:.3f}  (max {gen2_max:.3f})  {'OK' if ok else 'LEAK'}")
+    if not ok:
+        failures.append(f"gen2CollectionsPerMillion {gen2:.3f} > max {gen2_max:.3f}")
+
+    print(f"recordsProcessed: {run.get('recordsProcessed')}  recordsPerSecond: {run.get('recordsPerSecond')}")
+
+    if failures:
+        print("\nGC REGRESSION:\n  - " + "\n  - ".join(failures), file=sys.stderr)
+        return 1
+
+    print("\nGC profile within baseline.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #152. BDN micro-benchmarks measure single-call cost; this measures what only surfaces under long-running server/ETL load.

## What
- **`tools/GcProfile`** — runs extract → transform → load in a tight loop for `GC_PROFILE_SECONDS` and reports the two metrics that matter for a *materializing* streaming library:
  - **`allocatedBytesPerRecord`** — a hot-path allocation regression;
  - **`gen2CollectionsPerMillion`** — a retention leak (should be ~0; a streaming library promotes ~nothing to gen2).
- **`docs/gc-baseline.json`** — committed baseline + tolerance (wide on bytes/record since it's GC-mode/JIT-sensitive; strict on gen2 since a leak is environment-robust).
- **`tools/GcProfile/compare.py`** — gates a run against the baseline.
- **`gc-profile.yaml`** — monthly 10-min sweep + compare (uploads the run JSON, prints it to the step summary).

## Design note
Per `docs/ALLOCATION-PROFILE.md` (#157), this is a materializing library — per-call zero-alloc assertions aren't meaningful. So the sustained gate targets **steady-state** behavior: stable bytes/record + no gen2 growth. That catches real regressions (a hot-path alloc, or retained state leaking into gen2) without pinning to an arbitrary micro-threshold.

## Verified locally
- 15 s / **~49.5M records** at **337.6 bytes/record, gen2 = 0**, heap stable at ~700 KB (no leak).
- `compare.py` **passes** on the real run and **fails** on an injected regression (both metrics) — exit codes correct.

## Note
- **Protected file:** `gc-profile.yaml` is a new workflow → the `Detect .NET Projects` guard will flag this PR; needs the protected-file split / admin-bypass at merge. (Harness, baseline, compare are non-protected.)
- The baseline reference was captured on Windows/ServerGC; it can be re-tuned from the first CI run if ubuntu differs (tolerance is generous).

🤖 Generated with [Claude Code](https://claude.com/claude-code)