### PR TITLE
feat: OnError dead-letter capture on the extractor (#29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   counted in `CurrentErrorItemCount` and surfaced in the pipeline's `ErrorItemCount` — kept
   distinct from `RecordValidator` business rejects (which `CurrentRejectedItemCount` counts).
   `MalformedLineHandling.ReturnDefault` recovers before the give-up decision, so it never enters
-  the error policy. Closes #29.
+  the error policy. Part of #29.
+- `OnError` dead-letter sink (`Action<FixedWidthError>?`) on `FixedWidthExtractor<T>`: each record
+  that fails to parse is reported as a `FixedWidthError` (1-based `ItemNumber`, `RawContent`,
+  `Exception`) instead of only aborting. With `MalformedLineHandling.Skip` it is capture-and-continue;
+  even on the default `ThrowException` the failure is reported before the throw. `RecordValidator`
+  business rejects are **not** reported here (they are not parse errors). Closes #29.
 
 ### Changed
 

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthError.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthError.cs
@@ -1,0 +1,46 @@
+using System;
+
+namespace Wolfgang.Etl.FixedWidth;
+
+/// <summary>
+/// A record that failed to parse during extraction — a "dead letter". When
+/// <see cref="FixedWidthExtractor{TRecord}.OnError"/> is set, each failed line is
+/// reported as one of these instead of the exception aborting the run (provided
+/// <see cref="Enums.MalformedLineHandling.Skip"/> is configured to continue). Capture
+/// them for logging, a dead-letter queue, or post-run inspection (#29).
+/// </summary>
+public sealed class FixedWidthError
+{
+    /// <summary>
+    /// Initializes a new <see cref="FixedWidthError"/>.
+    /// </summary>
+    /// <param name="itemNumber">The 1-based ordinal of the failed record within the run.</param>
+    /// <param name="rawContent">The original line that failed, or <see langword="null"/> if unavailable.</param>
+    /// <param name="exception">The exception the record raised.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="exception"/> is <see langword="null"/>.</exception>
+    public FixedWidthError(long itemNumber, string? rawContent, Exception exception)
+    {
+        ItemNumber = itemNumber;
+        RawContent = rawContent;
+        Exception = exception ?? throw new ArgumentNullException(nameof(exception));
+    }
+
+    /// <summary>
+    /// The 1-based ordinal of the failed record within the current run.
+    /// </summary>
+    public long ItemNumber { get; }
+
+    /// <summary>
+    /// The original source line that failed to parse, or <see langword="null"/> if the
+    /// stage did not capture it.
+    /// </summary>
+    public string? RawContent { get; }
+
+    /// <summary>
+    /// The exception the record raised — typically a
+    /// <see cref="Exceptions.LineTooShortException"/>,
+    /// <see cref="Exceptions.MalformedLineException"/>, or
+    /// <see cref="Exceptions.FieldConversionException"/>.
+    /// </summary>
+    public Exception Exception { get; }
+}

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
@@ -363,6 +363,32 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
 
 
     /// <summary>
+    /// An optional dead-letter sink invoked once for each record that fails to parse (#29). The
+    /// failed line is reported as a <see cref="FixedWidthError"/> — its 1-based ordinal, raw content,
+    /// and exception — so the caller can log it, push it to a dead-letter queue, or collect it for
+    /// post-run inspection. Set <see cref="MalformedLineHandling"/> to
+    /// <see cref="Enums.MalformedLineHandling.Skip"/> to capture-and-continue; with the default
+    /// <see cref="Enums.MalformedLineHandling.ThrowException"/> the failure is still reported here
+    /// before the exception is re-thrown. Business rejects from <see cref="RecordValidator"/> are
+    /// <b>not</b> reported here — they are not parse errors.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// var errors = new List&lt;FixedWidthError&gt;();
+    /// var extractor = new FixedWidthExtractor&lt;Record&gt;(reader)
+    /// {
+    ///     MalformedLineHandling = MalformedLineHandling.Skip,
+    ///     OnError = errors.Add,
+    /// };
+    /// await foreach (var ok in extractor.ExtractAsync(token)) { /* only good records */ }
+    /// // errors now holds the dead letters
+    /// </code>
+    /// </example>
+    public Action<FixedWidthError>? OnError { get; set; }
+
+
+
+    /// <summary>
     /// A delegate that converts a raw string read from the file into the target property
     /// type. The <see cref="FieldContext"/> provides the property type, format string, and
     /// other field metadata needed to perform the conversion.
@@ -1073,6 +1099,13 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
     /// </exception>
     protected override ItemErrorAction OnItemError(ItemErrorContext context)
     {
+        // Dead-letter capture (#29): report every failure to the sink — on Skip and on Abort — so the
+        // failing record is always observable, then apply the give-up decision below.
+        if (context != null)
+        {
+            OnError?.Invoke(new FixedWidthError(context.ItemNumber, context.RawContent?.Invoke(), context.Exception));
+        }
+
         switch (MalformedLineHandling)
         {
             case MalformedLineHandling.Skip:

--- a/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
@@ -3,3 +3,10 @@ Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.EnableMetrics.get -> bool
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.EnableMetrics.set -> void
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.EnableMetrics.get -> bool
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.EnableMetrics.set -> void
+Wolfgang.Etl.FixedWidth.FixedWidthError
+Wolfgang.Etl.FixedWidth.FixedWidthError.Exception.get -> System.Exception
+Wolfgang.Etl.FixedWidth.FixedWidthError.FixedWidthError(long itemNumber, string rawContent, System.Exception exception) -> void
+Wolfgang.Etl.FixedWidth.FixedWidthError.ItemNumber.get -> long
+Wolfgang.Etl.FixedWidth.FixedWidthError.RawContent.get -> string?
+Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.OnError.get -> System.Action<Wolfgang.Etl.FixedWidth.FixedWidthError>
+Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.OnError.set -> void

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthItemErrorHandlingTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthItemErrorHandlingTests.cs
@@ -153,6 +153,44 @@ public class FixedWidthItemErrorHandlingTests
     }
 
 
+    [Fact]
+    public async Task OnError_captures_the_failed_lines_as_dead_letters()
+    {
+        var captured = new List<FixedWidthError>();
+        var extractor = new FixedWidthExtractor<PersonRecord>(new StringReader(GoodBadGoodBad))
+        {
+            MalformedLineHandling = MalformedLineHandling.Skip,
+            OnError = captured.Add,
+        };
+
+        var yielded = await Drain(extractor);
+
+        Assert.Equal(2, yielded.Count);                        // Carol, Dan yielded
+        Assert.Equal(2, captured.Count);                       // Eve, Foo captured
+        Assert.Equal(2, extractor.CurrentErrorItemCount);      // capture doesn't change the counters
+        Assert.All(captured, e => Assert.NotNull(e.Exception));
+        Assert.Contains(captured, e => e.RawContent != null && e.RawContent.Contains("Eve"));
+        Assert.All(captured, e => Assert.True(e.ItemNumber > 0));
+    }
+
+
+    [Fact]
+    public async Task OnError_reports_the_failure_even_when_the_run_aborts()
+    {
+        // Decision: OnError fires on Abort too — the failing record is always observable, then the run
+        // stops (default MalformedLineHandling == ThrowException).
+        var captured = new List<FixedWidthError>();
+        var extractor = new FixedWidthExtractor<PersonRecord>(new StringReader(GoodBadGoodBad))
+        {
+            OnError = captured.Add,
+        };
+
+        await Assert.ThrowsAnyAsync<MalformedLineException>(() => Drain(extractor));
+
+        Assert.Single(captured);                               // the first bad line, reported before the throw
+    }
+
+
     // ---- helpers / doubles ----
 
     private static async Task<List<PersonRecord>> Drain(FixedWidthExtractor<PersonRecord> extractor)


### PR DESCRIPTION
Closes #29. **Stacked on #268** (the #84 `OnItemError` foundation) — base is `feat/adopt-84-error-handling`, not vNext; it re-targets to vNext when #268 merges.

Implements the [design posted on #29](https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/29).

## What
- **`FixedWidthError`** `{ long ItemNumber; string? RawContent; Exception Exception }` — the dead letter.
- **`Action<FixedWidthError>? OnError`** on `FixedWidthExtractor<T>` — invoked once per parse failure, wired into #268's existing `OnItemError` override.
- Fires on **Skip and Abort** (every failure observable), *before* the give-up decision. `MalformedLineHandling.Skip` + `OnError` = capture-and-continue.
- `RecordValidator` business rejects are **not** reported (not parse errors) — the #268 counter distinction holds.

## Design calls (per the signed-off design)
- **A delegate, not a built-in `Errors` list** — an unbounded buffer is a memory hazard on exactly the large/messy files #29 targets; the delegate lets the caller pick the sink (`list.Add`, `channel.Writer.TryWrite`, DLQ).
- No parallel `ErrorHandling` enum — capture layers onto the existing `MalformedLineHandling`.

## Verified
- Builds all 5 TFMs; **8 error-handling tests pass** (capture list, raw content, `ItemNumber`, counters unchanged, fire-on-abort).

## Follow-ups (next in the stack)
- **PR B:** extend `OnError` to the **loader** (needs a loader error path — #268 wired the extractor only).
- **PR C:** `[Obsolete]` `MalformedLineHandling.ReturnDefault` (the #267 malformed decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)