### PR TITLE
test: shadow-testing sample workloads (#140)

### DIFF
--- a/.github/workflows/shadow.yaml
+++ b/.github/workflows/shadow.yaml
@@ -1,0 +1,64 @@
+name: Shadow Workloads
+
+# Shadow-testing against realistic consumer workloads (#140).
+#
+# Unit + property tests prove behaviour on synthetic input; these run realistic
+# end-to-end scenarios (streaming round trip, reformat transform, pipeline
+# composition) nightly and gate them against docs/shadow-baseline.json.
+# allocatedBytes is the hard gate (deterministic managed allocation); medianMs is
+# advisory — wall-clock on shared runners is too noisy to fail on, so it is
+# reported but does not fail the job. Distinct from the P2 BDN gh-pages trend
+# chart: this runs whole-scenario consumer flows, not curated micro-benchmarks.
+
+on:
+  schedule:
+    - cron: '41 3 * * *'   # nightly 03:41 UTC (runs from the default branch)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: shadow-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  shadow:
+    name: Shadow workloads vs baseline
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      SHADOW_OUT: shadow-run.json
+      PROJ: samples/ShadowWorkloads/Wolfgang.Etl.FixedWidth.ShadowWorkloads.csproj
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Run shadow workloads
+        run: dotnet run --project "$PROJ" -c Release -- --measure
+
+      - name: Summarize
+        if: always()
+        run: |
+          echo '### Shadow workloads' >> "$GITHUB_STEP_SUMMARY"
+          echo '```json' >> "$GITHUB_STEP_SUMMARY"
+          cat shadow-run.json >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || echo '(no run produced)' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload shadow run
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: shadow-run
+          path: shadow-run.json
+          if-no-files-found: warn
+
+      - name: Compare against baseline
+        run: python3 samples/ShadowWorkloads/compare.py shadow-run.json docs/shadow-baseline.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   all, restoring the pre-metrics throughput. Set `EnableMetrics = true` (and
   subscribe via `AddMeter("Wolfgang.Etl.FixedWidth")` or a `MeterListener`) to
   collect the counters and duration histogram ([#275]).
+- Shadow-testing sample workloads ([#140]): `samples/ShadowWorkloads` runs
+  realistic end-to-end scenarios (streaming round trip, reformat transform,
+  pipeline composition) that double as usage documentation. A nightly
+  `shadow.yaml` measures per-scenario latency + allocation and gates the result
+  against `docs/shadow-baseline.json` — allocation is the hard gate (a >50% jump
+  fails); latency is advisory (reported, not gated, since shared-runner wall-clock
+  is too noisy to fail on reliably).
 
 ### Changed
 
@@ -277,6 +284,7 @@ changes** — the shipped library is unchanged from 0.5.0.
 [#22]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/22
 [#24]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/24
 [#30]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/30
+[#140]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/140
 [#275]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/275
 [#253]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/253
 [Unreleased]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.7.0...HEAD

--- a/docs/shadow-baseline.json
+++ b/docs/shadow-baseline.json
@@ -1,0 +1,11 @@
+{
+  "_comment": "Shadow-workload baseline for #140. Regenerate by running samples/ShadowWorkloads in measure mode and updating these references in a reviewed PR. allocatedBytes is the HARD gate (deterministic managed allocation; a >allocTolerancePercent jump fails the nightly). medianMs is ADVISORY only: wall-clock on shared GitHub-hosted runners is too noisy to gate reliably — it is reported and flagged past latencyTolerancePercent but does not fail the job. Reliable latency gating would need a dedicated runner.",
+  "capturedOn": "windows-local, net10.0, 20000 records/scenario, 15 measured iterations",
+  "allocTolerancePercent": 50,
+  "latencyTolerancePercent": 20,
+  "scenarios": {
+    "streaming_round_trip": { "allocatedBytes": 11746947, "medianMs": 40.11 },
+    "reformat_transform": { "allocatedBytes": 13027700, "medianMs": 17.93 },
+    "pipeline_composition": { "allocatedBytes": 11587808, "medianMs": 15.80 }
+  }
+}

--- a/samples/ShadowWorkloads/Program.cs
+++ b/samples/ShadowWorkloads/Program.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.FixedWidth;
+using Wolfgang.Etl.FixedWidth.Attributes;
+using Wolfgang.Etl.FixedWidth.Enums;
+
+namespace Wolfgang.Etl.FixedWidth.ShadowWorkloads;
+
+// Shadow-testing sample workloads (#140). Each scenario is a realistic end-to-end
+// consumer flow written as readable usage (it doubles as documentation). Run with
+// no args to execute each once and print a summary; run with `--measure` to emit
+// per-scenario latency + allocation JSON for the nightly regression gate.
+internal static class Program
+{
+    private const int Lines = 20_000;
+    private const int Warmup = 3;
+    private const int Measured = 15;
+
+    private static readonly (string Name, Func<string, Task<int>> Run)[] Scenarios =
+    {
+        ("streaming_round_trip", StreamingRoundTripAsync),
+        ("reformat_transform", ReformatTransformAsync),
+        ("pipeline_composition", PipelineCompositionAsync),
+    };
+
+
+    private static async Task<int> Main(string[] args)
+    {
+        var data = BuildData(Lines);
+
+        if (args.Contains("--measure"))
+        {
+            await MeasureAllAsync(data).ConfigureAwait(false);
+        }
+        else
+        {
+            foreach (var (name, run) in Scenarios)
+            {
+                var count = await run(data).ConfigureAwait(false);
+                Console.WriteLine($"{name}: {count} records");
+            }
+        }
+
+        return 0;
+    }
+
+
+    // --- Scenario 1: stream a large fixed-width file straight through -----------
+    private static async Task<int> StreamingRoundTripAsync(string data)
+    {
+        var count = 0;
+        using var extractor = new FixedWidthExtractor<Customer>(new StringReader(data));
+        using var loader = new FixedWidthLoader<Customer>(TextWriter.Null);
+
+        var buffer = new List<Customer>(Lines);
+        await foreach (var customer in extractor.ExtractAsync(CancellationToken.None).ConfigureAwait(false))
+        {
+            buffer.Add(customer);
+            count++;
+        }
+
+        await loader.LoadAsync(ToAsync(buffer), CancellationToken.None).ConfigureAwait(false);
+        return count;
+    }
+
+
+    // --- Scenario 2: reformat one layout to another via same-name mapping -------
+    private static async Task<int> ReformatTransformAsync(string data)
+    {
+        var count = 0;
+        using var extractor = new FixedWidthExtractor<Customer>(new StringReader(data));
+        var transformer = FixedWidthTransformer<Customer, Customer>.ByMatchingProperties();
+        using var loader = new FixedWidthLoader<Customer>(TextWriter.Null);
+
+        var transformed = transformer.TransformAsync(extractor.ExtractAsync(CancellationToken.None), CancellationToken.None);
+        var buffer = new List<Customer>(Lines);
+        await foreach (var customer in transformed.ConfigureAwait(false))
+        {
+            buffer.Add(customer);
+            count++;
+        }
+
+        await loader.LoadAsync(ToAsync(buffer), CancellationToken.None).ConfigureAwait(false);
+        return count;
+    }
+
+
+    // --- Scenario 3: compose the whole flow as one EtlPipeline chain ------------
+    private static async Task<int> PipelineCompositionAsync(string data)
+    {
+        await EtlPipeline
+            .Create()
+            .FixedWidthExtractor<Customer>(new StringReader(data))
+            .FixedWidthLoader<Customer>(TextWriter.Null)
+            .RunAsync()
+            .ConfigureAwait(false);
+
+        return Lines;
+    }
+
+
+    // --- Measurement ------------------------------------------------------------
+    private static async Task MeasureAllAsync(string data)
+    {
+        var results = new List<string>();
+        foreach (var (name, run) in Scenarios)
+        {
+            results.Add(await MeasureOneAsync(name, run, data).ConfigureAwait(false));
+        }
+
+        var json = "[\n" + string.Join(",\n", results) + "\n]";
+        Console.WriteLine(json);
+
+        var outPath = Environment.GetEnvironmentVariable("SHADOW_OUT");
+        if (!string.IsNullOrEmpty(outPath))
+        {
+            await File.WriteAllTextAsync(outPath, json, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)).ConfigureAwait(false);
+        }
+    }
+
+
+    private static async Task<string> MeasureOneAsync(string name, Func<string, Task<int>> run, string data)
+    {
+        for (var i = 0; i < Warmup; i++)
+        {
+            await run(data).ConfigureAwait(false);
+        }
+
+        var samples = new double[Measured];
+        var records = 0;
+        var allocStart = GC.GetTotalAllocatedBytes(precise: true);
+        for (var i = 0; i < Measured; i++)
+        {
+            var sw = Stopwatch.StartNew();
+            records = await run(data).ConfigureAwait(false);
+            sw.Stop();
+            samples[i] = sw.Elapsed.TotalMilliseconds;
+        }
+
+        var allocatedPerIteration = (GC.GetTotalAllocatedBytes(precise: true) - allocStart) / Measured;
+        Array.Sort(samples);
+        var medianMs = samples[samples.Length / 2];
+
+        return string.Format
+        (
+            CultureInfo.InvariantCulture,
+            "  {{ \"scenario\": \"{0}\", \"records\": {1}, \"medianMs\": {2}, \"allocatedBytes\": {3} }}",
+            name,
+            records,
+            Math.Round(medianMs, 3),
+            allocatedPerIteration
+        );
+    }
+
+
+    private static string BuildData(int lines)
+    {
+        var sb = new StringBuilder(lines * 60);
+        for (var i = 0; i < lines; i++)
+        {
+            sb.AppendFormat
+            (
+                CultureInfo.InvariantCulture,
+                "{0:00000000}{1,-15}{2,-15}{3,-15}{4,-2}{5,12:0.00}\n",
+                i,
+                $"First{i % 997}",
+                $"Last{i % 991}",
+                $"City{i % 503}",
+                "PA",
+                (i % 100000) / 100.0
+            );
+        }
+
+        return sb.ToString();
+    }
+
+
+#pragma warning disable CS1998
+    private static async IAsyncEnumerable<Customer> ToAsync(IEnumerable<Customer> items)
+    {
+        foreach (var item in items)
+        {
+            yield return item;
+        }
+    }
+#pragma warning restore CS1998
+
+
+    private sealed class Customer
+    {
+        [FixedWidthField(0, 8, Alignment = FieldAlignment.Right, Pad = '0')]
+        public int Id { get; set; }
+
+        [FixedWidthField(1, 15)]
+        public string FirstName { get; set; } = string.Empty;
+
+        [FixedWidthField(2, 15)]
+        public string LastName { get; set; } = string.Empty;
+
+        [FixedWidthField(3, 15)]
+        public string City { get; set; } = string.Empty;
+
+        [FixedWidthField(4, 2)]
+        public string State { get; set; } = string.Empty;
+
+        [FixedWidthField(5, 12, Alignment = FieldAlignment.Right, Format = "0.00")]
+        public double Balance { get; set; }
+    }
+}

--- a/samples/ShadowWorkloads/Wolfgang.Etl.FixedWidth.ShadowWorkloads.csproj
+++ b/samples/ShadowWorkloads/Wolfgang.Etl.FixedWidth.ShadowWorkloads.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Shadow-testing sample workloads (#140). Realistic end-to-end consumer
+    scenarios that double as "real usage" documentation and, run under the nightly
+    shadow.yaml, as a regression gate. NOT in "ETL Fixed Width.slnx": it is driven
+    by the workflow (and read as docs), not a unit test. Running it in measure
+    mode emits per-scenario latency + allocation JSON for the gate.
+  -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.FixedWidth\Wolfgang.Etl.FixedWidth.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/ShadowWorkloads/compare.py
+++ b/samples/ShadowWorkloads/compare.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Gate shadow-workload results against the committed baseline (#140).
+
+Usage: compare.py <run.json> <baseline.json>
+
+allocatedBytes is the hard gate (deterministic): a per-scenario allocation jump
+beyond allocTolerancePercent fails (exit 1). medianMs is advisory: wall-clock on
+shared runners is too noisy to gate on, so a latency past latencyTolerancePercent
+is flagged but does not fail the job. A new scenario missing from the baseline
+also fails (the baseline must be updated deliberately).
+"""
+import json
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: compare.py <run.json> <baseline.json>", file=sys.stderr)
+        return 2
+
+    with open(sys.argv[1], encoding="utf-8-sig") as f:
+        run = json.load(f)
+    with open(sys.argv[2], encoding="utf-8-sig") as f:
+        base = json.load(f)
+
+    alloc_tol = 1.0 + float(base["allocTolerancePercent"]) / 100.0
+    lat_tol = 1.0 + float(base["latencyTolerancePercent"]) / 100.0
+    baselines = base["scenarios"]
+
+    failures = []
+    for row in run:
+        name = row["scenario"]
+        if name not in baselines:
+            failures.append(f"{name}: no baseline entry (update docs/shadow-baseline.json)")
+            print(f"{name}: NO BASELINE")
+            continue
+
+        b = baselines[name]
+        alloc = float(row["allocatedBytes"])
+        alloc_ceiling = float(b["allocatedBytes"]) * alloc_tol
+        alloc_ok = alloc <= alloc_ceiling
+
+        ms = float(row["medianMs"])
+        ms_ceiling = float(b["medianMs"]) * lat_tol
+        ms_flag = "" if ms <= ms_ceiling else "  [latency advisory: over threshold]"
+
+        status = "OK" if alloc_ok else "ALLOC REGRESSION"
+        print(f"{name}: alloc {alloc:,.0f} (ceiling {alloc_ceiling:,.0f}) {status}; "
+              f"median {ms:.2f}ms (baseline {float(b['medianMs']):.2f}ms){ms_flag}")
+
+        if not alloc_ok:
+            failures.append(f"{name}: allocatedBytes {alloc:,.0f} > ceiling {alloc_ceiling:,.0f}")
+
+    if failures:
+        print("\nSHADOW REGRESSION:\n  - " + "\n  - ".join(failures), file=sys.stderr)
+        return 1
+
+    print("\nAll scenarios within the allocation baseline.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #140. Unit/property tests prove behaviour on synthetic input; this replays realistic end-to-end consumer workloads and gates them against a golden baseline.

## What
- **`samples/ShadowWorkloads`** — three realistic scenarios written as **readable usage** (they double as "real usage" docs): streaming round trip, reformat transform (`ByMatchingProperties`), and full `EtlPipeline` composition. Measure mode emits per-scenario latency + allocation JSON.
- **`docs/shadow-baseline.json`** — committed golden baseline + tolerances.
- **`samples/ShadowWorkloads/compare.py`** — gates a run against the baseline.
- **`shadow.yaml`** — nightly run + compare (uploads results, prints to step summary).

## Gate design
- **`allocatedBytes` is the hard gate** — deterministic managed allocation; a **>50%** per-scenario jump fails the nightly (catches a hot-path allocation regression).
- **`medianMs` is advisory** — wall-clock on shared GitHub-hosted runners is too noisy to fail on reliably (the same constraint that scoped out #147's soak), so latency is reported and flagged past **20%** but does not fail the job. Documented in the baseline + workflow; reliable latency gating would need a dedicated runner.

## Verified locally
- 3 scenarios at **~11.6–13 MB / 20k records**; `compare.py` **passes** on the real run and **fails** on an injected allocation regression while treating an injected latency spike as **advisory** (doesn't fail) — exactly as intended.

## Note
- **Protected file:** `shadow.yaml` is a new workflow → the `Detect .NET Projects` guard will flag this PR; needs the protected-file split / admin-bypass at merge. (Samples, baseline, compare are non-protected.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)