### PR TITLE
refactor: gate metrics on Instrument.Enabled sample, drop EnableMetrics flag (#275)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `EnableMetrics` property on `FixedWidthExtractor<T>` and `FixedWidthLoader<T>`
-  (default `false`) that turns the #30 metrics on. Metrics are now **opt-in**:
-  when off — the default — the extract/load hot loop executes no metric code at
-  all, restoring the pre-metrics throughput. Set `EnableMetrics = true` (and
-  subscribe via `AddMeter("Wolfgang.Etl.FixedWidth")` or a `MeterListener`) to
-  collect the counters and duration histogram ([#275]).
-
 ### Changed
 
-- The metrics added in 0.7.0 (#30) no longer emit unless `EnableMetrics` is set.
-  This removes the always-on per-line/per-record overhead that made extraction
-  ~1.5–1.95× slower in 0.7.0 regardless of whether a listener was attached
-  ([#275]).
+- The #30 metrics no longer run unless a listener is subscribed to the
+  `Wolfgang.Etl.FixedWidth` meter. The extract/load loop samples the instruments'
+  `Enabled` state **once per operation** and executes no metric code when nothing
+  is listening — removing the always-on per-line/per-record overhead that made
+  extraction ~1.5–1.95× slower in 0.7.0 — with **no public API and no opt-in
+  flag** (zero-config, consistent with the rest of the ETL family) ([#275]).
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ See the [PipelineExtensions](examples/PipelineExtensions) example for a complete
 
 ### Metrics and observability
 
-The extractor and loader can emit standard [`System.Diagnostics.Metrics`](https://learn.microsoft.com/dotnet/core/diagnostics/metrics) instruments from the meter **`Wolfgang.Etl.FixedWidth`**, so throughput and error rates flow to OpenTelemetry, Prometheus, Grafana, Application Insights, or any `MeterListener`. Metrics are **opt-in**: set `EnableMetrics = true` on the extractor/loader to turn them on. When left off (the default), the extract/load loop runs **no** metric code at all, so telemetry adds zero overhead for callers that don't use it.
+The extractor and loader can emit standard [`System.Diagnostics.Metrics`](https://learn.microsoft.com/dotnet/core/diagnostics/metrics) instruments from the meter **`Wolfgang.Etl.FixedWidth`**, so throughput and error rates flow to OpenTelemetry, Prometheus, Grafana, Application Insights, or any `MeterListener`. Metrics are **zero-config**: they activate automatically when a listener subscribes to the `Wolfgang.Etl.FixedWidth` meter — there's no flag to set. When nothing is listening, the extract/load loop (sampling once per operation) runs **no** metric code at all, so telemetry adds zero overhead for callers that don't use it.
 
 | Instrument | Type | Description |
 |---|---|---|
@@ -262,10 +262,7 @@ The extractor and loader can emit standard [`System.Diagnostics.Metrics`](https:
 Every measurement is tagged `etl.operation` (`extract` or `load`) and `etl.record_type` (`typeof(TRecord).Name`).
 
 ```csharp
-// 1. Opt in on the extractor/loader (default is off):
-var extractor = new FixedWidthExtractor<Order>(reader) { EnableMetrics = true };
-
-// 2. Subscribe once at startup — OpenTelemetry, zero per-call code:
+// Subscribe once at startup — OpenTelemetry, zero per-call code; metrics turn on automatically:
 builder.Services.AddOpenTelemetry()
     .WithMetrics(m => m.AddMeter("Wolfgang.Etl.FixedWidth"));
 ```

--- a/docfx_project/docs/getting-started.md
+++ b/docfx_project/docs/getting-started.md
@@ -177,16 +177,14 @@ Every source and sink has **path**, `Stream`, and `TextReader`/`TextWriter` over
 
 ### Metrics and observability
 
-The extractor and loader can emit `System.Diagnostics.Metrics` instruments from the meter `Wolfgang.Etl.FixedWidth` — counters (`items.extracted`, `items.loaded`, `items.skipped`, `lines.read`) and a duration histogram (`operation.duration`), each tagged with `etl.operation` and `etl.record_type`. Metrics are **opt-in**: set `EnableMetrics = true` on the extractor/loader, then subscribe with OpenTelemetry so the telemetry flows to Prometheus, Grafana, Application Insights, and so on:
+The extractor and loader can emit `System.Diagnostics.Metrics` instruments from the meter `Wolfgang.Etl.FixedWidth` — counters (`items.extracted`, `items.loaded`, `items.skipped`, `lines.read`) and a duration histogram (`operation.duration`), each tagged with `etl.operation` and `etl.record_type`. Metrics are **zero-config**: they activate automatically when a listener subscribes to the meter — there is no flag to set — so the telemetry flows to Prometheus, Grafana, Application Insights, and so on:
 
 ```csharp
-var extractor = new FixedWidthExtractor<PersonRecord>(reader) { EnableMetrics = true };
-
 builder.Services.AddOpenTelemetry()
     .WithMetrics(m => m.AddMeter("Wolfgang.Etl.FixedWidth"));
 ```
 
-When `EnableMetrics` is left off (the default), the extract/load loop runs no metric code, so there is no overhead. See the [Metrics example](examples.md#metrics) for a raw `MeterListener` walk-through.
+When nothing is listening, the extract/load loop (sampling once per operation) runs no metric code, so there is no overhead. See the [Metrics example](examples.md#metrics) for a raw `MeterListener` walk-through.
 
 ## Next Steps
 

--- a/examples/Metrics/Program.cs
+++ b/examples/Metrics/Program.cs
@@ -70,8 +70,8 @@ var input =
     "Bob       Jones     025\n" +
     "Carol     White     035\n";
 
-// Metrics are opt-in (default off) — set EnableMetrics to emit them.
-var extractor = new FixedWidthExtractor<Person>(new StringReader(input)) { EnableMetrics = true, SkipItemCount = 1 };
+// Metrics are zero-config — the MeterListener subscribed above turns them on; there is no flag to set.
+var extractor = new FixedWidthExtractor<Person>(new StringReader(input)) { SkipItemCount = 1 };
 
 var people = new List<Person>();
 await foreach (var person in extractor.ExtractAsync(CancellationToken.None))
@@ -80,7 +80,7 @@ await foreach (var person in extractor.ExtractAsync(CancellationToken.None))
 }
 
 var writer = new StringWriter();
-var loader = new FixedWidthLoader<Person>(writer) { EnableMetrics = true };
+var loader = new FixedWidthLoader<Person>(writer);
 await loader.LoadAsync(ToAsyncEnumerable(people), CancellationToken.None);
 
 // ---------------------------------------------------------------------------

--- a/src/Wolfgang.Etl.FixedWidth/Diagnostics/FixedWidthMetrics.cs
+++ b/src/Wolfgang.Etl.FixedWidth/Diagnostics/FixedWidthMetrics.cs
@@ -77,6 +77,18 @@ internal static class FixedWidthMetrics
 
 
     /// <summary>
+    /// <see langword="true"/> when any fixed-width instrument currently has a subscribed listener.
+    /// The extract/load hot loop samples this once per operation to gate all metric work: when it is
+    /// <see langword="false"/> the loop touches no metric code, so instrumentation is zero-cost and
+    /// zero-config — it activates automatically when a <c>MeterListener</c> / OpenTelemetry subscribes
+    /// to the <c>Wolfgang.Etl.FixedWidth</c> meter, with no opt-in flag (#275).
+    /// </summary>
+    internal static bool AnyEnabled =>
+        ItemsExtracted.Enabled || ItemsLoaded.Enabled || ItemsSkipped.Enabled
+            || LinesRead.Enabled || OperationDuration.Enabled;
+
+
+    /// <summary>
     /// Builds the tag set shared by every measurement of a single operation.
     /// </summary>
     internal static TagList CreateTags(string operation, Type recordType)

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
@@ -491,19 +491,6 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
 
 
     /// <summary>
-    /// When <see langword="true"/>, the extractor emits the <c>Wolfgang.Etl.FixedWidth</c> metrics
-    /// (#30) as it runs. Defaults to <see langword="false"/> — metrics are <b>opt-in</b>. When off, the
-    /// extract loop executes no metric code at all (no per-line/record calls, no tag or duration
-    /// allocation), so telemetry adds no measurable overhead for callers that do not use it. Set to
-    /// <see langword="true"/> — and subscribe with OpenTelemetry (<c>AddMeter("Wolfgang.Etl.FixedWidth")</c>)
-    /// or a <see cref="System.Diagnostics.Metrics.MeterListener"/> — to collect the counters and the
-    /// duration histogram.
-    /// </summary>
-    public bool EnableMetrics { get; set; }
-
-
-
-    /// <summary>
     /// The 1-based physical line number of the line most recently read from the file.
     /// Updated before each line is parsed so that if an exception is thrown,
     /// this value points to the offending line. Matches the line number shown
@@ -646,12 +633,11 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
             ? HeaderLineCount + 1
             : -1;
 
-        // Metrics (#30, #275): opt-in via EnableMetrics. When off (the default) the extract loop runs
-        // no metric code — the per-line/record calls below are skipped and neither the tag set nor the
-        // duration scope is allocated — so telemetry adds no measurable overhead unless the caller opts
-        // in. When on, RecordLineRead / RecordExtracted / RecordSkipped fire but are themselves no-ops
-        // unless a MeterListener is subscribed.
-        var metricsEnabled = EnableMetrics;
+        // Metrics (#30, #275): sampled once per operation from the instruments. When no MeterListener
+        // is subscribed the extract loop runs no metric code — the per-line/record calls below are
+        // skipped and neither the tag set nor the duration scope is allocated — so telemetry is
+        // zero-cost and zero-config: it activates automatically when a listener subscribes.
+        var metricsEnabled = FixedWidthMetrics.AnyEnabled;
         var metricTags = metricsEnabled
             ? FixedWidthMetrics.CreateTags(FixedWidthMetrics.ExtractOperation, typeof(TRecord))
             : default;

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthLoader.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthLoader.cs
@@ -389,19 +389,6 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
 
 
     /// <summary>
-    /// When <see langword="true"/>, the loader emits the <c>Wolfgang.Etl.FixedWidth</c> metrics (#30)
-    /// as it runs. Defaults to <see langword="false"/> — metrics are <b>opt-in</b>. When off, the load
-    /// loop executes no metric code at all (no per-record calls, no tag or duration allocation), so
-    /// telemetry adds no measurable overhead for callers that do not use it. Set to
-    /// <see langword="true"/> — and subscribe with OpenTelemetry (<c>AddMeter("Wolfgang.Etl.FixedWidth")</c>)
-    /// or a <see cref="System.Diagnostics.Metrics.MeterListener"/> — to collect the counters and the
-    /// duration histogram.
-    /// </summary>
-    public bool EnableMetrics { get; set; }
-
-
-
-    /// <summary>
     /// The 1-based physical line number of the line most recently written to the output.
     /// Updated after each line is written. Includes the header line and separator line
     /// if written. Matches the line number shown in a text editor.
@@ -494,10 +481,11 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
         var fieldMap = FieldMap.GetResult<TRecord>();
         LogLoadingStarted(fieldMap);
 
-        // Metrics (#30, #275): opt-in via EnableMetrics. When off (the default) the load loop runs no
-        // metric code — the per-record calls below are skipped and neither the tag set nor the duration
-        // scope is allocated — so telemetry adds no measurable overhead unless the caller opts in.
-        var metricsEnabled = EnableMetrics;
+        // Metrics (#30, #275): sampled once per operation from the instruments. When no MeterListener
+        // is subscribed the load loop runs no metric code — the per-record calls below are skipped and
+        // neither the tag set nor the duration scope is allocated — so telemetry is zero-cost and
+        // zero-config: it activates automatically when a listener subscribes.
+        var metricsEnabled = FixedWidthMetrics.AnyEnabled;
         var metricTags = metricsEnabled
             ? FixedWidthMetrics.CreateTags(FixedWidthMetrics.LoadOperation, typeof(TRecord))
             : default;

--- a/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
@@ -1,5 +1,1 @@
 #nullable enable
-Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.EnableMetrics.get -> bool
-Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.EnableMetrics.set -> void
-Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.EnableMetrics.get -> bool
-Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.EnableMetrics.set -> void

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthMetricsTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthMetricsTests.cs
@@ -48,10 +48,7 @@ public sealed class FixedWidthMetricsTests
         var extractor = new FixedWidthExtractor<MetricsSample>
         (
             new StringReader(Content(("Alice", "Smith", 30), ("Bob", "Jones", 25), ("Carol", "White", 35)))
-        )
-        {
-            EnableMetrics = true,
-        };
+        );
 
         await DrainAsync(extractor);
 
@@ -78,7 +75,6 @@ public sealed class FixedWidthMetricsTests
             new StringReader(Content(("Alice", "Smith", 30), ("Bob", "Jones", 25), ("Carol", "White", 35)))
         )
         {
-            EnableMetrics = true,
             SkipItemCount = 2,
         };
 
@@ -95,7 +91,7 @@ public sealed class FixedWidthMetricsTests
         using var capture = new MetricCapture();
 
         var writer = new StringWriter();
-        var loader = new FixedWidthLoader<MetricsSample>(writer) { EnableMetrics = true };
+        var loader = new FixedWidthLoader<MetricsSample>(writer);
 
         await loader.LoadAsync(SampleAsync(), CancellationToken.None);
 
@@ -111,12 +107,13 @@ public sealed class FixedWidthMetricsTests
 
 
     [Fact]
-    public async Task Metrics_are_off_by_default_even_with_a_subscribed_listener()
+    public async Task Metrics_activate_with_no_opt_in_when_a_listener_is_subscribed()
     {
         using var capture = new MetricCapture();
 
-        // EnableMetrics defaults to false — metrics are opt-in (#275), so nothing is emitted even
-        // though a MeterListener is active.
+        // Zero-config (#275): there is no opt-in flag — a subscribed MeterListener alone turns metrics
+        // on. When nothing is listening the hot loop runs no metric code (that path is the pre-metrics
+        // throughput restored), but the moment a listener subscribes, both stages emit.
         var extractor = new FixedWidthExtractor<MetricsSample>
         (
             new StringReader(Content(("Alice", "Smith", 30), ("Bob", "Jones", 25)))
@@ -127,7 +124,9 @@ public sealed class FixedWidthMetricsTests
         var loader = new FixedWidthLoader<MetricsSample>(writer);
         await loader.LoadAsync(SampleAsync(), CancellationToken.None);
 
-        Assert.Empty(capture.All);
+        Assert.NotEmpty(capture.All);
+        Assert.Equal(2, capture.Sum("wolfgang.etl.fixedwidth.items.extracted"));
+        Assert.Equal(2, capture.Sum("wolfgang.etl.fixedwidth.items.loaded"));
     }
 
 


### PR DESCRIPTION
Reworks #276's metrics opt-in to the fleet-consistent design. #276 fixed the #275 perf regression with a public `EnableMetrics` flag; this achieves the **same perf win with no public API and no flag** by sampling `Instrument.Enabled` once per operation.

## What changed
- **`FixedWidthMetrics.AnyEnabled`** — an internal sample of the instruments' `Enabled` state. The extract/load loop hoists it into the existing `metricsEnabled` local (the only line that changed in each worker), so it still runs **no** per-record metric code when nothing is listening.
- **Removed the public `EnableMetrics` property** from `FixedWidthExtractor<T>` / `FixedWidthLoader<T>` (+ its 4 `PublicAPI.Unshipped` entries).
- Metrics tests drop the flag; the old "off by default even with a listener" test is inverted to **`Metrics_activate_with_no_opt_in_when_a_listener_is_subscribed`**.
- README / docfx / `examples/Metrics` reworded to "zero-config".

## Why (per the discussion)
- **Fleet-consistent** — ETL-Json gates purely on `Instrument.Enabled`, no flag.
- **Zero-config** — metrics turn on when a `MeterListener`/OpenTelemetry subscribes; nothing to set.
- **No silent break** for anyone who subscribed on 0.7.0's always-on metrics when they upgrade to 0.8.0.
- **Free to do now** — `EnableMetrics` is Unshipped (vNext only, never released), so removing it isn't a breaking change. (The one capability dropped: suppressing metrics *while* a listener is attached — deemed not worth the public knob + the upgrade break.)

## Verified
- **402 tests pass** (net10.0); solution builds clean on all 5 TFMs (0 warnings); PublicAPI analyzer accepts the removed Unshipped entries.

## ⚠️ Merge coordination
This removes `EnableMetrics`, which two other open PRs reference:
- **#278** (AOT smoke) — its `tests/AotSmoke` consumer sets `EnableMetrics = true`; that line must be dropped when #278 syncs vNext after this merges (else it won't compile).
- **#277** — carries vNext's inherited metrics-test/example `EnableMetrics` usages; they resolve to *this* PR's versions on sync.

Suggest merging this **before** #278, and updating #278's consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)