### PR TITLE
release: prep 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.8.0] - 2026-08-07
+
+Code-first schema building, error dead-lettering, and zero-config metrics.
+Additive public API — no breaking changes.
+
+### Added
+
 - `FixedWidthSchemaBuilder<T>` — define a fixed-width layout with a fluent,
   type-safe code API (`.Field(r => r.Name, index, length, …)` / `.Skip(index, length)`
   / `.Build()`) instead of `[FixedWidthField]` attributes, for record types you
@@ -349,7 +366,8 @@ changes** — the shipped library is unchanged from 0.5.0.
 [#165]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/165
 [#253]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/253
 [#275]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/275
-[Unreleased]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.5.0...v0.5.1

--- a/src/Wolfgang.Etl.FixedWidth/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Etl.FixedWidth/PublicAPI.Shipped.txt
@@ -70,6 +70,11 @@ Wolfgang.Etl.FixedWidth.FieldContext.Pad.get -> char
 Wolfgang.Etl.FixedWidth.FieldContext.PropertyName.get -> string
 Wolfgang.Etl.FixedWidth.FieldContext.PropertyType.get -> System.Type
 Wolfgang.Etl.FixedWidth.FixedWidthConverter
+Wolfgang.Etl.FixedWidth.FixedWidthError
+Wolfgang.Etl.FixedWidth.FixedWidthError.Exception.get -> System.Exception
+Wolfgang.Etl.FixedWidth.FixedWidthError.FixedWidthError(long itemNumber, string rawContent, System.Exception exception) -> void
+Wolfgang.Etl.FixedWidth.FixedWidthError.ItemNumber.get -> long
+Wolfgang.Etl.FixedWidth.FixedWidthError.RawContent.get -> string?
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.BlankLineHandling.get -> Wolfgang.Etl.FixedWidth.Enums.BlankLineHandling
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.BlankLineHandling.set -> void
@@ -92,8 +97,12 @@ Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.LineFilter.get -> System.Fu
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.LineFilter.set -> void
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.MalformedLineHandling.get -> Wolfgang.Etl.FixedWidth.Enums.MalformedLineHandling
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.MalformedLineHandling.set -> void
+Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.OnError.get -> System.Action<Wolfgang.Etl.FixedWidth.FixedWidthError>
+Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.OnError.set -> void
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.RecordValidator.get -> System.Func<TRecord, Wolfgang.Etl.FixedWidth.ValidationResult>
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.RecordValidator.set -> void
+Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.Schema.get -> Wolfgang.Etl.FixedWidth.FixedWidthSchema?
+Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.Schema.set -> void
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.ValueParser.get -> Wolfgang.Etl.FixedWidth.FixedWidthValueParser
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.ValueParser.set -> void
 Wolfgang.Etl.FixedWidth.FixedWidthFieldInfo
@@ -124,6 +133,8 @@ Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.HeaderConverter.get -> System.
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.HeaderConverter.set -> void
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.IsDryRun.get -> bool
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.IsDryRun.set -> void
+Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.Schema.get -> Wolfgang.Etl.FixedWidth.FixedWidthSchema?
+Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.Schema.set -> void
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.ValueConverter.get -> System.Func<object, Wolfgang.Etl.FixedWidth.FieldContext, string>
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.ValueConverter.set -> void
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.WriteHeader.get -> bool
@@ -143,6 +154,11 @@ Wolfgang.Etl.FixedWidth.FixedWidthSchema.RecordType.get -> System.Type
 Wolfgang.Etl.FixedWidth.FixedWidthSchema.SkipCount.get -> int
 Wolfgang.Etl.FixedWidth.FixedWidthSchema.ToDiagram() -> string
 Wolfgang.Etl.FixedWidth.FixedWidthSchema.TotalColumnCount.get -> int
+Wolfgang.Etl.FixedWidth.FixedWidthSchemaBuilder<T>
+Wolfgang.Etl.FixedWidth.FixedWidthSchemaBuilder<T>.Build() -> Wolfgang.Etl.FixedWidth.FixedWidthSchema
+Wolfgang.Etl.FixedWidth.FixedWidthSchemaBuilder<T>.Field<TProperty>(System.Linq.Expressions.Expression<System.Func<T, TProperty>> selector, int index, int length, Wolfgang.Etl.FixedWidth.Enums.FieldAlignment alignment = Wolfgang.Etl.FixedWidth.Enums.FieldAlignment.Left, char pad = ' ', string format = null, string header = null, System.Globalization.NumberStyles? numberStyles = null, bool trimValue = true) -> Wolfgang.Etl.FixedWidth.FixedWidthSchemaBuilder<T>
+Wolfgang.Etl.FixedWidth.FixedWidthSchemaBuilder<T>.FixedWidthSchemaBuilder() -> void
+Wolfgang.Etl.FixedWidth.FixedWidthSchemaBuilder<T>.Skip(int index, int length, string message = null) -> Wolfgang.Etl.FixedWidth.FixedWidthSchemaBuilder<T>
 Wolfgang.Etl.FixedWidth.FixedWidthTransformer<TSource, TDestination>
 Wolfgang.Etl.FixedWidth.FixedWidthTransformer<TSource, TDestination>.FixedWidthTransformer(System.Func<TSource, TDestination> transform) -> void
 Wolfgang.Etl.FixedWidth.FixedWidthValueParser

--- a/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
@@ -1,17 +1,1 @@
 #nullable enable
-Wolfgang.Etl.FixedWidth.FixedWidthError
-Wolfgang.Etl.FixedWidth.FixedWidthError.Exception.get -> System.Exception
-Wolfgang.Etl.FixedWidth.FixedWidthError.FixedWidthError(long itemNumber, string rawContent, System.Exception exception) -> void
-Wolfgang.Etl.FixedWidth.FixedWidthError.ItemNumber.get -> long
-Wolfgang.Etl.FixedWidth.FixedWidthError.RawContent.get -> string?
-Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.OnError.get -> System.Action<Wolfgang.Etl.FixedWidth.FixedWidthError>
-Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.OnError.set -> void
-Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.Schema.get -> Wolfgang.Etl.FixedWidth.FixedWidthSchema?
-Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.Schema.set -> void
-Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.Schema.get -> Wolfgang.Etl.FixedWidth.FixedWidthSchema?
-Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.Schema.set -> void
-Wolfgang.Etl.FixedWidth.FixedWidthSchemaBuilder<T>
-Wolfgang.Etl.FixedWidth.FixedWidthSchemaBuilder<T>.Build() -> Wolfgang.Etl.FixedWidth.FixedWidthSchema
-Wolfgang.Etl.FixedWidth.FixedWidthSchemaBuilder<T>.Field<TProperty>(System.Linq.Expressions.Expression<System.Func<T, TProperty>> selector, int index, int length, Wolfgang.Etl.FixedWidth.Enums.FieldAlignment alignment = Wolfgang.Etl.FixedWidth.Enums.FieldAlignment.Left, char pad = ' ', string format = null, string header = null, System.Globalization.NumberStyles? numberStyles = null, bool trimValue = true) -> Wolfgang.Etl.FixedWidth.FixedWidthSchemaBuilder<T>
-Wolfgang.Etl.FixedWidth.FixedWidthSchemaBuilder<T>.FixedWidthSchemaBuilder() -> void
-Wolfgang.Etl.FixedWidth.FixedWidthSchemaBuilder<T>.Skip(int index, int length, string message = null) -> Wolfgang.Etl.FixedWidth.FixedWidthSchemaBuilder<T>

--- a/src/Wolfgang.Etl.FixedWidth/Wolfgang.Etl.FixedWidth.csproj
+++ b/src/Wolfgang.Etl.FixedWidth/Wolfgang.Etl.FixedWidth.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net481;netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Version>0.7.0</Version>
+    <Version>0.8.0</Version>
     <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
          do not need to recompile / add binding redirects on every minor/patch
          bump. Bump only on a deliberate breaking API change. FileVersion +
@@ -22,7 +22,7 @@
          Intentional breaks in a MAJOR bump are recorded via a generated
          CompatibilitySuppressions.xml. -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.6.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.7.0</PackageValidationBaselineVersion>
     <Title>Wolfgang.Etl.FixedWidth</Title>
     <Description>Extractor and Loader implementations for reading and writing fixed-width text files, built on Wolfgang.Etl.Abstractions.</Description>
     <PackageProjectUrl>https://github.com/Chris-Wolfgang/ETL-FixedWidth</PackageProjectUrl>


### PR DESCRIPTION
Release preparation for **0.8.0** (base: `vNext`).

## Changes (release-prep only — no code changes)
- `<Version>` **0.7.0 → 0.8.0**
- `PackageValidationBaselineVersion` **0.6.0 → 0.7.0** (last published; the 0.7.0-release TODO was never applied)
- **CHANGELOG**: stamped `[Unreleased]` → `## [0.8.0] - 2026-08-07`, added a fresh empty `[Unreleased]`, and added the `[0.8.0]` compare link (updated `[Unreleased]` to `v0.8.0...HEAD`)
- **PublicAPI**: promoted the 16 `Unshipped` entries → `Shipped` (`FixedWidthExtractor/Loader.Schema`, `FixedWidthSchemaBuilder<T>`, `FixedWidthError`, `FixedWidthExtractor.OnError`); reset `Unshipped` to `#nullable enable`

## What 0.8.0 ships (all against Abstractions 0.21.0 / TestKit 0.14.0)
- **#23** — `FixedWidthSchemaBuilder<T>` + `Schema` override
- **#29** — Abstractions #84 error handling + `OnError` dead-letter sink (`FixedWidthError`)
- **#275** — zero-config metrics (removed the always-on 0.7.0 overhead; listener-gated, no opt-in flag)
- Test/tooling suites: AOT-trim smoke (#153), concurrency stress (#147), GC profiling (#152), shadow workloads (#140), reproducible-build docs (#165)

Additive public API — no breaking changes.

## Local verification
- Build Release net10.0 — 0 warnings (RS0016/RS0017 satisfied)
- Unit tests — **445/445** pass (net10.0)
- `dotnet pack` — **PackageValidation passed** vs the 0.7.0 baseline (ABI-additive; dep bump clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)