### PR TITLE
build: pin to published Abstractions 0.21.0 / TestKit 0.14.0 for 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is listening — removing the always-on per-line/per-record overhead that made
   extraction ~1.5–1.95× slower in 0.7.0 — with **no public API and no opt-in
   flag** (zero-config, consistent with the rest of the ETL family) ([#275]).
-- Bumped `Wolfgang.Etl.Abstractions` 0.17.0 → 0.22.0 (and `Wolfgang.Etl.TestKit`
-  0.10.0 → 0.22.0), adopting the renamed
+- Bumped `Wolfgang.Etl.Abstractions` 0.17.0 → 0.21.0 (and `Wolfgang.Etl.TestKit`
+  0.10.0 → 0.14.0), adopting the renamed
   `EtlPipelineProgress.{Extracted,Loaded,Error}ItemCount` counters (formerly
   `Records{Extracted,Loaded,Errored}`). The loader and transformer
   now honor an already-cancelled `CancellationToken` before consuming their

--- a/examples/BasicExtraction/BasicExtraction.csproj
+++ b/examples/BasicExtraction/BasicExtraction.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.22.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.14.0" />
   </ItemGroup>
 
   <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->

--- a/examples/BasicLoading/BasicLoading.csproj
+++ b/examples/BasicLoading/BasicLoading.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.22.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.14.0" />
   </ItemGroup>
 
   <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->

--- a/src/Wolfgang.Etl.FixedWidth/Wolfgang.Etl.FixedWidth.csproj
+++ b/src/Wolfgang.Etl.FixedWidth/Wolfgang.Etl.FixedWidth.csproj
@@ -57,7 +57,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.10" />
     <PackageReference Include="System.Memory" Version="4.6.3" />
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.22.0" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.21.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />
   </ItemGroup>
 

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/Wolfgang.Etl.FixedWidth.Tests.Unit.csproj
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/Wolfgang.Etl.FixedWidth.Tests.Unit.csproj
@@ -20,8 +20,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')) And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
-    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.22.0" />
-    <PackageReference Include="Wolfgang.Etl.TestKit.Xunit" Version="0.22.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.14.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit.Xunit" Version="0.14.0" />
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Ships the 0.8.0 cycle against the highest versions **published to nuget.org** — Abstractions **0.21.0**, TestKit/TestKit.Xunit **0.14.0** — instead of the local-only **0.22.0**. This clears **NU1102** across the vNext PR train so 0.8.0 can ship today without waiting on the 0.22 publish.

**No functionality lost:** the code uses zero 0.22-only API (no `ErrorPolicy`, no fewer-param base classes); the Abstractions #84 error mechanism it relies on shipped in 0.18. The published 0.8.0 package will depend on `Wolfgang.Etl.Abstractions >= 0.21.0` (published), and TestKit is test-only (never a package dependency).

**Verified:** 443/443 unit tests pass on net10.0 against 0.21.0 / 0.14.0.

Pins changed: src (Abstractions), unit-test (TestKit + TestKit.Xunit), examples/BasicExtraction + BasicLoading (TestKit), CHANGELOG bump line.

**Merge first** — it flips vNext CI green; the four feature PRs (#280/#281/#282/#286) then inherit the published pins on re-sync.