### PR TITLE
release: 0.8.0 to main (non-protected)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,99 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+## [0.8.0] - 2026-08-07
+
+Code-first schema building, error dead-lettering, and zero-config metrics.
+Additive public API — no breaking changes.
+
+### Added
+
+- `FixedWidthSchemaBuilder<T>` — define a fixed-width layout with a fluent,
+  type-safe code API (`.Field(r => r.Name, index, length, …)` / `.Skip(index, length)`
+  / `.Build()`) instead of `[FixedWidthField]` attributes, for record types you
+  cannot decorate or layouts built at runtime. Assign the resulting
+  `FixedWidthSchema` to the new `FixedWidthExtractor<T>.Schema` /
+  `FixedWidthLoader<T>.Schema` property to override attribute resolution; a
+  built schema is equivalent to (and introspectable like) an attribute-resolved
+  one ([#23]).
+- Malformed-line handling now flows through the Abstractions #84 policy. `FixedWidthExtractor`
+  overrides `OnItemError` to translate the existing `MalformedLineHandling` knob (`Skip` → skip,
+  `ThrowException` → abort) and calls the base `HandleItemError`, so a genuine parse failure is
+  counted in `CurrentErrorItemCount` and surfaced in the pipeline's `ErrorItemCount` — kept
+  distinct from `RecordValidator` business rejects (which `CurrentRejectedItemCount` counts).
+  `MalformedLineHandling.ReturnDefault` recovers before the give-up decision, so it never enters
+  the error policy. Part of #29.
+- `OnError` dead-letter sink (`Action<FixedWidthError>?`) on `FixedWidthExtractor<T>`: each record
+  that fails to parse is reported as a `FixedWidthError` (1-based `ItemNumber`, `RawContent`,
+  `Exception`) instead of only aborting. With `MalformedLineHandling.Skip` it is capture-and-continue;
+  even on the default `ThrowException` the failure is reported before the throw. `RecordValidator`
+  business rejects are **not** reported here (they are not parse errors). Closes #29.
+- Native-AOT / trim-compatibility smoke test ([#153]): a `PublishAot` console
+  consumer (`tests/AotSmoke`) exercises every public path against a concrete
+  record type and asserts the results, and the `aot-smoke.yaml` workflow
+  publishes it on Linux and runs the native binary so an AOT/trim regression
+  fails before merge. The `Expression.Compile` accessor sites carry documented
+  `IL3050` suppressions — under Native AOT they fall back to the interpreter, so
+  the library runs correctly (without JIT speed). **Known limitation surfaced by
+  the smoke:** attribute-based mapping reads `[FixedWidthField]` by reflection,
+  and Native-AOT trimming strips those attribute instances unless the record's
+  assembly is rooted (`TrimmerRootAssembly`) — a consumer using attribute mapping
+  under AOT must root its record types today; removing that need is the
+  source-generated-accessors follow-up.
+- Concurrency / race-condition stress suite ([#147]):
+  `tests/Wolfgang.Etl.FixedWidth.Tests.Concurrency` asserts correctness under
+  contention — concurrent first-use of the process-global caches (`FieldMap`
+  cache, `FixedWidthTransformer` static property-mapper), racing disposal, and
+  cross-thread cancellation mid-enumeration. A weekly `concurrency.yaml` sweep
+  cranks the iteration budget up via `STRESS_ITERATIONS`. (Coyote is not used —
+  its `IAsyncEnumerable` support is rough and its CLI is net8-only; the xunit
+  stress suite is the gate.)
+- Sustained-load GC / allocation profiling ([#152]): `tools/GcProfile` runs
+  extract → transform → load in a tight loop for a configurable duration and
+  reports allocated bytes per record and gen2 collections per million records.
+  A monthly `gc-profile.yaml` sweep gates the run against `docs/gc-baseline.json`
+  — a per-record allocation jump (hot-path regression) or gen2 promotion
+  (retention leak) fails the job. Complements the per-call allocation snapshot in
+  `docs/ALLOCATION-PROFILE.md` (#157).
+- Shadow-testing sample workloads ([#140]): `samples/ShadowWorkloads` runs
+  realistic end-to-end scenarios (streaming round trip, reformat transform,
+  pipeline composition) that double as usage documentation. A nightly
+  `shadow.yaml` measures per-scenario latency + allocation and gates the result
+  against `docs/shadow-baseline.json` — allocation is the hard gate (a >50% jump
+  fails); latency is advisory (reported, not gated, since shared-runner wall-clock
+  is too noisy to fail on reliably).
+
+### Changed
+
+- The #30 metrics no longer run unless a listener is subscribed to the
+  `Wolfgang.Etl.FixedWidth` meter. The extract/load loop samples the instruments'
+  `Enabled` state **once per operation** and executes no metric code when nothing
+  is listening — removing the always-on per-line/per-record overhead that made
+  extraction ~1.5–1.95× slower in 0.7.0 — with **no public API and no opt-in
+  flag** (zero-config, consistent with the rest of the ETL family) ([#275]).
+- Bumped `Wolfgang.Etl.Abstractions` 0.17.0 → 0.21.0 (and `Wolfgang.Etl.TestKit`
+  0.10.0 → 0.14.0), adopting the renamed
+  `EtlPipelineProgress.{Extracted,Loaded,Error}ItemCount` counters (formerly
+  `Records{Extracted,Loaded,Errored}`). The loader and transformer
+  now honor an already-cancelled `CancellationToken` before consuming their
+  source — a pre-cancelled `LoadAsync` / `TransformAsync` reads nothing — matching
+  the extractor and the TestKit base cancellation contract.
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+- Consumer-side reproducible-build verification ([#165]): each release now
+  attaches a `reproducible-build-manifest.json` (expected per-framework assembly
+  SHA-256 hashes + the exact toolchain), and `docs/REPRODUCIBLE-BUILD.md` plus a
+  README "Verify the build" section document how a third party rebuilds the tag,
+  compares hashes, files a discrepancy, and publishes an independent verification
+  attestation.
+
 ## [0.7.0] - 2026-07-24
 
 Pipeline composition and observability. Additive — no breaking changes.
@@ -264,9 +357,17 @@ changes** — the shipped library is unchanged from 0.5.0.
 [#14]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/14
 [#22]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/22
 [#24]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/24
+[#23]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/23
 [#30]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/30
+[#140]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/140
+[#147]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/147
+[#152]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/152
+[#153]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/153
+[#165]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/165
 [#253]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/253
-[Unreleased]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.7.0...HEAD
+[#275]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/275
+[Unreleased]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.5.0...v0.5.1

--- a/ETL Fixed Width.slnx
+++ b/ETL Fixed Width.slnx
@@ -49,12 +49,14 @@
     <Project Path="examples/PipelineExtensions/PipelineExtensions.csproj" />
     <Project Path="examples/ProgressReporting/ProgressReporting.csproj" />
     <Project Path="examples/RoundTrip/RoundTrip.csproj" />
+    <Project Path="examples/SchemaBuilder/SchemaBuilder.csproj" />
     <Project Path="examples/SkipAndMax/SkipAndMax.csproj" />
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/Wolfgang.Etl.FixedWidth/Wolfgang.Etl.FixedWidth.csproj" />
   </Folder>
   <Folder Name="/tests/">
+    <Project Path="tests/Wolfgang.Etl.FixedWidth.Tests.Concurrency/Wolfgang.Etl.FixedWidth.Tests.Concurrency.csproj" />
     <Project Path="tests/Wolfgang.Etl.FixedWidth.Tests.Fuzz/Wolfgang.Etl.FixedWidth.Tests.Fuzz.csproj" />
     <Project Path="tests/Wolfgang.Etl.FixedWidth.Tests.Snapshot/Wolfgang.Etl.FixedWidth.Tests.Snapshot.csproj" />
     <Project Path="tests/Wolfgang.Etl.FixedWidth.Tests.Unit/Wolfgang.Etl.FixedWidth.Tests.Unit.csproj" />

--- a/README.md
+++ b/README.md
@@ -186,6 +186,25 @@ Position  Field           Type    Length  Align  Pad  Format
 Total width: 24  |  Columns: 3 (2 fields + 1 skip)  |  Delimiter: none
 ```
 
+### Defining the layout in code
+
+When you can't decorate the record type — a third-party POCO, or a layout chosen at runtime — build the schema with `FixedWidthSchemaBuilder<T>` instead of attributes, then hand it to the extractor or loader via its `Schema` property:
+
+```csharp
+var schema = new FixedWidthSchemaBuilder<CustomerRecord>()
+    .Field(r => r.CustomerId, index: 0, length: 8)
+    .Field(r => r.Name, index: 1, length: 30)
+    .Skip(index: 2, length: 5)
+    .Field(r => r.Balance, index: 3, length: 9, alignment: FieldAlignment.Right, format: "0000000.00")
+    .Build();
+
+using var extractor = new FixedWidthExtractor<CustomerRecord>(reader) { Schema = schema };
+```
+
+The builder uses lambda expressions for type-safe, refactor-proof property references — no magic strings. `index` is the zero-based column ordinal (the same value as `[FixedWidthField(index, length)]`); start positions are computed from the column lengths. A schema built this way is **equivalent** to one resolved from attributes: it validates the same way (duplicate index, no public setter) and is fully introspectable via `Fields` / `ToDiagram()`. Setting `Schema` overrides any attributes on the type.
+
+See the [SchemaBuilder](examples/SchemaBuilder) example for a runnable walk-through.
+
 ### Transforming between layouts
 
 To reformat a fixed-width file from one layout to another — reordering, adding/removing, or format-converting fields (a common mainframe-migration task) — `FixedWidthTransformer<TSource, TDestination>` is the projection stage between an extractor and a loader:
@@ -249,7 +268,7 @@ See the [PipelineExtensions](examples/PipelineExtensions) example for a complete
 
 ### Metrics and observability
 
-The extractor and loader emit standard [`System.Diagnostics.Metrics`](https://learn.microsoft.com/dotnet/core/diagnostics/metrics) instruments from the meter **`Wolfgang.Etl.FixedWidth`**, so throughput and error rates flow to OpenTelemetry, Prometheus, Grafana, Application Insights, or any `MeterListener` with no code changes. Metrics are a no-op when nothing is listening, so there is no overhead in the default case.
+The extractor and loader can emit standard [`System.Diagnostics.Metrics`](https://learn.microsoft.com/dotnet/core/diagnostics/metrics) instruments from the meter **`Wolfgang.Etl.FixedWidth`**, so throughput and error rates flow to OpenTelemetry, Prometheus, Grafana, Application Insights, or any `MeterListener`. Metrics are **zero-config**: they activate automatically when a listener subscribes to the `Wolfgang.Etl.FixedWidth` meter — there's no flag to set. When nothing is listening, the extract/load loop (sampling once per operation) runs **no** metric code at all, so telemetry adds zero overhead for callers that don't use it.
 
 | Instrument | Type | Description |
 |---|---|---|
@@ -262,7 +281,7 @@ The extractor and loader emit standard [`System.Diagnostics.Metrics`](https://le
 Every measurement is tagged `etl.operation` (`extract` or `load`) and `etl.record_type` (`typeof(TRecord).Name`).
 
 ```csharp
-// OpenTelemetry — one line, zero library changes:
+// Subscribe once at startup — OpenTelemetry, zero per-call code; metrics turn on automatically:
 builder.Services.AddOpenTelemetry()
     .WithMetrics(m => m.AddMeter("Wolfgang.Etl.FixedWidth"));
 ```
@@ -292,6 +311,7 @@ See the [Metrics](examples/Metrics) example for a runnable `MeterListener` walk-
 | **Span-based numerics** | `Span<char>`-based numeric parsing on net8.0+ for reduced allocation |
 | **Compiled delegates** | Field accessors use compiled delegates instead of reflection for fast property get/set |
 | **Schema introspection** | `FixedWidthSchema.For<T>()` exposes the resolved layout (positions, widths, types, skips); `ToDiagram()` renders it as a text table |
+| **Code-defined layout** | `FixedWidthSchemaBuilder<T>` defines a layout in fluent, type-safe code (no attributes required); assign it to the extractor/loader `Schema` property |
 | **Format transformation** | `FixedWidthTransformer<TSource, TDestination>` projects one layout to another in a single streaming pass, with optional `ByMatchingProperties()` auto-mapping |
 | **Pipeline composition** | `EtlPipeline.Create().FixedWidthExtractor<T>(…).FixedWidthLoader<T>(…).RunAsync()` — fluent source factories and sink terminators over the generic `EtlPipeline` (requires `Wolfgang.Etl.Abstractions` 0.16.0) |
 | **Metrics** | Zero-config `System.Diagnostics.Metrics` instruments (throughput, skips, duration) from the `Wolfgang.Etl.FixedWidth` meter — OpenTelemetry / Prometheus / any `MeterListener` |
@@ -299,7 +319,7 @@ See the [Metrics](examples/Metrics) example for a runnable `MeterListener` walk-
 
 **Examples:**
 
-The [examples/](examples/) folder contains 12 runnable console projects demonstrating each feature:
+The [examples/](examples/) folder contains 13 runnable console projects demonstrating each feature:
 
 | Example | Description |
 |---------|-------------|
@@ -315,6 +335,7 @@ The [examples/](examples/) folder contains 12 runnable console projects demonstr
 | [HeadersAndSeparators](examples/HeadersAndSeparators) | `WriteHeader`, `HasHeader`, and `FieldSeparator` |
 | [PipelineExtensions](examples/PipelineExtensions) | Compose extract → transform → load as one `EtlPipeline` fluent chain |
 | [Metrics](examples/Metrics) | Subscribe to the `Wolfgang.Etl.FixedWidth` meter and read throughput/duration metrics |
+| [SchemaBuilder](examples/SchemaBuilder) | Define a layout in code with `FixedWidthSchemaBuilder<T>` instead of attributes |
 
 ---
 
@@ -433,6 +454,28 @@ docfx build --serve
 - `docfx_project/index.md` - Main landing page content
 - `docfx_project/docs/` - Additional documentation articles
 - `docfx_project/api/` - Auto-generated API reference YAML files
+
+---
+
+## 🔐 Verify the build
+
+The library is built **deterministically**, so you can rebuild the exact
+assemblies from the tagged source and confirm a NuGet release was built from that
+source and nothing else. Every GitHub release attaches a
+`reproducible-build-manifest.json` with the expected per-framework assembly
+hashes and the toolchain that produced them.
+
+```bash
+# Download the manifest for a release, rebuild at the tag, and compare hashes.
+gh release download v0.8.0 --repo Chris-Wolfgang/ETL-FixedWidth --pattern reproducible-build-manifest.json
+git clone --depth 1 --branch v0.8.0 https://github.com/Chris-Wolfgang/ETL-FixedWidth
+dotnet build ETL-FixedWidth/src/Wolfgang.Etl.FixedWidth/Wolfgang.Etl.FixedWidth.csproj -c Release -p:ContinuousIntegrationBuild=true
+find ETL-FixedWidth/src/Wolfgang.Etl.FixedWidth/bin/Release -name 'Wolfgang.Etl.FixedWidth.dll' -exec sha256sum {} \;
+```
+
+See **[docs/REPRODUCIBLE-BUILD.md](docs/REPRODUCIBLE-BUILD.md)** for the full
+procedure — which SDK version to use, how to file a discrepancy, and how to
+publish a third-party verification attestation.
 
 ---
 

--- a/docfx_project/docs/examples.md
+++ b/docfx_project/docs/examples.md
@@ -73,3 +73,9 @@ Composes an extract → transform → load flow as a single `EtlPipeline` fluent
 Subscribes to the `Wolfgang.Etl.FixedWidth` meter with a `MeterListener` and prints the counters and duration histogram the extractor and loader emit during an extract → load round trip (`items.extracted`, `items.loaded`, `items.skipped`, `lines.read`, `operation.duration`, each tagged with `etl.operation` and `etl.record_type`). In production you would subscribe with `AddMeter("Wolfgang.Etl.FixedWidth")` via OpenTelemetry instead.
 
 [View source](https://github.com/Chris-Wolfgang/ETL-FixedWidth/tree/main/examples/Metrics)
+
+## SchemaBuilder
+
+Defines a fixed-width layout in code with `FixedWidthSchemaBuilder<T>` for a record type that carries no `[FixedWidthField]` attributes, then uses it — via the extractor/loader `Schema` property — to load and re-extract records. Also shows that a code-built schema is fully introspectable (`ToDiagram` / `Fields`), exactly like an attribute-resolved one.
+
+[View source](https://github.com/Chris-Wolfgang/ETL-FixedWidth/tree/main/examples/SchemaBuilder)

--- a/docfx_project/docs/getting-started.md
+++ b/docfx_project/docs/getting-started.md
@@ -139,6 +139,23 @@ Console.WriteLine(FixedWidthSchema.For<EmployeeRecord>().ToDiagram());
 // Total width: 24  |  Columns: 3 (2 fields + 1 skip)  |  Delimiter: none
 ```
 
+### Defining the layout in code
+
+When you can't decorate the record type, or the layout is chosen at runtime, build the schema with `FixedWidthSchemaBuilder<T>` and assign it to the extractor/loader `Schema` property instead of using attributes:
+
+```csharp
+var schema = new FixedWidthSchemaBuilder<CustomerRecord>()
+    .Field(r => r.CustomerId, index: 0, length: 8)
+    .Field(r => r.Name, index: 1, length: 30)
+    .Skip(index: 2, length: 5)
+    .Field(r => r.Balance, index: 3, length: 9, alignment: FieldAlignment.Right, format: "0000000.00")
+    .Build();
+
+using var extractor = new FixedWidthExtractor<CustomerRecord>(reader) { Schema = schema };
+```
+
+The lambda selectors are type-safe (no magic strings) and `index` is the zero-based column ordinal, matching `[FixedWidthField(index, length)]`. A built schema is equivalent to an attribute-resolved one — same validation and the same `Fields` / `ToDiagram()` introspection — and overrides any attributes on the type when set. See the [SchemaBuilder example](examples.md#schemabuilder).
+
 ### Transforming between layouts
 
 `FixedWidthTransformer<TSource, TDestination>` reformats records from one layout to another (reorder, add/remove, or format-convert fields) as the projection stage between an extractor and a loader:
@@ -177,14 +194,14 @@ Every source and sink has **path**, `Stream`, and `TextReader`/`TextWriter` over
 
 ### Metrics and observability
 
-The extractor and loader emit `System.Diagnostics.Metrics` instruments from the meter `Wolfgang.Etl.FixedWidth` — counters (`items.extracted`, `items.loaded`, `items.skipped`, `lines.read`) and a duration histogram (`operation.duration`), each tagged with `etl.operation` and `etl.record_type`. Subscribe with OpenTelemetry and the telemetry flows to Prometheus, Grafana, Application Insights, and so on, with no changes to your extraction/loading code:
+The extractor and loader can emit `System.Diagnostics.Metrics` instruments from the meter `Wolfgang.Etl.FixedWidth` — counters (`items.extracted`, `items.loaded`, `items.skipped`, `lines.read`) and a duration histogram (`operation.duration`), each tagged with `etl.operation` and `etl.record_type`. Metrics are **zero-config**: they activate automatically when a listener subscribes to the meter — there is no flag to set — so the telemetry flows to Prometheus, Grafana, Application Insights, and so on:
 
 ```csharp
 builder.Services.AddOpenTelemetry()
     .WithMetrics(m => m.AddMeter("Wolfgang.Etl.FixedWidth"));
 ```
 
-Metrics are a no-op when nothing is listening. See the [Metrics example](examples.md#metrics) for a raw `MeterListener` walk-through.
+When nothing is listening, the extract/load loop (sampling once per operation) runs no metric code, so there is no overhead. See the [Metrics example](examples.md#metrics) for a raw `MeterListener` walk-through.
 
 ## Next Steps
 

--- a/docs/REPRODUCIBLE-BUILD.md
+++ b/docs/REPRODUCIBLE-BUILD.md
@@ -1,0 +1,108 @@
+# Reproducible builds — verify it yourself
+
+`Wolfgang.Etl.FixedWidth` is built deterministically, so anyone can rebuild the
+exact same compiled assemblies from the tagged source and confirm the release on
+NuGet was built from that source and nothing else. This page is the **consumer
+side** of that guarantee: how *you* independently verify a release.
+
+> Related: [`reproducible-build.yaml`](../.github/workflows/reproducible-build.yaml)
+> proves the build is reproducible on every PR (it builds the same commit twice in
+> different paths and fails if the assemblies differ). This document is about a
+> third party reproducing it out-of-band.
+
+## What is reproducible
+
+The unit of verification is the **compiled assembly** — one
+`Wolfgang.Etl.FixedWidth.dll` per target framework
+(`net462`, `net481`, `netstandard2.0`, `net8.0`, `net10.0`). These are
+byte-for-byte reproducible because the build sets:
+
+- `Deterministic` (default) — no timestamps or random GUIDs baked into the IL;
+- `ContinuousIntegrationBuild=true` on CI — normalizes source paths to `/_/` so
+  the checkout directory doesn't affect output;
+- `EmbedUntrackedSources` + SourceLink — provenance is embedded deterministically.
+
+> **NuGet packages (`.nupkg`) are *not* byte-for-byte reproducible.** A `.nupkg`
+> is a ZIP and records per-entry timestamps, so its hash varies between builds.
+> The manifest lists the package hashes for reference, but **verify the
+> assemblies**, not the package.
+
+## The per-release manifest
+
+Every GitHub release attaches **`reproducible-build-manifest.json`**, produced by
+[`release.yaml`](../.github/workflows/release.yaml) from the exact build that was
+published. It records the expected assembly hashes plus the toolchain that
+produced them:
+
+```jsonc
+{
+  "tag": "v0.8.0",
+  "commit": "…",
+  "dotnetSdk": "10.0.100",          // the SDK you must use to reproduce
+  "runnerOs": "Windows",
+  "buildConfiguration": "Release",
+  "assemblies": [
+    { "tfm": "net10.0", "file": "Wolfgang.Etl.FixedWidth.dll", "sha256": "…" },
+    …
+  ],
+  "packages": [                      // reference only — not byte-reproducible
+    { "file": "Wolfgang.Etl.FixedWidth.0.8.0.nupkg", "sha256": "…" }
+  ]
+}
+```
+
+Download it from the release page, or with the CLI:
+
+```bash
+gh release download v0.8.0 --repo Chris-Wolfgang/ETL-FixedWidth --pattern reproducible-build-manifest.json
+```
+
+## Reproduce it
+
+You need the **same .NET SDK version** the manifest records in `dotnetSdk`
+(a different SDK ships a different Roslyn and may emit different IL). Install it
+from <https://dotnet.microsoft.com/download/dotnet>.
+
+```bash
+# 1. Clone the source at the exact published tag.
+git clone --depth 1 --branch v0.8.0 https://github.com/Chris-Wolfgang/ETL-FixedWidth
+cd ETL-FixedWidth
+
+# 2. Build Release with the CI determinism flag (matches the release build).
+dotnet build src/Wolfgang.Etl.FixedWidth/Wolfgang.Etl.FixedWidth.csproj \
+  -c Release -p:ContinuousIntegrationBuild=true
+
+# 3. Hash each per-TFM assembly and compare against the manifest.
+find src/Wolfgang.Etl.FixedWidth/bin/Release -name 'Wolfgang.Etl.FixedWidth.dll' \
+  -exec sha256sum {} \;
+```
+
+If your `sha256` values match the manifest's `assemblies[].sha256`, the published
+release is reproducible from source on your machine.
+
+## If a hash does not match
+
+A mismatch is worth reporting — it may be a determinism regression, a
+toolchain difference, or something more serious.
+
+1. Double-check you used the **exact** `dotnetSdk` from the manifest
+   (`dotnet --version` must match) and passed `-p:ContinuousIntegrationBuild=true`.
+2. [Open an issue](https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/new)
+   titled `reproducible-build discrepancy: <tag>` and include: the tag, your
+   `dotnet --version`, your OS, and the assembly hashes you got versus the
+   manifest's. Label it `maintenance - security`.
+
+## Publish a third-party verification attestation
+
+Independent verifications make the guarantee stronger than a single publisher's
+claim. If you reproduced a release, you can publish an attestation others can
+find:
+
+- **Reproducible Builds conventions** — follow
+  <https://reproducible-builds.org/docs/> to record your environment and result.
+- **[vouchsafe.io](https://vouchsafe.io/)** (or a similar attestation service) —
+  publish a signed statement that tag `vX.Y.Z` reproduced to the manifest hashes
+  in your environment, and link it back on the release discussion.
+
+Link your attestation in a comment on the release so future consumers can find
+corroborating verifications.

--- a/docs/gc-baseline.json
+++ b/docs/gc-baseline.json
@@ -1,0 +1,6 @@
+{
+  "_comment": "Sustained-load GC baseline for #152. Regenerate by running tools/GcProfile and updating these references in a reviewed PR. allocatedBytesPerRecord is environment-sensitive (GC mode, JIT version) so it carries a wide tolerance and only catches a gross hot-path allocation regression; gen2CollectionsPerMillion is the environment-robust retention-leak gate (a materializing streaming library should promote ~nothing to gen2).",
+  "capturedOn": "windows-local, ServerGC, net10.0, 15s (~49.5M records)",
+  "allocatedBytesPerRecord": { "reference": 340.0, "tolerancePercent": 25 },
+  "gen2CollectionsPerMillion": { "max": 1.0 }
+}

--- a/docs/shadow-baseline.json
+++ b/docs/shadow-baseline.json
@@ -1,0 +1,11 @@
+{
+  "_comment": "Shadow-workload baseline for #140. Regenerate by running samples/ShadowWorkloads in measure mode and updating these references in a reviewed PR. allocatedBytes is the HARD gate (deterministic managed allocation; a >allocTolerancePercent jump fails the nightly). medianMs is ADVISORY only: wall-clock on shared GitHub-hosted runners is too noisy to gate reliably — it is reported and flagged past latencyTolerancePercent but does not fail the job. Reliable latency gating would need a dedicated runner.",
+  "capturedOn": "windows-local, net10.0, 20000 records/scenario, 15 measured iterations",
+  "allocTolerancePercent": 50,
+  "latencyTolerancePercent": 20,
+  "scenarios": {
+    "streaming_round_trip": { "allocatedBytes": 11746947, "medianMs": 40.11 },
+    "reformat_transform": { "allocatedBytes": 13027700, "medianMs": 17.93 },
+    "pipeline_composition": { "allocatedBytes": 11587808, "medianMs": 15.80 }
+  }
+}

--- a/examples/BasicLoading/BasicLoading.csproj
+++ b/examples/BasicLoading/BasicLoading.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.10.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.14.0" />
   </ItemGroup>
 
   <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->

--- a/examples/Metrics/Program.cs
+++ b/examples/Metrics/Program.cs
@@ -70,6 +70,7 @@ var input =
     "Bob       Jones     025\n" +
     "Carol     White     035\n";
 
+// Metrics are zero-config — the MeterListener subscribed above turns them on; there is no flag to set.
 var extractor = new FixedWidthExtractor<Person>(new StringReader(input)) { SkipItemCount = 1 };
 
 var people = new List<Person>();

--- a/examples/SchemaBuilder/Program.cs
+++ b/examples/SchemaBuilder/Program.cs
@@ -1,0 +1,114 @@
+// ---------------------------------------------------------------------------
+// SchemaBuilder Example
+// ---------------------------------------------------------------------------
+//
+// This example demonstrates defining a fixed-width layout in code with
+// FixedWidthSchemaBuilder<T> (issue #23) instead of [FixedWidthField]
+// attributes. This is the approach to reach for when you do not own the record
+// type (a third-party POCO you cannot decorate) or when the layout is decided
+// at runtime.
+//
+// The Customer type below carries NO attributes. The schema maps it entirely
+// through fluent, type-safe lambda expressions, and is then handed to the
+// extractor and loader via their Schema property.
+//
+// Key concepts covered:
+//   - Building a layout with .Field(...) / .Skip(...) / .Build()
+//   - Type-safe property references (c => c.Name) — no magic strings
+//   - A built schema is introspectable, exactly like an attribute-resolved one
+//     (ToDiagram / Fields)
+//   - Using the schema for both loading and extraction via the Schema property
+// ---------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.FixedWidth;
+using Wolfgang.Etl.FixedWidth.Enums;
+
+// ---------------------------------------------------------------------------
+// Step 1: Build the layout in code for an undecorated type.
+//
+//   Id    columns 0    width 5   right-aligned, zero-padded
+//   Name  column  1    width 15
+//   [skip]column  2    width 3   (a reserved range in the file)
+//   City  column  3    width 10
+// ---------------------------------------------------------------------------
+
+var schema = new FixedWidthSchemaBuilder<Customer>()
+    .Field(c => c.Id, index: 0, length: 5, alignment: FieldAlignment.Right, pad: '0')
+    .Field(c => c.Name, index: 1, length: 15)
+    .Skip(index: 2, length: 3, message: "reserved")
+    .Field(c => c.City, index: 3, length: 10)
+    .Build();
+
+// ---------------------------------------------------------------------------
+// Step 2: A built schema is introspectable, just like an attribute-resolved one.
+// ---------------------------------------------------------------------------
+
+Console.WriteLine("Layout defined in code:");
+Console.WriteLine(schema.ToDiagram());
+Console.WriteLine();
+
+// ---------------------------------------------------------------------------
+// Step 3: Load records to fixed-width text using the schema.
+// ---------------------------------------------------------------------------
+
+var customers = new[]
+{
+    new Customer { Id = 1, Name = "Alice", City = "London" },
+    new Customer { Id = 42, Name = "Bob", City = "Paris" },
+};
+
+var writer = new StringWriter();
+var loader = new FixedWidthLoader<Customer>(writer) { Schema = schema };
+await loader.LoadAsync(ToAsyncEnumerable(customers), CancellationToken.None);
+
+var text = writer.ToString();
+Console.WriteLine("Written fixed-width output (columns shown with a ruler):");
+Console.WriteLine("0    5              20 23        33");
+Console.Write(text);
+Console.WriteLine();
+
+// ---------------------------------------------------------------------------
+// Step 4: Extract the same text back through the same schema.
+// ---------------------------------------------------------------------------
+
+var extractor = new FixedWidthExtractor<Customer>(new StringReader(text)) { Schema = schema };
+
+Console.WriteLine("Extracted back into records:");
+await foreach (var customer in extractor.ExtractAsync(CancellationToken.None))
+{
+    Console.WriteLine($"  Id={customer.Id}, Name={customer.Name}, City={customer.City}");
+}
+
+// ---------------------------------------------------------------------------
+// Adapts a synchronous array to the IAsyncEnumerable the loader consumes.
+// ---------------------------------------------------------------------------
+
+#pragma warning disable CS1998 // synchronous sequence — no await needed
+static async IAsyncEnumerable<Customer> ToAsyncEnumerable(IEnumerable<Customer> items)
+{
+    foreach (var item in items)
+    {
+        yield return item;
+    }
+}
+#pragma warning restore CS1998
+
+// ---------------------------------------------------------------------------
+// Customer — an undecorated POCO. No [FixedWidthField] attributes; the layout
+// lives entirely in the schema built above.
+// ---------------------------------------------------------------------------
+
+/// <summary>A customer record whose fixed-width layout is defined in code, not by attributes.</summary>
+public sealed class Customer
+{
+    public int Id { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+
+    public string City { get; set; } = string.Empty;
+}

--- a/examples/SchemaBuilder/SchemaBuilder.csproj
+++ b/examples/SchemaBuilder/SchemaBuilder.csproj
@@ -10,10 +10,6 @@
     <ProjectReference Include="..\..\src\Wolfgang.Etl.FixedWidth\Wolfgang.Etl.FixedWidth.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.14.0" />
-  </ItemGroup>
-
   <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
 
 

--- a/samples/ShadowWorkloads/Program.cs
+++ b/samples/ShadowWorkloads/Program.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.FixedWidth;
+using Wolfgang.Etl.FixedWidth.Attributes;
+using Wolfgang.Etl.FixedWidth.Enums;
+
+namespace Wolfgang.Etl.FixedWidth.ShadowWorkloads;
+
+// Shadow-testing sample workloads (#140). Each scenario is a realistic end-to-end
+// consumer flow written as readable usage (it doubles as documentation). Run with
+// no args to execute each once and print a summary; run with `--measure` to emit
+// per-scenario latency + allocation JSON for the nightly regression gate.
+internal static class Program
+{
+    private const int Lines = 20_000;
+    private const int Warmup = 3;
+    private const int Measured = 15;
+
+    private static readonly (string Name, Func<string, Task<int>> Run)[] Scenarios =
+    {
+        ("streaming_round_trip", StreamingRoundTripAsync),
+        ("reformat_transform", ReformatTransformAsync),
+        ("pipeline_composition", PipelineCompositionAsync),
+    };
+
+
+    private static async Task<int> Main(string[] args)
+    {
+        var data = BuildData(Lines);
+
+        if (args.Contains("--measure"))
+        {
+            await MeasureAllAsync(data).ConfigureAwait(false);
+        }
+        else
+        {
+            foreach (var (name, run) in Scenarios)
+            {
+                var count = await run(data).ConfigureAwait(false);
+                Console.WriteLine($"{name}: {count} records");
+            }
+        }
+
+        return 0;
+    }
+
+
+    // --- Scenario 1: stream a large fixed-width file straight through -----------
+    private static async Task<int> StreamingRoundTripAsync(string data)
+    {
+        var count = 0;
+        using var extractor = new FixedWidthExtractor<Customer>(new StringReader(data));
+        using var loader = new FixedWidthLoader<Customer>(TextWriter.Null);
+
+        var buffer = new List<Customer>(Lines);
+        await foreach (var customer in extractor.ExtractAsync(CancellationToken.None).ConfigureAwait(false))
+        {
+            buffer.Add(customer);
+            count++;
+        }
+
+        await loader.LoadAsync(ToAsync(buffer), CancellationToken.None).ConfigureAwait(false);
+        return count;
+    }
+
+
+    // --- Scenario 2: reformat one layout to another via same-name mapping -------
+    private static async Task<int> ReformatTransformAsync(string data)
+    {
+        var count = 0;
+        using var extractor = new FixedWidthExtractor<Customer>(new StringReader(data));
+        var transformer = FixedWidthTransformer<Customer, Customer>.ByMatchingProperties();
+        using var loader = new FixedWidthLoader<Customer>(TextWriter.Null);
+
+        var transformed = transformer.TransformAsync(extractor.ExtractAsync(CancellationToken.None), CancellationToken.None);
+        var buffer = new List<Customer>(Lines);
+        await foreach (var customer in transformed.ConfigureAwait(false))
+        {
+            buffer.Add(customer);
+            count++;
+        }
+
+        await loader.LoadAsync(ToAsync(buffer), CancellationToken.None).ConfigureAwait(false);
+        return count;
+    }
+
+
+    // --- Scenario 3: compose the whole flow as one EtlPipeline chain ------------
+    private static async Task<int> PipelineCompositionAsync(string data)
+    {
+        await EtlPipeline
+            .Create()
+            .FixedWidthExtractor<Customer>(new StringReader(data))
+            .FixedWidthLoader<Customer>(TextWriter.Null)
+            .RunAsync()
+            .ConfigureAwait(false);
+
+        return Lines;
+    }
+
+
+    // --- Measurement ------------------------------------------------------------
+    private static async Task MeasureAllAsync(string data)
+    {
+        var results = new List<string>();
+        foreach (var (name, run) in Scenarios)
+        {
+            results.Add(await MeasureOneAsync(name, run, data).ConfigureAwait(false));
+        }
+
+        var json = "[\n" + string.Join(",\n", results) + "\n]";
+        Console.WriteLine(json);
+
+        var outPath = Environment.GetEnvironmentVariable("SHADOW_OUT");
+        if (!string.IsNullOrEmpty(outPath))
+        {
+            await File.WriteAllTextAsync(outPath, json, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)).ConfigureAwait(false);
+        }
+    }
+
+
+    private static async Task<string> MeasureOneAsync(string name, Func<string, Task<int>> run, string data)
+    {
+        for (var i = 0; i < Warmup; i++)
+        {
+            await run(data).ConfigureAwait(false);
+        }
+
+        var samples = new double[Measured];
+        var records = 0;
+        var allocStart = GC.GetTotalAllocatedBytes(precise: true);
+        for (var i = 0; i < Measured; i++)
+        {
+            var sw = Stopwatch.StartNew();
+            records = await run(data).ConfigureAwait(false);
+            sw.Stop();
+            samples[i] = sw.Elapsed.TotalMilliseconds;
+        }
+
+        var allocatedPerIteration = (GC.GetTotalAllocatedBytes(precise: true) - allocStart) / Measured;
+        Array.Sort(samples);
+        var medianMs = samples[samples.Length / 2];
+
+        return string.Format
+        (
+            CultureInfo.InvariantCulture,
+            "  {{ \"scenario\": \"{0}\", \"records\": {1}, \"medianMs\": {2}, \"allocatedBytes\": {3} }}",
+            name,
+            records,
+            Math.Round(medianMs, 3),
+            allocatedPerIteration
+        );
+    }
+
+
+    private static string BuildData(int lines)
+    {
+        var sb = new StringBuilder(lines * 60);
+        for (var i = 0; i < lines; i++)
+        {
+            sb.AppendFormat
+            (
+                CultureInfo.InvariantCulture,
+                "{0:00000000}{1,-15}{2,-15}{3,-15}{4,-2}{5,12:0.00}\n",
+                i,
+                $"First{i % 997}",
+                $"Last{i % 991}",
+                $"City{i % 503}",
+                "PA",
+                (i % 100000) / 100.0
+            );
+        }
+
+        return sb.ToString();
+    }
+
+
+#pragma warning disable CS1998
+    private static async IAsyncEnumerable<Customer> ToAsync(IEnumerable<Customer> items)
+    {
+        foreach (var item in items)
+        {
+            yield return item;
+        }
+    }
+#pragma warning restore CS1998
+
+
+    private sealed class Customer
+    {
+        [FixedWidthField(0, 8, Alignment = FieldAlignment.Right, Pad = '0')]
+        public int Id { get; set; }
+
+        [FixedWidthField(1, 15)]
+        public string FirstName { get; set; } = string.Empty;
+
+        [FixedWidthField(2, 15)]
+        public string LastName { get; set; } = string.Empty;
+
+        [FixedWidthField(3, 15)]
+        public string City { get; set; } = string.Empty;
+
+        [FixedWidthField(4, 2)]
+        public string State { get; set; } = string.Empty;
+
+        [FixedWidthField(5, 12, Alignment = FieldAlignment.Right, Format = "0.00")]
+        public double Balance { get; set; }
+    }
+}

--- a/samples/ShadowWorkloads/Wolfgang.Etl.FixedWidth.ShadowWorkloads.csproj
+++ b/samples/ShadowWorkloads/Wolfgang.Etl.FixedWidth.ShadowWorkloads.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Shadow-testing sample workloads (#140). Realistic end-to-end consumer
+    scenarios that double as "real usage" documentation and, run under the nightly
+    shadow.yaml, as a regression gate. NOT in "ETL Fixed Width.slnx": it is driven
+    by the workflow (and read as docs), not a unit test. Running it in measure
+    mode emits per-scenario latency + allocation JSON for the gate.
+  -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.FixedWidth\Wolfgang.Etl.FixedWidth.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/ShadowWorkloads/compare.py
+++ b/samples/ShadowWorkloads/compare.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Gate shadow-workload results against the committed baseline (#140).
+
+Usage: compare.py <run.json> <baseline.json>
+
+allocatedBytes is the hard gate (deterministic): a per-scenario allocation jump
+beyond allocTolerancePercent fails (exit 1). medianMs is advisory: wall-clock on
+shared runners is too noisy to gate on, so a latency past latencyTolerancePercent
+is flagged but does not fail the job. A new scenario missing from the baseline
+also fails (the baseline must be updated deliberately).
+"""
+import json
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: compare.py <run.json> <baseline.json>", file=sys.stderr)
+        return 2
+
+    with open(sys.argv[1], encoding="utf-8-sig") as f:
+        run = json.load(f)
+    with open(sys.argv[2], encoding="utf-8-sig") as f:
+        base = json.load(f)
+
+    alloc_tol = 1.0 + float(base["allocTolerancePercent"]) / 100.0
+    lat_tol = 1.0 + float(base["latencyTolerancePercent"]) / 100.0
+    baselines = base["scenarios"]
+
+    failures = []
+    for row in run:
+        name = row["scenario"]
+        if name not in baselines:
+            failures.append(f"{name}: no baseline entry (update docs/shadow-baseline.json)")
+            print(f"{name}: NO BASELINE")
+            continue
+
+        b = baselines[name]
+        alloc = float(row["allocatedBytes"])
+        alloc_ceiling = float(b["allocatedBytes"]) * alloc_tol
+        alloc_ok = alloc <= alloc_ceiling
+
+        ms = float(row["medianMs"])
+        ms_ceiling = float(b["medianMs"]) * lat_tol
+        ms_flag = "" if ms <= ms_ceiling else "  [latency advisory: over threshold]"
+
+        status = "OK" if alloc_ok else "ALLOC REGRESSION"
+        print(f"{name}: alloc {alloc:,.0f} (ceiling {alloc_ceiling:,.0f}) {status}; "
+              f"median {ms:.2f}ms (baseline {float(b['medianMs']):.2f}ms){ms_flag}")
+
+        if not alloc_ok:
+            failures.append(f"{name}: allocatedBytes {alloc:,.0f} > ceiling {alloc_ceiling:,.0f}")
+
+    if failures:
+        print("\nSHADOW REGRESSION:\n  - " + "\n  - ".join(failures), file=sys.stderr)
+        return 1
+
+    print("\nAll scenarios within the allocation baseline.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/Wolfgang.Etl.FixedWidth/Diagnostics/FixedWidthMetrics.cs
+++ b/src/Wolfgang.Etl.FixedWidth/Diagnostics/FixedWidthMetrics.cs
@@ -77,6 +77,28 @@ internal static class FixedWidthMetrics
 
 
     /// <summary>
+    /// <see langword="true"/> when any fixed-width instrument is currently <b>enabled</b> — i.e. a
+    /// subscribed <c>MeterListener</c> has called <c>EnableMeasurementEvents</c> on at least one of them
+    /// (as OpenTelemetry's <c>AddMeter("Wolfgang.Etl.FixedWidth")</c> does). The extract/load hot loop
+    /// samples this once per operation to gate all metric work: when it is <see langword="false"/> the
+    /// loop touches no metric code, so instrumentation is zero-cost and zero-config, with no opt-in flag
+    /// (#275).
+    /// </summary>
+    internal static bool AnyEnabled =>
+        ItemsExtracted.Enabled || ItemsLoaded.Enabled || ItemsSkipped.Enabled
+            || LinesRead.Enabled || OperationDuration.Enabled;
+
+
+    /// <summary>
+    /// <see langword="true"/> when the <see cref="OperationDuration"/> histogram specifically is enabled.
+    /// The extract/load loop gates its per-operation <see cref="DurationScope"/> on this so a listener
+    /// enabling only the counters does not pay the scope allocation and the <c>Stopwatch</c> timestamp
+    /// read for a duration that will never be recorded.
+    /// </summary>
+    internal static bool DurationEnabled => OperationDuration.Enabled;
+
+
+    /// <summary>
     /// Builds the tag set shared by every measurement of a single operation.
     /// </summary>
     internal static TagList CreateTags(string operation, Type recordType)

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthError.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthError.cs
@@ -14,7 +14,7 @@ public sealed class FixedWidthError
     /// <summary>
     /// Initializes a new <see cref="FixedWidthError"/>.
     /// </summary>
-    /// <param name="itemNumber">The 1-based ordinal of the failed record within the run.</param>
+    /// <param name="itemNumber">The 1-based physical source line number of the failed line.</param>
     /// <param name="rawContent">The original line that failed, or <see langword="null"/> if unavailable.</param>
     /// <param name="exception">The exception the record raised.</param>
     /// <exception cref="ArgumentNullException"><paramref name="exception"/> is <see langword="null"/>.</exception>
@@ -26,7 +26,9 @@ public sealed class FixedWidthError
     }
 
     /// <summary>
-    /// The 1-based ordinal of the failed record within the current run.
+    /// The 1-based physical source line number of the failed line — the same value as
+    /// <see cref="FixedWidthExtractor{TRecord}.CurrentLineNumber"/> and the line number in the
+    /// exception message, matching what a text editor shows. Not a logical record ordinal.
     /// </summary>
     public long ItemNumber { get; }
 

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthError.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthError.cs
@@ -1,0 +1,46 @@
+using System;
+
+namespace Wolfgang.Etl.FixedWidth;
+
+/// <summary>
+/// A record that failed to parse during extraction — a "dead letter". When
+/// <see cref="FixedWidthExtractor{TRecord}.OnError"/> is set, each failed line is
+/// reported as one of these instead of the exception aborting the run (provided
+/// <see cref="Enums.MalformedLineHandling.Skip"/> is configured to continue). Capture
+/// them for logging, a dead-letter queue, or post-run inspection (#29).
+/// </summary>
+public sealed class FixedWidthError
+{
+    /// <summary>
+    /// Initializes a new <see cref="FixedWidthError"/>.
+    /// </summary>
+    /// <param name="itemNumber">The 1-based ordinal of the failed record within the run.</param>
+    /// <param name="rawContent">The original line that failed, or <see langword="null"/> if unavailable.</param>
+    /// <param name="exception">The exception the record raised.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="exception"/> is <see langword="null"/>.</exception>
+    public FixedWidthError(long itemNumber, string? rawContent, Exception exception)
+    {
+        ItemNumber = itemNumber;
+        RawContent = rawContent;
+        Exception = exception ?? throw new ArgumentNullException(nameof(exception));
+    }
+
+    /// <summary>
+    /// The 1-based ordinal of the failed record within the current run.
+    /// </summary>
+    public long ItemNumber { get; }
+
+    /// <summary>
+    /// The original source line that failed to parse, or <see langword="null"/> if the
+    /// stage did not capture it.
+    /// </summary>
+    public string? RawContent { get; }
+
+    /// <summary>
+    /// The exception the record raised — typically a
+    /// <see cref="Exceptions.LineTooShortException"/>,
+    /// <see cref="Exceptions.MalformedLineException"/>, or
+    /// <see cref="Exceptions.FieldConversionException"/>.
+    /// </summary>
+    public Exception Exception { get; }
+}

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
@@ -363,6 +363,32 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
 
 
     /// <summary>
+    /// An optional dead-letter sink invoked once for each record that fails to parse (#29). The
+    /// failed line is reported as a <see cref="FixedWidthError"/> — its 1-based ordinal, raw content,
+    /// and exception — so the caller can log it, push it to a dead-letter queue, or collect it for
+    /// post-run inspection. Set <see cref="MalformedLineHandling"/> to
+    /// <see cref="Enums.MalformedLineHandling.Skip"/> to capture-and-continue; with the default
+    /// <see cref="Enums.MalformedLineHandling.ThrowException"/> the failure is still reported here
+    /// before the exception is re-thrown. Business rejects from <see cref="RecordValidator"/> are
+    /// <b>not</b> reported here — they are not parse errors.
+    /// </summary>
+    /// <example>
+    /// <code>
+    /// var errors = new List&lt;FixedWidthError&gt;();
+    /// var extractor = new FixedWidthExtractor&lt;Record&gt;(reader)
+    /// {
+    ///     MalformedLineHandling = MalformedLineHandling.Skip,
+    ///     OnError = errors.Add,
+    /// };
+    /// await foreach (var ok in extractor.ExtractAsync(token)) { /* only good records */ }
+    /// // errors now holds the dead letters
+    /// </code>
+    /// </example>
+    public Action<FixedWidthError>? OnError { get; set; }
+
+
+
+    /// <summary>
     /// A delegate that converts a raw string read from the file into the target property
     /// type. The <see cref="FieldContext"/> provides the property type, format string, and
     /// other field metadata needed to perform the conversion.
@@ -487,6 +513,17 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
     /// </code>
     /// </example>
     public string? FieldDelimiter { get; set; }
+
+
+
+    /// <summary>
+    /// An optional layout that overrides the <c>[FixedWidthField]</c> / <c>[FixedWidthSkip]</c> attributes
+    /// on <typeparamref name="TRecord"/> (#23). Build one with <see cref="FixedWidthSchemaBuilder{T}"/> to
+    /// map a type you cannot decorate, or to define the layout in code. When <see langword="null"/> (the
+    /// default) the attribute-based layout is used. The schema's <see cref="FixedWidthSchema.RecordType"/>
+    /// must be <typeparamref name="TRecord"/>.
+    /// </summary>
+    public FixedWidthSchema? Schema { get; set; }
 
 
 
@@ -627,16 +664,23 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
         // cost without benefit for file-based and memory-based streams.
         // The method remains async IAsyncEnumerable as required by the base class.
 
-        var fieldMap = FieldMap.GetResult<TRecord>();
+        var fieldMap = ResolveFieldMap();
         long dataLinesSkipped = 0;
         var separatorLineNo = HeaderLineCount > 0 && FieldSeparator.HasValue
             ? HeaderLineCount + 1
             : -1;
 
-        // Metrics (#30): records the operation duration when the enumerator completes, ends early, or
-        // throws; the per-item/line counters below are no-ops unless a MeterListener is subscribed.
-        var metricTags = FixedWidthMetrics.CreateTags(FixedWidthMetrics.ExtractOperation, typeof(TRecord));
-        using var operationScope = FixedWidthMetrics.MeasureDuration(metricTags);
+        // Metrics (#30, #275): sampled once per operation from the instruments. When no MeterListener
+        // is subscribed the extract loop runs no metric code — the per-line/record calls below are
+        // skipped and neither the tag set nor the duration scope is allocated — so telemetry is
+        // zero-cost and zero-config: it activates automatically when a listener subscribes.
+        var metricsEnabled = FixedWidthMetrics.AnyEnabled;
+        var metricTags = metricsEnabled
+            ? FixedWidthMetrics.CreateTags(FixedWidthMetrics.ExtractOperation, typeof(TRecord))
+            : default;
+        using var operationScope = FixedWidthMetrics.DurationEnabled
+            ? FixedWidthMetrics.MeasureDuration(metricTags)
+            : null;
 
         LogExtractionStarted(fieldMap);
 
@@ -652,7 +696,10 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
             // Update before any processing so that if an exception is thrown,
             // CurrentLineNumber points to the offending line in the file.
             Interlocked.Increment(ref _currentLineNumber);
-            FixedWidthMetrics.RecordLineRead(metricTags);
+            if (metricsEnabled)
+            {
+                FixedWidthMetrics.RecordLineRead(metricTags);
+            }
 
             if (IsStructuralLine(separatorLineNo))
             {
@@ -676,7 +723,10 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
                 {
                     dataLinesSkipped++;
                     IncrementCurrentSkippedItemCount();
-                    FixedWidthMetrics.RecordSkipped(metricTags);
+                    if (metricsEnabled)
+                    {
+                        FixedWidthMetrics.RecordSkipped(metricTags);
+                    }
                     LogDebugBlankLineInSkipBudget(dataLinesSkipped);
                     continue;
                 }
@@ -691,7 +741,10 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
 
                 LogDebugBlankLineYieldedAsDefault();
                 IncrementCurrentItemCount();
-                FixedWidthMetrics.RecordExtracted(metricTags);
+                if (metricsEnabled)
+                {
+                    FixedWidthMetrics.RecordExtracted(metricTags);
+                }
                 yield return defaultRecord;
                 continue;
             }
@@ -715,7 +768,10 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
             {
                 dataLinesSkipped++;
                 IncrementCurrentSkippedItemCount();
-                FixedWidthMetrics.RecordSkipped(metricTags);
+                if (metricsEnabled)
+                {
+                    FixedWidthMetrics.RecordSkipped(metricTags);
+                }
                 LogDebugDataLineSkipped(dataLinesSkipped);
                 continue;
             }
@@ -747,7 +803,10 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
 
             LogDebugRecordParsed();
             IncrementCurrentItemCount();
-            FixedWidthMetrics.RecordExtracted(metricTags);
+            if (metricsEnabled)
+            {
+                FixedWidthMetrics.RecordExtracted(metricTags);
+            }
             yield return record;
         }
 
@@ -1022,9 +1081,77 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
 
 
 
+    /// <summary>
+    /// Translates this extractor's <see cref="MalformedLineHandling"/> knob into the base
+    /// per-item error policy. <see cref="MalformedLineHandling.Skip"/> maps to
+    /// <see cref="ItemErrorAction.Skip"/>; <see cref="MalformedLineHandling.ThrowException"/>
+    /// maps to <see cref="ItemErrorAction.Abort"/>. <see cref="MalformedLineHandling.ReturnDefault"/>
+    /// recovers with a substitute record before the give-up decision, so it never reaches this
+    /// hook.
+    /// </summary>
+    /// <param name="context">The failure context supplied by the extract worker.</param>
+    /// <returns>The action the base class should apply to the failed line.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <see cref="MalformedLineHandling"/> holds an unrecognized value.
+    /// </exception>
+    protected override ItemErrorAction OnItemError(ItemErrorContext context)
+    {
+        // Dead-letter capture (#29): report every failure to the sink — on Skip and on Abort — so the
+        // failing record is always observable, then apply the give-up decision below.
+        if (context != null)
+        {
+            OnError?.Invoke(new FixedWidthError(context.ItemNumber, context.RawContent?.Invoke(), context.Exception));
+        }
+
+        switch (MalformedLineHandling)
+        {
+            case MalformedLineHandling.Skip:
+                return ItemErrorAction.Skip;
+
+            case MalformedLineHandling.ThrowException:
+                return ItemErrorAction.Abort;
+
+            default:
+                throw new InvalidOperationException
+                (
+                    $"Unexpected {nameof(MalformedLineHandling)} value: {MalformedLineHandling}"
+                );
+        }
+    }
+
+
+
     // ------------------------------------------------------------------
     // Private helpers
     // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Resolves the field map to use: the caller-supplied <see cref="Schema"/> when set, otherwise the
+    /// attribute-derived layout for <typeparamref name="TRecord"/>.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// <see cref="Schema"/> is set but describes a different record type.
+    /// </exception>
+    private FieldMapResult ResolveFieldMap()
+    {
+        if (Schema is null)
+        {
+            return FieldMap.GetResult<TRecord>();
+        }
+
+        if (Schema.RecordType != typeof(TRecord))
+        {
+            throw new InvalidOperationException
+            (
+                $"The supplied Schema describes '{Schema.RecordType.FullName}' but this extractor is " +
+                $"typed for '{typeof(TRecord).FullName}'."
+            );
+        }
+
+        return Schema.MapResult;
+    }
+
+
 
     /// <summary>
     /// Returns <see langword="true"/> if the current line is a header or separator
@@ -1139,26 +1266,26 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
         {
             LogMalformedLine(ex);
 
-            switch (MalformedLineHandling)
+            // ReturnDefault recovers with a substitute record — it never reaches the
+            // "give up on this item" decision, so it does not go through the base error
+            // policy. The caller performs the yield and item-count increment.
+            if (MalformedLineHandling == MalformedLineHandling.ReturnDefault)
             {
-                case MalformedLineHandling.Skip:
-                    IncrementRejectedItemCount();
-                    return false;
-
-                case MalformedLineHandling.ReturnDefault:
-                    // Cannot yield inside catch — caller handles the yield and increment.
-                    record = CreateDefaultRecord(fieldMap);
-                    return true;
-
-                case MalformedLineHandling.ThrowException:
-                    throw;
-
-                default:
-                    throw new InvalidOperationException
-                    (
-                        $"Unexpected {nameof(MalformedLineHandling)} value: {MalformedLineHandling}"
-                    );
+                record = CreateDefaultRecord(fieldMap);
+                return true;
             }
+
+            // Throw / Skip are the give-up decisions. Route them through the base
+            // per-item error policy (OnItemError, translated from MalformedLineHandling)
+            // so the failure is counted (CurrentErrorItemCount) and surfaced in the
+            // pipeline (ErrorItemCount) rather than being silent.
+            if (HandleItemError(new ItemErrorContext(_currentLineNumber, ex, () => line)) == ItemErrorAction.Abort)
+            {
+                throw;
+            }
+
+            IncrementRejectedItemCount();
+            return false;
         }
     }
 }

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthExtractor.cs
@@ -364,8 +364,8 @@ public class FixedWidthExtractor<TRecord> : ExtractorBase<TRecord, FixedWidthRep
 
     /// <summary>
     /// An optional dead-letter sink invoked once for each record that fails to parse (#29). The
-    /// failed line is reported as a <see cref="FixedWidthError"/> — its 1-based ordinal, raw content,
-    /// and exception — so the caller can log it, push it to a dead-letter queue, or collect it for
+    /// failed line is reported as a <see cref="FixedWidthError"/> — its 1-based source line number, raw
+    /// content, and exception — so the caller can log it, push it to a dead-letter queue, or collect it for
     /// post-run inspection. Set <see cref="MalformedLineHandling"/> to
     /// <see cref="Enums.MalformedLineHandling.Skip"/> to capture-and-continue; with the default
     /// <see cref="Enums.MalformedLineHandling.ThrowException"/> the failure is still reported here

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthLoader.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthLoader.cs
@@ -389,6 +389,17 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
 
 
     /// <summary>
+    /// An optional layout that overrides the <c>[FixedWidthField]</c> / <c>[FixedWidthSkip]</c> attributes
+    /// on <typeparamref name="TRecord"/> (#23). Build one with <see cref="FixedWidthSchemaBuilder{T}"/> to
+    /// map a type you cannot decorate, or to define the layout in code. When <see langword="null"/> (the
+    /// default) the attribute-based layout is used. The schema's <see cref="FixedWidthSchema.RecordType"/>
+    /// must be <typeparamref name="TRecord"/>.
+    /// </summary>
+    public FixedWidthSchema? Schema { get; set; }
+
+
+
+    /// <summary>
     /// The 1-based physical line number of the line most recently written to the output.
     /// Updated after each line is written. Includes the header line and separator line
     /// if written. Matches the line number shown in a text editor.
@@ -470,19 +481,60 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
 
 
 
+    /// <summary>
+    /// Resolves the field map to use: the caller-supplied <see cref="Schema"/> when set, otherwise the
+    /// attribute-derived layout for <typeparamref name="TRecord"/>.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// <see cref="Schema"/> is set but describes a different record type.
+    /// </exception>
+    private FieldMapResult ResolveFieldMap()
+    {
+        if (Schema is null)
+        {
+            return FieldMap.GetResult<TRecord>();
+        }
+
+        if (Schema.RecordType != typeof(TRecord))
+        {
+            throw new InvalidOperationException
+            (
+                $"The supplied Schema describes '{Schema.RecordType.FullName}' but this loader is " +
+                $"typed for '{typeof(TRecord).FullName}'."
+            );
+        }
+
+        return Schema.MapResult;
+    }
+
+
+
     /// <inheritdoc/>
+#pragma warning disable MA0051 // hot-path load loop; the metric guards (#275) are inlined intentionally so the default metrics-off path calls and allocates nothing
     protected override async Task LoadWorkerAsync
     (
         IAsyncEnumerable<TRecord> items,
         CancellationToken token
     )
     {
-        var fieldMap = FieldMap.GetResult<TRecord>();
+        // Honor an already-cancelled token before consuming the source or writing a header, so a
+        // pre-cancelled load reads nothing (TestKit LoaderBase cancellation contract).
+        token.ThrowIfCancellationRequested();
+
+        var fieldMap = ResolveFieldMap();
         LogLoadingStarted(fieldMap);
 
-        // Metrics (#30): duration recorded on completion/throw; counters are no-ops without a listener.
-        var metricTags = FixedWidthMetrics.CreateTags(FixedWidthMetrics.LoadOperation, typeof(TRecord));
-        using var operationScope = FixedWidthMetrics.MeasureDuration(metricTags);
+        // Metrics (#30, #275): sampled once per operation from the instruments. When no MeterListener
+        // is subscribed the load loop runs no metric code — the per-record calls below are skipped and
+        // neither the tag set nor the duration scope is allocated — so telemetry is zero-cost and
+        // zero-config: it activates automatically when a listener subscribes.
+        var metricsEnabled = FixedWidthMetrics.AnyEnabled;
+        var metricTags = metricsEnabled
+            ? FixedWidthMetrics.CreateTags(FixedWidthMetrics.LoadOperation, typeof(TRecord))
+            : default;
+        using var operationScope = FixedWidthMetrics.DurationEnabled
+            ? FixedWidthMetrics.MeasureDuration(metricTags)
+            : null;
 
         // In dry-run mode, route all formatting through a throwaway writer so the
         // pipeline — including field-width validation — still runs, but nothing
@@ -507,7 +559,10 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
             if (CurrentSkippedItemCount < SkipItemCount)
             {
                 IncrementCurrentSkippedItemCount();
-                FixedWidthMetrics.RecordSkipped(metricTags);
+                if (metricsEnabled)
+                {
+                    FixedWidthMetrics.RecordSkipped(metricTags);
+                }
                 LogDebugItemSkipped();
                 continue;
             }
@@ -529,7 +584,10 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
             Interlocked.Increment(ref _currentLineNumber);
             await target.WriteLineAsync().ConfigureAwait(false);
             IncrementCurrentItemCount();
-            FixedWidthMetrics.RecordLoaded(metricTags);
+            if (metricsEnabled)
+            {
+                FixedWidthMetrics.RecordLoaded(metricTags);
+            }
             LogDebugRecordWritten();
         }
 
@@ -537,6 +595,7 @@ public class FixedWidthLoader<TRecord> : LoaderBase<TRecord, FixedWidthReport>, 
 
         LogLoadingCompleted();
     }
+#pragma warning restore MA0051
 
 
 

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthSchema.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthSchema.cs
@@ -26,17 +26,29 @@ namespace Wolfgang.Etl.FixedWidth;
 /// </example>
 public sealed class FixedWidthSchema
 {
-    private FixedWidthSchema
+    internal FixedWidthSchema
     (
         Type recordType,
         IReadOnlyList<FixedWidthFieldInfo> fields,
-        int expectedLineWidth
+        int expectedLineWidth,
+        FieldMapResult mapResult
     )
     {
         RecordType = recordType;
         Fields = fields;
         ExpectedLineWidth = expectedLineWidth;
+        MapResult = mapResult;
     }
+
+
+
+    /// <summary>
+    /// The resolved, executable field map (compiled accessors, factory, positions) the extractor and
+    /// loader use when this schema is supplied via their <c>Schema</c> property (#23). Whether the schema
+    /// was resolved from attributes (<see cref="For(Type)"/>) or built with
+    /// <see cref="FixedWidthSchemaBuilder{T}"/>, this is the same shape as the attribute-derived map.
+    /// </summary>
+    internal FieldMapResult MapResult { get; }
 
 
 
@@ -71,7 +83,7 @@ public sealed class FixedWidthSchema
             width += column.Length;
         }
 
-        return new FixedWidthSchema(recordType, fields.AsReadOnly(), width);
+        return new FixedWidthSchema(recordType, fields.AsReadOnly(), width, FieldMap.GetResult(recordType));
     }
 
 

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthSchemaBuilder.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthSchemaBuilder.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Wolfgang.Etl.FixedWidth.Attributes;
+using Wolfgang.Etl.FixedWidth.Enums;
+using Wolfgang.Etl.FixedWidth.Parsing;
+
+namespace Wolfgang.Etl.FixedWidth;
+
+/// <summary>
+/// Builds a <see cref="FixedWidthSchema"/> for <typeparamref name="T"/> from a fluent, type-safe code
+/// API instead of <c>[FixedWidthField]</c> / <c>[FixedWidthSkip]</c> attributes (#23). Use it when the
+/// record type is not yours to decorate, when you prefer configuration-as-code, or when the layout is
+/// built dynamically. The resulting schema is equivalent to one resolved from attributes — assign it to
+/// <see cref="FixedWidthExtractor{TRecord}.Schema"/> / <see cref="FixedWidthLoader{TRecord}.Schema"/> to
+/// use it, or inspect it with <see cref="FixedWidthSchema.Fields"/> / <see cref="FixedWidthSchema.ToDiagram"/>.
+/// </summary>
+/// <typeparam name="T">The record type the schema describes.</typeparam>
+/// <example>
+/// <code>
+/// var schema = new FixedWidthSchemaBuilder&lt;CustomerRecord&gt;()
+///     .Field(r =&gt; r.CustomerId, index: 0, length: 8)
+///     .Field(r =&gt; r.Name, index: 1, length: 30)
+///     .Skip(index: 2, length: 5)
+///     .Field(r =&gt; r.Balance, index: 3, length: 9, alignment: FieldAlignment.Right, format: "0000000.00")
+///     .Build();
+///
+/// var extractor = new FixedWidthExtractor&lt;CustomerRecord&gt;(reader) { Schema = schema };
+/// </code>
+/// </example>
+public sealed class FixedWidthSchemaBuilder<T>
+    where T : notnull
+{
+    private readonly List<Entry> _entries = new();
+
+
+    /// <summary>
+    /// Adds a mapped field. The <paramref name="index"/> is a zero-based column ordinal (matching
+    /// <c>[FixedWidthField(index, length)]</c>); start positions are computed by summing the lengths of
+    /// all lower-indexed columns, so indexes only need to be unique, not contiguous.
+    /// </summary>
+    /// <typeparam name="TProperty">The property type.</typeparam>
+    /// <param name="selector">A simple property access expression, e.g. <c>r =&gt; r.Name</c>.</param>
+    /// <param name="index">The zero-based column index. Must be unique across fields and skips.</param>
+    /// <param name="length">The field width in characters. Must be greater than zero.</param>
+    /// <param name="alignment">Padding alignment for writing. Defaults to <see cref="FieldAlignment.Left"/>.</param>
+    /// <param name="pad">Pad character for writing. Defaults to <c>' '</c>.</param>
+    /// <param name="format">Optional format string for parsing/formatting the value.</param>
+    /// <param name="header">Optional header label; defaults to the property name when writing headers.</param>
+    /// <param name="numberStyles">Optional <see cref="NumberStyles"/> for numeric parsing; defaults to the type's natural style.</param>
+    /// <param name="trimValue">Whether to trim whitespace from the extracted value. Defaults to <see langword="true"/>.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="selector"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="selector"/> is not a simple property access.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is negative or <paramref name="length"/> is not positive.</exception>
+    /// <exception cref="InvalidOperationException">The selected property has no public setter.</exception>
+    public FixedWidthSchemaBuilder<T> Field<TProperty>
+    (
+        Expression<Func<T, TProperty>> selector,
+        int index,
+        int length,
+        FieldAlignment alignment = FieldAlignment.Left,
+        char pad = ' ',
+        string? format = null,
+        string? header = null,
+        NumberStyles? numberStyles = null,
+        bool trimValue = true
+    )
+    {
+        if (selector is null)
+        {
+            throw new ArgumentNullException(nameof(selector));
+        }
+
+        var property = ResolveProperty(selector);
+        if (property.SetMethod is null || !property.SetMethod.IsPublic)
+        {
+            throw new InvalidOperationException
+            (
+                $"Property '{property.Name}' on '{typeof(T).FullName}' has no public setter; " +
+                "a fixed-width field must be writable for extraction."
+            );
+        }
+
+        var attribute = new FixedWidthFieldAttribute(index, length)
+        {
+            Alignment = alignment,
+            Pad = pad,
+            Format = format,
+            Header = header,
+            TrimValue = trimValue,
+            NumberStyles = numberStyles ?? FixedWidthFieldAttribute.UnspecifiedNumberStyles,
+        };
+
+        _entries.Add(new Entry(property, attribute, skip: null));
+        return this;
+    }
+
+
+    /// <summary>
+    /// Adds a skipped column — a range in the file mapped to no property. Its width still contributes to
+    /// the positions of later fields.
+    /// </summary>
+    /// <param name="index">The zero-based column index. Must be unique across fields and skips.</param>
+    /// <param name="length">The skipped width in characters. Must be greater than zero.</param>
+    /// <param name="message">Optional note describing the skipped column (surfaced by schema introspection).</param>
+    /// <returns>The same builder, for chaining.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is negative or <paramref name="length"/> is not positive.</exception>
+    public FixedWidthSchemaBuilder<T> Skip(int index, int length, string? message = null)
+    {
+        var attribute = new FixedWidthSkipAttribute(index, length) { Message = message };
+        _entries.Add(new Entry(property: null, field: null, attribute));
+        return this;
+    }
+
+
+    /// <summary>
+    /// Validates the accumulated fields and skips and produces the immutable <see cref="FixedWidthSchema"/>.
+    /// </summary>
+    /// <returns>The resolved schema.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// No fields were defined, or two columns share the same index.
+    /// </exception>
+    public FixedWidthSchema Build()
+    {
+        if (_entries.TrueForAll(e => e.IsSkip))
+        {
+            throw new InvalidOperationException("The schema must define at least one field.");
+        }
+
+        var duplicate = _entries
+            .GroupBy(e => e.Index)
+            .FirstOrDefault(g => g.Count() > 1);
+
+        if (duplicate != null)
+        {
+            throw new InvalidOperationException
+            (
+                $"Duplicate column index {duplicate.Key}. Each field and skip must have a unique index."
+            );
+        }
+
+        var ordered = _entries.OrderBy(e => e.Index).ToList();
+        var descriptors = new List<FieldDescriptor>();
+        var fields = new List<FixedWidthFieldInfo>(ordered.Count);
+        var position = 0;
+        var columnIndex = 0;
+
+        foreach (var entry in ordered)
+        {
+            if (!entry.IsSkip)
+            {
+                descriptors.Add(new FieldDescriptor(entry.Property!, entry.Field!, position, columnIndex));
+            }
+
+            fields.Add(FixedWidthFieldInfo.From(new FieldMap.ColumnLayout(columnIndex, position, entry.Property, entry.Field, entry.Skip)));
+            position += entry.Length;
+            columnIndex++;
+        }
+
+        var mapResult = new FieldMapResult
+        (
+            descriptors.AsReadOnly(),
+            expectedLineWidth: position,
+            totalColumnCount: columnIndex,
+            factory: FieldMapResult.CompileFactory(typeof(T))
+        );
+
+        return new FixedWidthSchema(typeof(T), fields.AsReadOnly(), position, mapResult);
+    }
+
+
+    private static PropertyInfo ResolveProperty<TProperty>(Expression<Func<T, TProperty>> selector)
+    {
+        var body = selector.Body;
+
+        // Unwrap the Convert node the compiler inserts when a value-type property is used through the
+        // Func<T, TProperty> boxing (e.g. r => r.Age where TProperty is object).
+        if (body is UnaryExpression { NodeType: ExpressionType.Convert } unary)
+        {
+            body = unary.Operand;
+        }
+
+        if (body is MemberExpression { Member: PropertyInfo property })
+        {
+            return property;
+        }
+
+        throw new ArgumentException
+        (
+            "The selector must be a simple property access, for example 'r => r.Name'.",
+            nameof(selector)
+        );
+    }
+
+
+    private sealed class Entry
+    {
+        internal Entry(PropertyInfo? property, FixedWidthFieldAttribute? field, FixedWidthSkipAttribute? skip)
+        {
+            Property = property;
+            Field = field;
+            Skip = skip;
+        }
+
+        internal PropertyInfo? Property { get; }
+
+        internal FixedWidthFieldAttribute? Field { get; }
+
+        internal FixedWidthSkipAttribute? Skip { get; }
+
+        internal bool IsSkip => Skip != null;
+
+        internal int Index => Skip?.Index ?? Field!.Index;
+
+        internal int Length => Skip?.Length ?? Field!.Length;
+    }
+}

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthSchemaBuilder.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthSchemaBuilder.cs
@@ -184,14 +184,19 @@ public sealed class FixedWidthSchemaBuilder<T>
             body = unary.Operand;
         }
 
-        if (body is MemberExpression { Member: PropertyInfo property })
+        // Require a property accessed directly on the record parameter (r => r.Name). A nested or
+        // foreign member access (r => r.Address.Street, or a captured variable) has a non-parameter
+        // Expression and would compile a delegate that casts the record to the wrong declaring type
+        // and fail at runtime — reject it here with a clear message instead.
+        if (body is MemberExpression { Member: PropertyInfo property, Expression: ParameterExpression })
         {
             return property;
         }
 
         throw new ArgumentException
         (
-            "The selector must be a simple property access, for example 'r => r.Name'.",
+            "The selector must be a simple property access directly on the record, for example "
+            + "'r => r.Name'. Nested (r => r.Address.Street) and captured member accesses are not supported.",
             nameof(selector)
         );
     }

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthTransformer.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthTransformer.cs
@@ -93,6 +93,10 @@ public sealed class FixedWidthTransformer<TSource, TDestination> : TransformerBa
             throw new ArgumentNullException(nameof(source));
         }
 
+        // Honor an already-cancelled token before consuming the source, so a pre-cancelled transform
+        // reads nothing (TestKit TransformerBase cancellation contract).
+        cancellationToken.ThrowIfCancellationRequested();
+
         await foreach (var item in source.WithCancellation(cancellationToken).ConfigureAwait(false))
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -155,6 +159,10 @@ public sealed class FixedWidthTransformer<TSource, TDestination> : TransformerBa
 
 
 
+#if NET8_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Expression.Compile is RequiresDynamicCode but falls back to the interpreter when RuntimeFeature.IsDynamicCodeSupported is false, so the compiled property mapper still runs correctly under Native AOT (without JIT speed). See #153.")]
+#endif
     private static Func<TSource, TDestination> BuildPropertyMapper()
     {
         var constructor = typeof(TDestination).GetConstructor(Type.EmptyTypes)

--- a/src/Wolfgang.Etl.FixedWidth/Parsing/FieldDescriptor.cs
+++ b/src/Wolfgang.Etl.FixedWidth/Parsing/FieldDescriptor.cs
@@ -118,6 +118,10 @@ internal sealed class FieldDescriptor
     /// <summary>
     /// Compiles a getter delegate: (object instance) => (object?)instance.Property
     /// </summary>
+#if NET8_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Expression.Compile is RequiresDynamicCode but falls back to the interpreter when RuntimeFeature.IsDynamicCodeSupported is false, so the compiled getter still runs correctly under Native AOT (without JIT speed). See #153.")]
+#endif
     private static Func<object, object?> CompileGetter(PropertyInfo property)
     {
         // Parameter: object instance
@@ -140,6 +144,10 @@ internal sealed class FieldDescriptor
     /// <summary>
     /// Compiles a setter delegate: (object instance, object? value) => instance.Property = (T)value
     /// </summary>
+#if NET8_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Expression.Compile is RequiresDynamicCode but falls back to the interpreter when RuntimeFeature.IsDynamicCodeSupported is false, so the compiled setter still runs correctly under Native AOT (without JIT speed). See #153.")]
+#endif
     private static Action<object, object?> CompileSetter(PropertyInfo property)
     {
         // Parameters: object instance, object? value

--- a/src/Wolfgang.Etl.FixedWidth/Parsing/FieldMap.cs
+++ b/src/Wolfgang.Etl.FixedWidth/Parsing/FieldMap.cs
@@ -30,6 +30,16 @@ internal static class FieldMap
 
 
 
+    /// <summary>
+    /// Non-generic overload of <see cref="GetResult{T}"/> for callers that hold a
+    /// <see cref="Type"/> rather than a compile-time type argument (for example
+    /// <see cref="FixedWidthSchema.For(Type)"/>).
+    /// </summary>
+    internal static FieldMapResult GetResult(Type type)
+        => Cache.GetOrAdd(type, Resolve);
+
+
+
     // ------------------------------------------------------------------
     // Private helpers
     // ------------------------------------------------------------------

--- a/src/Wolfgang.Etl.FixedWidth/Parsing/FieldMapResult.cs
+++ b/src/Wolfgang.Etl.FixedWidth/Parsing/FieldMapResult.cs
@@ -77,6 +77,10 @@ internal sealed class FieldMapResult
     /// Returns a throwing delegate if the type has no public parameterless constructor
     /// (e.g. when used by the loader which never needs to instantiate records).
     /// </summary>
+#if NET8_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050",
+        Justification = "Expression.Compile is RequiresDynamicCode but falls back to the interpreter when RuntimeFeature.IsDynamicCodeSupported is false, so the compiled activator still runs correctly under Native AOT (without JIT speed). See #153.")]
+#endif
     internal static Func<object> CompileFactory(Type type)
     {
         var ctor = type.GetConstructor(Type.EmptyTypes);

--- a/src/Wolfgang.Etl.FixedWidth/PublicAPI.Shipped.txt
+++ b/src/Wolfgang.Etl.FixedWidth/PublicAPI.Shipped.txt
@@ -70,6 +70,11 @@ Wolfgang.Etl.FixedWidth.FieldContext.Pad.get -> char
 Wolfgang.Etl.FixedWidth.FieldContext.PropertyName.get -> string
 Wolfgang.Etl.FixedWidth.FieldContext.PropertyType.get -> System.Type
 Wolfgang.Etl.FixedWidth.FixedWidthConverter
+Wolfgang.Etl.FixedWidth.FixedWidthError
+Wolfgang.Etl.FixedWidth.FixedWidthError.Exception.get -> System.Exception
+Wolfgang.Etl.FixedWidth.FixedWidthError.FixedWidthError(long itemNumber, string rawContent, System.Exception exception) -> void
+Wolfgang.Etl.FixedWidth.FixedWidthError.ItemNumber.get -> long
+Wolfgang.Etl.FixedWidth.FixedWidthError.RawContent.get -> string?
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.BlankLineHandling.get -> Wolfgang.Etl.FixedWidth.Enums.BlankLineHandling
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.BlankLineHandling.set -> void
@@ -92,8 +97,12 @@ Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.LineFilter.get -> System.Fu
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.LineFilter.set -> void
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.MalformedLineHandling.get -> Wolfgang.Etl.FixedWidth.Enums.MalformedLineHandling
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.MalformedLineHandling.set -> void
+Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.OnError.get -> System.Action<Wolfgang.Etl.FixedWidth.FixedWidthError>
+Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.OnError.set -> void
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.RecordValidator.get -> System.Func<TRecord, Wolfgang.Etl.FixedWidth.ValidationResult>
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.RecordValidator.set -> void
+Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.Schema.get -> Wolfgang.Etl.FixedWidth.FixedWidthSchema?
+Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.Schema.set -> void
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.ValueParser.get -> Wolfgang.Etl.FixedWidth.FixedWidthValueParser
 Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.ValueParser.set -> void
 Wolfgang.Etl.FixedWidth.FixedWidthFieldInfo
@@ -124,6 +133,8 @@ Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.HeaderConverter.get -> System.
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.HeaderConverter.set -> void
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.IsDryRun.get -> bool
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.IsDryRun.set -> void
+Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.Schema.get -> Wolfgang.Etl.FixedWidth.FixedWidthSchema?
+Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.Schema.set -> void
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.ValueConverter.get -> System.Func<object, Wolfgang.Etl.FixedWidth.FieldContext, string>
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.ValueConverter.set -> void
 Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.WriteHeader.get -> bool
@@ -143,6 +154,11 @@ Wolfgang.Etl.FixedWidth.FixedWidthSchema.RecordType.get -> System.Type
 Wolfgang.Etl.FixedWidth.FixedWidthSchema.SkipCount.get -> int
 Wolfgang.Etl.FixedWidth.FixedWidthSchema.ToDiagram() -> string
 Wolfgang.Etl.FixedWidth.FixedWidthSchema.TotalColumnCount.get -> int
+Wolfgang.Etl.FixedWidth.FixedWidthSchemaBuilder<T>
+Wolfgang.Etl.FixedWidth.FixedWidthSchemaBuilder<T>.Build() -> Wolfgang.Etl.FixedWidth.FixedWidthSchema
+Wolfgang.Etl.FixedWidth.FixedWidthSchemaBuilder<T>.Field<TProperty>(System.Linq.Expressions.Expression<System.Func<T, TProperty>> selector, int index, int length, Wolfgang.Etl.FixedWidth.Enums.FieldAlignment alignment = Wolfgang.Etl.FixedWidth.Enums.FieldAlignment.Left, char pad = ' ', string format = null, string header = null, System.Globalization.NumberStyles? numberStyles = null, bool trimValue = true) -> Wolfgang.Etl.FixedWidth.FixedWidthSchemaBuilder<T>
+Wolfgang.Etl.FixedWidth.FixedWidthSchemaBuilder<T>.FixedWidthSchemaBuilder() -> void
+Wolfgang.Etl.FixedWidth.FixedWidthSchemaBuilder<T>.Skip(int index, int length, string message = null) -> Wolfgang.Etl.FixedWidth.FixedWidthSchemaBuilder<T>
 Wolfgang.Etl.FixedWidth.FixedWidthTransformer<TSource, TDestination>
 Wolfgang.Etl.FixedWidth.FixedWidthTransformer<TSource, TDestination>.FixedWidthTransformer(System.Func<TSource, TDestination> transform) -> void
 Wolfgang.Etl.FixedWidth.FixedWidthValueParser
@@ -171,6 +187,7 @@ Wolfgang.Etl.FixedWidth.ValidationResult.Reason.get -> string?
 override Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.CreateProgressReport() -> Wolfgang.Etl.FixedWidth.FixedWidthReport
 override Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.CreateProgressTimer(System.IProgress<Wolfgang.Etl.FixedWidth.FixedWidthReport> progress) -> Wolfgang.Etl.Abstractions.IProgressTimer
 override Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.ExtractWorkerAsync(System.Threading.CancellationToken token) -> System.Collections.Generic.IAsyncEnumerable<TRecord>
+override Wolfgang.Etl.FixedWidth.FixedWidthExtractor<TRecord>.OnItemError(Wolfgang.Etl.Abstractions.ItemErrorContext context) -> Wolfgang.Etl.Abstractions.ItemErrorAction
 override Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.CreateProgressReport() -> Wolfgang.Etl.FixedWidth.FixedWidthReport
 override Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.CreateProgressTimer(System.IProgress<Wolfgang.Etl.FixedWidth.FixedWidthReport> progress) -> Wolfgang.Etl.Abstractions.IProgressTimer
 override Wolfgang.Etl.FixedWidth.FixedWidthLoader<TRecord>.LoadWorkerAsync(System.Collections.Generic.IAsyncEnumerable<TRecord> items, System.Threading.CancellationToken token) -> System.Threading.Tasks.Task

--- a/src/Wolfgang.Etl.FixedWidth/Wolfgang.Etl.FixedWidth.csproj
+++ b/src/Wolfgang.Etl.FixedWidth/Wolfgang.Etl.FixedWidth.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net481;netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
-    <Version>0.7.0</Version>
+    <Version>0.8.0</Version>
     <!-- Pin AssemblyVersion to a fixed binding-stability baseline so consumers
          do not need to recompile / add binding redirects on every minor/patch
          bump. Bump only on a deliberate breaking API change. FileVersion +
@@ -22,7 +22,7 @@
          Intentional breaks in a MAJOR bump are recorded via a generated
          CompatibilitySuppressions.xml. -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.6.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.7.0</PackageValidationBaselineVersion>
     <Title>Wolfgang.Etl.FixedWidth</Title>
     <Description>Extractor and Loader implementations for reading and writing fixed-width text files, built on Wolfgang.Etl.Abstractions.</Description>
     <PackageProjectUrl>https://github.com/Chris-Wolfgang/ETL-FixedWidth</PackageProjectUrl>
@@ -57,7 +57,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.10" />
     <PackageReference Include="System.Memory" Version="4.6.3" />
-    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.17.0" />
+    <PackageReference Include="Wolfgang.Etl.Abstractions" Version="0.21.0" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.10" />
   </ItemGroup>
 

--- a/tests/AotSmoke/Program.cs
+++ b/tests/AotSmoke/Program.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.FixedWidth;
+using Wolfgang.Etl.FixedWidth.Attributes;
+using Wolfgang.Etl.FixedWidth.Enums;
+
+namespace Wolfgang.Etl.FixedWidth.AotSmoke;
+
+// Native-AOT / trim smoke test (#153). Exercises every reflection- and
+// Expression.Compile-backed path in the library against concrete record types,
+// then ASSERTS the results. Under a trimmer that removed the record property
+// metadata FixedWidth reflects over, extraction/loading would silently produce
+// default records — the assertions turn that into a non-zero exit instead of a
+// green "it ran" result. Returns 0 only if every check passes.
+internal static class Program
+{
+    private const string Source =
+        "Alice     Anderson  025\n" +
+        "Bob       Baker     042\n";
+
+    private static async Task<int> Main()
+    {
+        try
+        {
+            // 0. Statically root PersonRecord's parameterless ctor + property getters/setters. A real
+            // AOT app constructs and reads its record types in code; doing so here keeps the trimmer
+            // from removing the members the library then reaches via reflection / compiled accessors.
+            var seed = new PersonRecord { FirstName = "Seed", LastName = "Row", Age = 1 };
+            Check(seed.FirstName == "Seed" && seed.LastName == "Row" && seed.Age == 1, "static record round-trip failed");
+
+            // 1. Schema introspection — FieldMap reflection + FieldMapResult compiled activator.
+            var schema = FixedWidthSchema.For<PersonRecord>();
+            Check(schema.FieldCount == 3, $"schema.FieldCount expected 3, got {schema.FieldCount}");
+            Check(schema.ToDiagram().Contains("FirstName", StringComparison.Ordinal), "ToDiagram missing FirstName");
+
+            // 2. Extract — compiled property setters (FieldDescriptor.CompileSetter).
+            var people = new List<PersonRecord>();
+            using (var extractor = new FixedWidthExtractor<PersonRecord>(new StringReader(Source)))
+            {
+                await foreach (var p in extractor.ExtractAsync(CancellationToken.None).ConfigureAwait(false))
+                {
+                    people.Add(p);
+                }
+            }
+
+            Check(people.Count == 2, $"extracted {people.Count} records, expected 2");
+            Check(people[0].FirstName == "Alice" && people[0].LastName == "Anderson" && people[0].Age == 25,
+                $"record 0 mismatched: '{people[0].FirstName}'/'{people[0].LastName}'/{people[0].Age}");
+
+            // 3. Transform via ByMatchingProperties — Expression.Compile projection.
+            var transformer = FixedWidthTransformer<PersonRecord, PersonRecord>.ByMatchingProperties();
+            var transformed = new List<PersonRecord>();
+            await foreach (var p in transformer.TransformAsync(ToAsync(people), CancellationToken.None).ConfigureAwait(false))
+            {
+                transformed.Add(p);
+            }
+
+            Check(transformed.Count == 2 && transformed[1].Age == 42, "ByMatchingProperties transform lost data");
+
+            // 4. Load — compiled property getters (FieldDescriptor.CompileGetter).
+            var loaded = new StringWriter();
+            using (var loader = new FixedWidthLoader<PersonRecord>(loaded))
+            {
+                await loader.LoadAsync(ToAsync(people), CancellationToken.None).ConfigureAwait(false);
+            }
+
+            Check(loaded.ToString().Contains("Alice", StringComparison.Ordinal), "loader output missing 'Alice'");
+
+            // 5. Full pipeline round trip — extractor factory + loader terminator over EtlPipeline.
+            var piped = new StringWriter();
+            await EtlPipeline
+                .Create()
+                .FixedWidthExtractor<PersonRecord>(new StringReader(Source))
+                .FixedWidthLoader<PersonRecord>(piped)
+                .RunAsync()
+                .ConfigureAwait(false);
+
+            Check(piped.ToString().Contains("Baker", StringComparison.Ordinal), "pipeline output missing 'Baker'");
+
+            Console.WriteLine("AOT smoke: OK — all public paths ran and produced correct results under AOT+trim.");
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"AOT smoke: FAILED — {ex.GetType().Name}: {ex.Message}");
+            return 1;
+        }
+    }
+
+    private static void Check(bool condition, string message)
+    {
+        if (!condition)
+        {
+            throw new InvalidOperationException(message);
+        }
+    }
+
+#pragma warning disable CS1998 // synchronous sample sequence — no await needed
+    private static async IAsyncEnumerable<PersonRecord> ToAsync(IEnumerable<PersonRecord> items)
+    {
+        foreach (var item in items)
+        {
+            yield return item;
+        }
+    }
+#pragma warning restore CS1998
+}
+
+internal sealed class PersonRecord
+{
+    [FixedWidthField(0, 10)]
+    public string FirstName { get; set; } = string.Empty;
+
+    [FixedWidthField(1, 10)]
+    public string LastName { get; set; } = string.Empty;
+
+    [FixedWidthField(2, 3, Alignment = FieldAlignment.Right, Pad = '0')]
+    public int Age { get; set; }
+}

--- a/tests/AotSmoke/Wolfgang.Etl.FixedWidth.AotSmoke.csproj
+++ b/tests/AotSmoke/Wolfgang.Etl.FixedWidth.AotSmoke.csproj
@@ -1,0 +1,47 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Native-AOT / trim smoke consumer (#153). Deliberately NOT listed in
+    "ETL Fixed Width.slnx": a normal Release solution build treats warnings as
+    errors, and the trim/AOT analyzers (IL2xxx / IL3050) would fail that build.
+    The AOT job in pr.yaml publishes this project explicitly with
+    `-p:PublishAot=true` on Linux and then RUNS the native binary — the run
+    (exit 0 + assertions) is the gate, catching a trimmer that removes the
+    record property metadata FixedWidth reflects over.
+  -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <PublishAot>true</PublishAot>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <IsAotCompatible>true</IsAotCompatible>
+    <!-- The run is the gate. Expression.Compile emits IL3050 but falls back to
+         the interpreter under AOT (it does not throw), so warnings must not fail
+         the publish; the assertions below prove correctness. -->
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.FixedWidth\Wolfgang.Etl.FixedWidth.csproj" />
+  </ItemGroup>
+
+  <!--
+    The AOT smoke caught a real trim hazard: Native-AOT trimming strips the
+    [FixedWidthField] custom-attribute *instances* that the mapper reads by
+    reflection, zeroing the field map (FieldCount -> 0, a silent empty result).
+    Root the record assembly (keeps its attribute instances) and the library
+    (keeps the attribute types) so the smoke verifies AOT *execution* correctly —
+    this is the configuration a real AOT consumer of the attribute-based mapper
+    must supply today. Removing the need for it is the source-generated-accessors
+    follow-up on #153 (pilot: ETL-SqlBulkCopy).
+  -->
+  <ItemGroup>
+    <TrimmerRootAssembly Include="Wolfgang.Etl.FixedWidth.AotSmoke" />
+    <TrimmerRootAssembly Include="Wolfgang.Etl.FixedWidth" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Concurrency/ConcurrencyStressTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Concurrency/ConcurrencyStressTests.cs
@@ -1,0 +1,256 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.FixedWidth;
+using Wolfgang.Etl.FixedWidth.Attributes;
+using Wolfgang.Etl.FixedWidth.Enums;
+using Xunit;
+
+namespace Wolfgang.Etl.FixedWidth.Tests.Concurrency;
+
+/// <summary>
+/// Race-condition stress tests (#147). Production usage hits real schedule
+/// interleavings that a single-threaded per-PR test never explores: concurrent
+/// first-use of the process-global caches (<c>FieldMap</c>'s
+/// <see cref="System.Collections.Concurrent.ConcurrentDictionary{TKey,TValue}"/>
+/// and <c>FixedWidthTransformer</c>'s static property-mapper), racing disposal,
+/// and cancellation arriving on a different worker mid-enumeration.
+///
+/// Every test asserts <em>correctness under contention</em> (not timing), so it
+/// is deterministic: a torn cache or shared-state bleed makes a result wrong, not
+/// merely slow. <see cref="Iterations"/> scales via the <c>STRESS_ITERATIONS</c>
+/// environment variable — modest on a PR, generous on the weekly sweep.
+/// </summary>
+[Trait("Category", "Concurrency")]
+public sealed class ConcurrencyStressTests
+{
+    private static int Iterations =>
+        int.TryParse(Environment.GetEnvironmentVariable("STRESS_ITERATIONS"), NumberStyles.Integer, CultureInfo.InvariantCulture, out var n) && n > 0
+            ? n
+            : 64;
+
+    private static readonly int Fanout = Math.Max(4, Environment.ProcessorCount * 2);
+
+
+    [Fact]
+    public async Task Concurrent_extraction_shares_the_field_map_cache_safely()
+    {
+        // Many workers extract the same record type at once. They race to populate
+        // FieldMap's process-global cache on first use; every worker must still get
+        // a correct, complete result.
+        var content = Content(("Alice", "Anderson", 25), ("Bob", "Baker", 42), ("Carol", "Clark", 33));
+
+        await RunFanoutAsync(async () =>
+        {
+            using var extractor = new FixedWidthExtractor<PersonRecord>(new StringReader(content));
+            var rows = new List<PersonRecord>();
+            await foreach (var r in extractor.ExtractAsync(CancellationToken.None).ConfigureAwait(false))
+            {
+                rows.Add(r);
+            }
+
+            Assert.Equal(3, rows.Count);
+            Assert.Equal("Alice", rows[0].FirstName);
+            Assert.Equal(42, rows[1].Age);
+            Assert.Equal("Clark", rows[2].LastName);
+        });
+    }
+
+
+    [Fact]
+    public async Task ByMatchingProperties_is_safe_under_concurrent_first_use()
+    {
+        // FixedWidthTransformer<,>._propertyMapper is a static ??= — concurrent first
+        // callers may build it twice, but both mappers are equivalent, so every
+        // transform must produce identical, correct output.
+        await RunFanoutAsync(async () =>
+        {
+            var transformer = FixedWidthTransformer<PersonRecord, PersonRecord>.ByMatchingProperties();
+            var src = new[]
+            {
+                new PersonRecord { FirstName = "Dana", LastName = "Doe", Age = 51 },
+                new PersonRecord { FirstName = "Evan", LastName = "East", Age = 27 },
+            };
+
+            var outp = new List<PersonRecord>();
+            await foreach (var r in transformer.TransformAsync(ToAsync(src), CancellationToken.None).ConfigureAwait(false))
+            {
+                outp.Add(r);
+            }
+
+            Assert.Equal(2, outp.Count);
+            Assert.Equal("Dana", outp[0].FirstName);
+            Assert.Equal(27, outp[1].Age);
+        });
+    }
+
+
+    [Fact]
+    public async Task Parallel_round_trips_do_not_bleed_state_between_operations()
+    {
+        // Each worker round-trips a distinct payload through an independent
+        // extractor+loader. Shared static state (caches, mappers) must not let one
+        // operation's data leak into another's output.
+        await RunFanoutAsync(async index =>
+        {
+            var name = $"N{index:D5}";
+            var content = Content((name, "Row", index % 100));
+
+            var people = new List<PersonRecord>();
+            using (var extractor = new FixedWidthExtractor<PersonRecord>(new StringReader(content)))
+            {
+                await foreach (var r in extractor.ExtractAsync(CancellationToken.None).ConfigureAwait(false))
+                {
+                    people.Add(r);
+                }
+            }
+
+            var writer = new StringWriter();
+            using (var loader = new FixedWidthLoader<PersonRecord>(writer))
+            {
+                await loader.LoadAsync(ToAsync(people), CancellationToken.None).ConfigureAwait(false);
+            }
+
+            Assert.Single(people);
+            Assert.Equal(name, people[0].FirstName.TrimEnd());
+            Assert.Equal(index % 100, people[0].Age);
+            Assert.Contains(name, writer.ToString(), StringComparison.Ordinal);
+        });
+    }
+
+
+    [Fact]
+    public async Task Dispose_during_enumeration_never_corrupts_yielded_records()
+    {
+        // Dispose the extractor from another task while a worker enumerates. Any
+        // records already yielded must be correct; the enumeration must end cleanly
+        // (completion or a disposal-related exception), never a torn record.
+        var content = Content(Enumerable.Range(0, 500).Select(i => ($"P{i:D6}", "X", i % 90)).ToArray());
+
+        await RunFanoutAsync(async () =>
+        {
+            var extractor = new FixedWidthExtractor<PersonRecord>(new StringReader(content));
+            var seen = 0;
+            try
+            {
+                await foreach (var r in extractor.ExtractAsync(CancellationToken.None).ConfigureAwait(false))
+                {
+                    Assert.False(string.IsNullOrEmpty(r.FirstName));   // never a torn/default record
+                    if (++seen == 10)
+                    {
+#pragma warning disable CS4014 // fire-and-forget dispose to race the enumerator
+                        Task.Run(() => extractor.Dispose());
+#pragma warning restore CS4014
+                    }
+                }
+            }
+            catch (ObjectDisposedException)
+            {
+                // Acceptable: disposal won the race.
+            }
+            catch (InvalidOperationException)
+            {
+                // Acceptable: reader closed underneath the enumerator.
+            }
+            finally
+            {
+                extractor.Dispose();
+            }
+        });
+    }
+
+
+    [Fact]
+    public async Task Cancellation_from_another_thread_stops_enumeration_cleanly()
+    {
+        var content = Content(Enumerable.Range(0, 1000).Select(i => ($"C{i:D6}", "Y", i % 90)).ToArray());
+
+        await RunFanoutAsync(async () =>
+        {
+            using var cts = new CancellationTokenSource();
+            using var extractor = new FixedWidthExtractor<PersonRecord>(new StringReader(content));
+            var seen = 0;
+            try
+            {
+                await foreach (var r in extractor.ExtractAsync(cts.Token).ConfigureAwait(false))
+                {
+                    Assert.False(string.IsNullOrEmpty(r.FirstName));
+                    if (++seen == 5)
+                    {
+                        cts.Cancel();
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected when cancellation wins the race.
+            }
+        });
+    }
+
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    private static Task RunFanoutAsync(Func<Task> body) => RunFanoutAsync(_ => body());
+
+
+    private static async Task RunFanoutAsync(Func<int, Task> body)
+    {
+        var failures = new ConcurrentQueue<Exception>();
+        var total = Iterations * Fanout;
+
+        var tasks = Enumerable.Range(0, total).Select(i => Task.Run(async () =>
+        {
+            try
+            {
+                await body(i).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                failures.Enqueue(ex);
+            }
+        }));
+
+        await Task.WhenAll(tasks).ConfigureAwait(false);
+
+        if (!failures.IsEmpty)
+        {
+            throw new AggregateException($"{failures.Count}/{total} concurrent iterations failed.", failures);
+        }
+    }
+
+
+#pragma warning disable CS1998 // synchronous sample sequence — no await needed
+    private static async IAsyncEnumerable<PersonRecord> ToAsync(IEnumerable<PersonRecord> items)
+    {
+        foreach (var item in items)
+        {
+            yield return item;
+        }
+    }
+#pragma warning restore CS1998
+
+
+    private static string Content(params (string First, string Last, int Age)[] rows)
+        => string.Concat(rows.Select(r => string.Format(CultureInfo.InvariantCulture, "{0,-10}{1,-10}{2:000}\n", r.First, r.Last, r.Age)));
+
+
+    private sealed class PersonRecord
+    {
+        [FixedWidthField(0, 10)]
+        public string FirstName { get; set; } = string.Empty;
+
+        [FixedWidthField(1, 10)]
+        public string LastName { get; set; } = string.Empty;
+
+        [FixedWidthField(2, 3, Alignment = FieldAlignment.Right, Pad = '0')]
+        public int Age { get; set; }
+    }
+}

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Concurrency/Wolfgang.Etl.FixedWidth.Tests.Concurrency.csproj
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Concurrency/Wolfgang.Etl.FixedWidth.Tests.Concurrency.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Concurrency / race-condition stress suite (#147). Per-PR the tests run a
+    modest iteration budget (fast, deterministic — they assert correctness under
+    contention, not timing); the scheduled concurrency.yaml workflow cranks
+    STRESS_ITERATIONS up for a generous weekly sweep. Every test is tagged
+    [Trait("Category","Concurrency")] so a normal run can filter it in or out.
+
+    Coyote (Microsoft's async model checker) is intentionally not wired in: its
+    IAsyncEnumerable support is rough and its CLI is net8-only, so systematic
+    schedule exploration of a streaming library is unreliable. The xunit stress
+    suite is the practical gate; see the workflow header for detail.
+  -->
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <Version>0.1.0</Version>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.FixedWidth\Wolfgang.Etl.FixedWidth.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" NoWarn="NU1701">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <!-- Analyzer PackageReferences are centralized in Directory.Build.props -->
+
+</Project>

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthItemErrorHandlingTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthItemErrorHandlingTests.cs
@@ -230,6 +230,15 @@ public class FixedWidthItemErrorHandlingTests
 
         protected override Report CreateProgressReport() => new(CurrentItemCount);
 
-        public sealed record Report(int Count);
+        // Non-positional record with a get-only property + ctor rather than a positional
+        // record: a positional parameter compiles an `init` setter, which needs
+        // System.Runtime.CompilerServices.IsExternalInit — absent on net462-481 and
+        // netcoreapp3.1. This form keeps value equality without it.
+        public sealed record Report
+        {
+            public Report(int count) => Count = count;
+
+            public int Count { get; }
+        }
     }
 }

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthItemErrorHandlingTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthItemErrorHandlingTests.cs
@@ -1,0 +1,235 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
+using Wolfgang.Etl.FixedWidth.Enums;
+using Wolfgang.Etl.FixedWidth.Exceptions;
+using Xunit;
+
+namespace Wolfgang.Etl.FixedWidth.Tests.Unit;
+
+/// <summary>
+/// Covers the extractor's adoption of the Abstractions #84 per-item error mechanism: a malformed
+/// line routed through <c>MalformedLineHandling</c> now flows through the base
+/// <c>OnItemError</c>/<c>HandleItemError</c> policy, so a genuine parse failure is counted in the
+/// base <see cref="Wolfgang.Etl.Abstractions.ExtractorBase{TSource,TProgress}.CurrentErrorItemCount"/>
+/// and surfaced as <see cref="EtlPipelineProgress.ErrorItemCount"/> — distinct from the broader
+/// <c>CurrentRejectedItemCount</c>, which also counts validator rejects. <c>ReturnDefault</c>
+/// recovers before the give-up decision and is therefore never an error.
+/// </summary>
+public class FixedWidthItemErrorHandlingTests
+{
+    // FirstName(10) + LastName(10) + Age(3). "abc" is an unparseable Age -> malformed line.
+    private static string Line(string first, string last, string age) =>
+        first.PadRight(10) + last.PadRight(10) + age.PadLeft(3, '0');
+
+    private const string BadAge = "abc";
+
+    private static readonly string GoodBadGoodBad = string.Join
+    (
+        "\n",
+        Line("Carol", "Clark", "35"),
+        Line("Eve", "Evans", BadAge),
+        Line("Dan", "Davis", "40"),
+        Line("Foo", "Bar", BadAge)
+    );
+
+
+    [Fact]
+    public async Task Malformed_Skip_counts_as_a_base_error_item()
+    {
+        var extractor = new FixedWidthExtractor<PersonRecord>(new StringReader(GoodBadGoodBad))
+        {
+            MalformedLineHandling = MalformedLineHandling.Skip,
+        };
+
+        var yielded = await Drain(extractor);
+
+        Assert.Equal(2, yielded.Count);                     // Carol, Dan
+        Assert.Equal(2, extractor.CurrentErrorItemCount);   // Eve, Foo — genuine parse failures
+        Assert.Equal(2, extractor.CurrentRejectedItemCount);// same two (no validator here)
+    }
+
+
+    [Fact]
+    public async Task Validator_reject_is_not_a_base_error_item()
+    {
+        // The one line parses fine but the validator rejects it. That is a business decision,
+        // not a parse error — CurrentRejectedItemCount counts it, CurrentErrorItemCount does not.
+        var extractor = new FixedWidthExtractor<PersonRecord>(new StringReader(Line("Bob", "Brown", "30")))
+        {
+            RecordValidator = _ => ValidationResult.Skip("no bobs"),
+        };
+
+        var yielded = await Drain(extractor);
+
+        Assert.Empty(yielded);
+        Assert.Equal(0, extractor.CurrentErrorItemCount);    // not an error
+        Assert.Equal(1, extractor.CurrentRejectedItemCount); // but still a reject
+    }
+
+
+    [Fact]
+    public async Task Malformed_ReturnDefault_recovers_and_is_not_an_error()
+    {
+        var extractor = new FixedWidthExtractor<PersonRecord>(new StringReader(Line("Eve", "Evans", BadAge)))
+        {
+            MalformedLineHandling = MalformedLineHandling.ReturnDefault,
+        };
+
+        var yielded = await Drain(extractor);
+
+        Assert.Single(yielded);                             // a substitute default record
+        Assert.Equal(0, extractor.CurrentErrorItemCount);   // recovery never reaches the error policy
+    }
+
+
+    [Fact]
+    public async Task Mixed_stream_keeps_ReturnDefault_recovery_and_validator_reject_off_the_error_policy()
+    {
+        // One stream interleaves all three per-item outcomes to lock in the invariant that neither a
+        // ReturnDefault recovery nor a validator reject is ever counted as a parse error:
+        //   Carol — parses and passes the validator                 -> yielded
+        //   Eve   — malformed, MalformedLineHandling.ReturnDefault   -> a default substitute, yielded
+        //   Bob   — parses but the validator rejects it (business)   -> dropped
+        var input = string.Join
+        (
+            "\n",
+            Line("Carol", "Clark", "35"),
+            Line("Eve", "Evans", BadAge),
+            Line("Bob", "Brown", "30")
+        );
+
+        var extractor = new FixedWidthExtractor<PersonRecord>(new StringReader(input))
+        {
+            MalformedLineHandling = MalformedLineHandling.ReturnDefault,
+            RecordValidator = record =>
+                (record.FirstName ?? string.Empty).IndexOf("Bob", System.StringComparison.Ordinal) >= 0
+                    ? ValidationResult.Skip("no bobs")
+                    : ValidationResult.Accept(),
+        };
+
+        var yielded = await Drain(extractor);
+
+        Assert.Equal(2, yielded.Count);                      // Carol + Eve's default substitute; Bob dropped
+        Assert.Equal(0, extractor.CurrentErrorItemCount);    // ReturnDefault recovery and a validator reject are both non-errors
+        Assert.Equal(1, extractor.CurrentRejectedItemCount); // only the validator reject (Bob)
+    }
+
+
+    [Fact]
+    public async Task Malformed_ThrowException_aborts_the_run()
+    {
+        var extractor = new FixedWidthExtractor<PersonRecord>(new StringReader(GoodBadGoodBad));
+        // default MalformedLineHandling == ThrowException -> OnItemError returns Abort -> rethrow
+
+        await Assert.ThrowsAnyAsync<MalformedLineException>(() => Drain(extractor));
+    }
+
+
+    [Fact]
+    public async Task Pipeline_ErrorItemCount_surfaces_the_malformed_skips()
+    {
+        var reports = new List<EtlPipelineProgress>();
+        var progress = new SyncProgress(reports.Add);
+        var extractor = new FixedWidthExtractor<PersonRecord>(new StringReader(GoodBadGoodBad))
+        {
+            MalformedLineHandling = MalformedLineHandling.Skip,
+        };
+        var loader = new CountingLoader();
+
+        await EtlPipeline
+            .Create()
+            .From(extractor)
+            .To(loader)
+            .RunAsync(progress);
+
+        var final = reports[^1];
+        Assert.Equal(2, final.ExtractedItemCount);
+        Assert.Equal(2, final.LoadedItemCount);
+        Assert.Equal(2, final.ErrorItemCount);
+        Assert.Equal(2, loader.Loaded.Count);
+    }
+
+
+    [Fact]
+    public async Task OnError_captures_the_failed_lines_as_dead_letters()
+    {
+        var captured = new List<FixedWidthError>();
+        var extractor = new FixedWidthExtractor<PersonRecord>(new StringReader(GoodBadGoodBad))
+        {
+            MalformedLineHandling = MalformedLineHandling.Skip,
+            OnError = captured.Add,
+        };
+
+        var yielded = await Drain(extractor);
+
+        Assert.Equal(2, yielded.Count);                        // Carol, Dan yielded
+        Assert.Equal(2, captured.Count);                       // Eve, Foo captured
+        Assert.Equal(2, extractor.CurrentErrorItemCount);      // capture doesn't change the counters
+        Assert.All(captured, e => Assert.NotNull(e.Exception));
+        Assert.Contains(captured, e => e.RawContent != null && e.RawContent.Contains("Eve"));
+        Assert.All(captured, e => Assert.True(e.ItemNumber > 0));
+    }
+
+
+    [Fact]
+    public async Task OnError_reports_the_failure_even_when_the_run_aborts()
+    {
+        // Decision: OnError fires on Abort too — the failing record is always observable, then the run
+        // stops (default MalformedLineHandling == ThrowException).
+        var captured = new List<FixedWidthError>();
+        var extractor = new FixedWidthExtractor<PersonRecord>(new StringReader(GoodBadGoodBad))
+        {
+            OnError = captured.Add,
+        };
+
+        await Assert.ThrowsAnyAsync<MalformedLineException>(() => Drain(extractor));
+
+        Assert.Single(captured);                               // the first bad line, reported before the throw
+    }
+
+
+    // ---- helpers / doubles ----
+
+    private static async Task<List<PersonRecord>> Drain(FixedWidthExtractor<PersonRecord> extractor)
+    {
+        var result = new List<PersonRecord>();
+        await foreach (var item in extractor.ExtractAsync(CancellationToken.None).ConfigureAwait(false))
+        {
+            result.Add(item);
+        }
+
+        return result;
+    }
+
+
+    private sealed class SyncProgress : System.IProgress<EtlPipelineProgress>
+    {
+        private readonly System.Action<EtlPipelineProgress> _report;
+
+        public SyncProgress(System.Action<EtlPipelineProgress> report) => _report = report;
+
+        public void Report(EtlPipelineProgress value) => _report(value);
+    }
+
+
+    private sealed class CountingLoader : LoaderBase<PersonRecord, CountingLoader.Report>
+    {
+        public List<PersonRecord> Loaded { get; } = new();
+
+        protected override async Task LoadWorkerAsync(IAsyncEnumerable<PersonRecord> items, CancellationToken token)
+        {
+            await foreach (var item in items.WithCancellation(token).ConfigureAwait(false))
+            {
+                Loaded.Add(item);
+                IncrementCurrentItemCount();
+            }
+        }
+
+        protected override Report CreateProgressReport() => new(CurrentItemCount);
+
+        public sealed record Report(int Count);
+    }
+}

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthMetricsTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthMetricsTests.cs
@@ -107,6 +107,30 @@ public sealed class FixedWidthMetricsTests
 
 
     [Fact]
+    public async Task Metrics_activate_with_no_opt_in_when_a_listener_is_subscribed()
+    {
+        using var capture = new MetricCapture();
+
+        // Zero-config (#275): there is no opt-in flag — a subscribed MeterListener alone turns metrics
+        // on. When nothing is listening the hot loop runs no metric code (that path is the pre-metrics
+        // throughput restored), but the moment a listener subscribes, both stages emit.
+        var extractor = new FixedWidthExtractor<MetricsSample>
+        (
+            new StringReader(Content(("Alice", "Smith", 30), ("Bob", "Jones", 25)))
+        );
+        await DrainAsync(extractor);
+
+        var writer = new StringWriter();
+        var loader = new FixedWidthLoader<MetricsSample>(writer);
+        await loader.LoadAsync(SampleAsync(), CancellationToken.None);
+
+        Assert.NotEmpty(capture.All);
+        Assert.Equal(2, capture.Sum("wolfgang.etl.fixedwidth.items.extracted"));
+        Assert.Equal(2, capture.Sum("wolfgang.etl.fixedwidth.items.loaded"));
+    }
+
+
+    [Fact]
     public void Duration_scope_dispose_is_idempotent()
     {
         using var capture = new MetricCapture();

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthSchemaBuilderTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthSchemaBuilderTests.cs
@@ -1,0 +1,320 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.FixedWidth.Enums;
+using Xunit;
+
+namespace Wolfgang.Etl.FixedWidth.Tests.Unit;
+
+/// <summary>
+/// Covers <see cref="FixedWidthSchemaBuilder{T}"/> and the extractor/loader <c>Schema</c> override (#23):
+/// building a layout in code, using it on a type that carries no attributes, equivalence with the
+/// attribute-resolved layout, and the builder's validation.
+/// </summary>
+public sealed class FixedWidthSchemaBuilderTests
+{
+    // An undecorated record — no [FixedWidthField] attributes — to prove the builder maps a type the
+    // caller does not own / cannot decorate.
+    [ExcludeFromCodeCoverage]
+    public sealed class PlainPerson
+    {
+        public string FirstName { get; set; } = string.Empty;
+
+        public string LastName { get; set; } = string.Empty;
+
+        public int Age { get; set; }
+    }
+
+
+    [ExcludeFromCodeCoverage]
+    private sealed class ReadOnlyProperty
+    {
+        public string Name => "fixed";
+    }
+
+
+    private static FixedWidthSchemaBuilder<PlainPerson> PlainPersonBuilder()
+        => new FixedWidthSchemaBuilder<PlainPerson>()
+            .Field(r => r.FirstName, index: 0, length: 10)
+            .Field(r => r.LastName, index: 1, length: 10)
+            .Field(r => r.Age, index: 2, length: 3, alignment: FieldAlignment.Right, pad: '0');
+
+
+    [Fact]
+    public void Built_schema_is_equivalent_to_the_attribute_schema()
+    {
+        // A builder schema for PersonRecord's exact attribute layout must match FixedWidthSchema.For<PersonRecord>().
+        var built = new FixedWidthSchemaBuilder<PersonRecord>()
+            .Field(r => r.FirstName, 0, 10)
+            .Field(r => r.LastName, 1, 10)
+            .Field(r => r.Age, 2, 3, alignment: FieldAlignment.Right, pad: '0')
+            .Build();
+
+        var fromAttributes = FixedWidthSchema.For<PersonRecord>();
+
+        Assert.Equal(fromAttributes.ExpectedLineWidth, built.ExpectedLineWidth);
+        Assert.Equal(fromAttributes.TotalColumnCount, built.TotalColumnCount);
+        Assert.Equal(fromAttributes.Fields.Count, built.Fields.Count);
+
+        for (var i = 0; i < fromAttributes.Fields.Count; i++)
+        {
+            var expected = fromAttributes.Fields[i];
+            var actual = built.Fields[i];
+            Assert.Equal(expected.Name, actual.Name);
+            Assert.Equal(expected.StartPosition, actual.StartPosition);
+            Assert.Equal(expected.EndPosition, actual.EndPosition);
+            Assert.Equal(expected.Length, actual.Length);
+            Assert.Equal(expected.Alignment, actual.Alignment);
+            Assert.Equal(expected.Pad, actual.Pad);
+            Assert.Equal(expected.IsSkip, actual.IsSkip);
+        }
+    }
+
+
+    [Fact]
+    public async Task Extractor_reads_an_undecorated_type_via_builder_schema()
+    {
+        var schema = PlainPersonBuilder().Build();
+
+        var extractor = new FixedWidthExtractor<PlainPerson>
+        (
+            new StringReader(Content(("Alice", "Smith", 30), ("Bob", "Jones", 25)))
+        )
+        {
+            Schema = schema,
+        };
+
+        var people = await DrainAsync(extractor);
+
+        Assert.Collection
+        (
+            people,
+            p => Assert.Equal(("Alice", "Smith", 30), (p.FirstName, p.LastName, p.Age)),
+            p => Assert.Equal(("Bob", "Jones", 25), (p.FirstName, p.LastName, p.Age))
+        );
+    }
+
+
+    [Fact]
+    public async Task Loader_writes_an_undecorated_type_via_builder_schema()
+    {
+        var schema = PlainPersonBuilder().Build();
+        var writer = new StringWriter();
+        var loader = new FixedWidthLoader<PlainPerson>(writer) { Schema = schema };
+
+        await loader.LoadAsync(ToAsync(new PlainPerson { FirstName = "Alice", LastName = "Smith", Age = 30 }), CancellationToken.None);
+
+        Assert.Equal("Alice     Smith     030", Normalize(writer.ToString()).TrimEnd('\n'));
+    }
+
+
+    [Fact]
+    public async Task Round_trips_an_undecorated_type_through_the_builder_schema()
+    {
+        var schema = PlainPersonBuilder().Build();
+        var source = Content(("Alice", "Smith", 30), ("Bob", "Jones", 25));
+
+        var extractor = new FixedWidthExtractor<PlainPerson>(new StringReader(source)) { Schema = schema };
+        var people = await DrainAsync(extractor);
+
+        var writer = new StringWriter();
+        var loader = new FixedWidthLoader<PlainPerson>(writer) { Schema = schema };
+        await loader.LoadAsync(ToAsync(people.ToArray()), CancellationToken.None);
+
+        Assert.Equal(source.TrimEnd('\n'), Normalize(writer.ToString()).TrimEnd('\n'));
+    }
+
+
+    [Fact]
+    public async Task Skip_column_defined_by_the_builder_is_honored()
+    {
+        // FirstName(0,10) [skip 8] EmployeeNumber(18,6)
+        var schema = new FixedWidthSchemaBuilder<PlainRecordWithSkip>()
+            .Field(r => r.FirstName, 0, 10)
+            .Skip(1, 8, message: "DOB")
+            .Field(r => r.EmployeeNumber, 2, 6)
+            .Build();
+
+        Assert.Equal(24, schema.ExpectedLineWidth);
+        Assert.Equal(1, schema.SkipCount);
+
+        var extractor = new FixedWidthExtractor<PlainRecordWithSkip>
+        (
+            new StringReader("Alice     19900101E12345\n")
+        )
+        {
+            Schema = schema,
+        };
+
+        var records = await DrainAsync(extractor);
+
+        Assert.Single(records);
+        Assert.Equal("Alice", records[0].FirstName);
+        Assert.Equal("E12345", records[0].EmployeeNumber);
+    }
+
+
+    [Fact]
+    public async Task Schema_overrides_attributes_when_set()
+    {
+        // PersonRecord's attributes map all three fields; this schema maps only FirstName, so Age stays default.
+        var schema = new FixedWidthSchemaBuilder<PersonRecord>()
+            .Field(r => r.FirstName, 0, 10)
+            .Skip(1, 13)
+            .Build();
+
+        var extractor = new FixedWidthExtractor<PersonRecord>
+        (
+            new StringReader("Alice     Smith     030\n")
+        )
+        {
+            Schema = schema,
+        };
+
+        var people = await DrainAsync(extractor);
+
+        Assert.Equal("Alice", people[0].FirstName);
+        Assert.Equal(0, people[0].Age);      // not mapped by the override schema
+        Assert.Null(people[0].LastName);     // not mapped
+    }
+
+
+    [Fact]
+    public void Build_with_no_fields_throws()
+    {
+        var builder = new FixedWidthSchemaBuilder<PlainPerson>().Skip(0, 5);
+
+        Assert.Throws<InvalidOperationException>(() => builder.Build());
+    }
+
+
+    [Fact]
+    public void Build_with_duplicate_index_throws()
+    {
+        var builder = new FixedWidthSchemaBuilder<PlainPerson>()
+            .Field(r => r.FirstName, 0, 10)
+            .Field(r => r.LastName, 0, 10);
+
+        Assert.Throws<InvalidOperationException>(() => builder.Build());
+    }
+
+
+    [Fact]
+    public void Field_without_a_public_setter_throws()
+    {
+        var builder = new FixedWidthSchemaBuilder<ReadOnlyProperty>();
+
+        Assert.Throws<InvalidOperationException>(() => builder.Field(r => r.Name, 0, 5));
+    }
+
+
+    [Fact]
+    public void Field_unwraps_a_boxing_conversion_in_the_selector()
+    {
+        // r => (object)r.Age inserts a Convert node the resolver must unwrap to reach the property.
+        var schema = new FixedWidthSchemaBuilder<PlainPerson>()
+            .Field(r => (object)r.Age, 0, 3)
+            .Build();
+
+        Assert.Equal("Age", schema.Fields[0].Name);
+    }
+
+
+    [Fact]
+    public void Field_with_a_non_property_selector_throws()
+    {
+        var builder = new FixedWidthSchemaBuilder<PlainPerson>();
+
+        Assert.Throws<ArgumentException>(() => builder.Field(r => r.Age + 1, 0, 5));
+    }
+
+
+    [Fact]
+    public void Field_rejects_null_selector_and_invalid_index_or_length()
+    {
+        var builder = new FixedWidthSchemaBuilder<PlainPerson>();
+
+        Assert.Throws<ArgumentNullException>(() => builder.Field<string>(null!, 0, 5));
+        Assert.Throws<ArgumentOutOfRangeException>(() => builder.Field(r => r.FirstName, -1, 5));
+        Assert.Throws<ArgumentOutOfRangeException>(() => builder.Field(r => r.FirstName, 0, 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => builder.Skip(0, -3));
+    }
+
+
+    [Fact]
+    public async Task Extractor_with_a_mismatched_schema_record_type_throws()
+    {
+        var plainSchema = PlainPersonBuilder().Build();
+        var extractor = new FixedWidthExtractor<PersonRecord>(new StringReader("Alice     Smith     030\n"))
+        {
+            Schema = plainSchema,   // schema is for PlainPerson, not PersonRecord
+        };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        {
+            await foreach (var _ in extractor.ExtractAsync(CancellationToken.None).ConfigureAwait(false))
+            {
+            }
+        });
+    }
+
+
+    [Fact]
+    public async Task Loader_with_a_mismatched_schema_record_type_throws()
+    {
+        var plainSchema = PlainPersonBuilder().Build();
+        var loader = new FixedWidthLoader<PersonRecord>(new StringWriter()) { Schema = plainSchema };
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            loader.LoadAsync(ToAsync(new PersonRecord { FirstName = "Alice", LastName = "Smith", Age = 30 }), CancellationToken.None));
+    }
+
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    [ExcludeFromCodeCoverage]
+    public sealed class PlainRecordWithSkip
+    {
+        public string FirstName { get; set; } = string.Empty;
+
+        public string EmployeeNumber { get; set; } = string.Empty;
+    }
+
+
+    private static string Content(params (string First, string Last, int Age)[] people)
+        => string.Concat(people.Select(p => string.Format(CultureInfo.InvariantCulture, "{0,-10}{1,-10}{2:000}\n", p.First, p.Last, p.Age)));
+
+
+    private static string Normalize(string text) => text.Replace("\r\n", "\n").Replace("\r", "\n");
+
+
+    private static async Task<IReadOnlyList<T>> DrainAsync<T>(FixedWidthExtractor<T> extractor)
+        where T : notnull, new()
+    {
+        var list = new List<T>();
+        await foreach (var item in extractor.ExtractAsync(CancellationToken.None).ConfigureAwait(false))
+        {
+            list.Add(item);
+        }
+
+        return list;
+    }
+
+
+#pragma warning disable CS1998 // synchronous sample sequence
+    private static async IAsyncEnumerable<T> ToAsync<T>(params T[] items)
+    {
+        foreach (var item in items)
+        {
+            yield return item;
+        }
+    }
+#pragma warning restore CS1998
+}

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthSchemaBuilderTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthSchemaBuilderTests.cs
@@ -38,6 +38,13 @@ public sealed class FixedWidthSchemaBuilderTests
     }
 
 
+    [ExcludeFromCodeCoverage]
+    private sealed class NestedHolder
+    {
+        public PlainPerson Inner { get; set; } = new();
+    }
+
+
     private static FixedWidthSchemaBuilder<PlainPerson> PlainPersonBuilder()
         => new FixedWidthSchemaBuilder<PlainPerson>()
             .Field(r => r.FirstName, index: 0, length: 10)
@@ -231,6 +238,18 @@ public sealed class FixedWidthSchemaBuilderTests
         var builder = new FixedWidthSchemaBuilder<PlainPerson>();
 
         Assert.Throws<ArgumentException>(() => builder.Field(r => r.Age + 1, 0, 5));
+    }
+
+
+    [Fact]
+    public void Field_with_a_nested_property_selector_throws()
+    {
+        var builder = new FixedWidthSchemaBuilder<NestedHolder>();
+
+        // A nested access (r => r.Inner.FirstName) is not a direct property on the record — it would
+        // compile a delegate that casts NestedHolder to PlainPerson and fail at runtime, so it is
+        // rejected up front.
+        Assert.Throws<ArgumentException>(() => builder.Field(r => r.Inner.FirstName, 0, 10));
     }
 
 

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthTransformerTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthTransformerTests.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Wolfgang.Etl.Abstractions;
 using Xunit;
 
 namespace Wolfgang.Etl.FixedWidth.Tests.Unit;
@@ -148,5 +149,88 @@ public class FixedWidthTransformerTests
     {
         // The mapper is compiled eagerly by the factory, so it throws here.
         Assert.Throws<InvalidOperationException>(FixedWidthTransformer<Src, NoParameterlessCtor>.ByMatchingProperties);
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_reports_progress_via_the_injected_timer()
+    {
+        var timer = new ManualProgressTimer();
+        var sink = new CollectingProgress();
+        using var transformer = new FixedWidthTransformer<Src, Dst>(
+            s => new Dst { Name = s.Name, Value = s.Value },
+            timer);
+
+        await foreach (var _ in transformer.TransformAsync(ToAsync(Sources), sink, CancellationToken.None))
+        {
+            // Fire the injected timer mid-enumeration so the wired progress callback runs.
+            timer.Fire();
+        }
+
+        // A report per Fire() proves the injected timer's Elapsed is wired to the progress callback;
+        // the fire after the last item reports the full transformed count.
+        Assert.NotEmpty(sink.Reports);
+        Assert.Equal(Sources.Count, (int)sink.Reports.Max(r => r.CurrentItemCount));
+    }
+
+
+
+    [Fact]
+    public async Task TransformAsync_when_token_already_cancelled_reads_nothing()
+    {
+        using var transformer = new FixedWidthTransformer<Src, Dst>(s => new Dst { Name = s.Name });
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var enumerated = false;
+        async IAsyncEnumerable<Src> Poisoned()
+        {
+            enumerated = true;
+            yield return new Src { Name = "never" };
+            await Task.CompletedTask;
+        }
+
+        // The pre-cancellation guard throws before the source is touched.
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await transformer.TransformAsync(Poisoned(), cts.Token).ToListAsync());
+
+        Assert.False(enumerated);
+    }
+
+
+    [ExcludeFromCodeCoverage]
+    private sealed class ManualProgressTimer : IProgressTimer
+    {
+        private Action? _elapsed;
+
+        public bool WasStarted { get; private set; }
+
+        public event Action? Elapsed
+        {
+            add => _elapsed += value;
+            remove => _elapsed -= value;
+        }
+
+        public void Start(int intervalMilliseconds) => WasStarted = true;
+
+        public void StopTimer()
+        {
+        }
+
+        public void Fire() => _elapsed?.Invoke();
+
+        public void Dispose()
+        {
+        }
+    }
+
+
+    [ExcludeFromCodeCoverage]
+    private sealed class CollectingProgress : IProgress<FixedWidthReport>
+    {
+        public List<FixedWidthReport> Reports { get; } = new();
+
+        public void Report(FixedWidthReport value) => Reports.Add(value);
     }
 }

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/Wolfgang.Etl.FixedWidth.Tests.Unit.csproj
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/Wolfgang.Etl.FixedWidth.Tests.Unit.csproj
@@ -20,8 +20,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')) And '$(TargetFramework)' != 'netcoreapp3.1' And '$(TargetFramework)' != 'net5.0'" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
     <PackageReference Include="System.Linq.Async" Version="7.0.1" />
-    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.10.0" />
-    <PackageReference Include="Wolfgang.Etl.TestKit.Xunit" Version="0.10.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit" Version="0.14.0" />
+    <PackageReference Include="Wolfgang.Etl.TestKit.Xunit" Version="0.14.0" />
     <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/tools/GcProfile/Program.cs
+++ b/tools/GcProfile/Program.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Wolfgang.Etl.FixedWidth;
+using Wolfgang.Etl.FixedWidth.Attributes;
+using Wolfgang.Etl.FixedWidth.Enums;
+
+namespace Wolfgang.Etl.FixedWidth.GcProfile;
+
+// Sustained-load GC / allocation profiler (#152). Runs extract -> transform ->
+// load in a tight loop for a configurable duration, then reports the two metrics
+// that actually matter for a materializing streaming library under long-running
+// server / ETL load:
+//   * allocatedBytesPerRecord      — catches a hot-path allocation regression;
+//   * gen2CollectionsPerMillion    — catches a retention leak (records or state
+//                                     surviving into gen2 when they shouldn't).
+// Emits JSON to stdout and (if GC_PROFILE_OUT is set) to that file. The scheduled
+// workflow compares against docs/gc-baseline.json and fails on regression.
+internal static class Program
+{
+    private const int BatchLines = 1000;
+
+    private static async Task<int> Main(string[] args)
+    {
+        var seconds = ResolveSeconds(args);
+        var batch = BuildBatch(BatchLines);
+
+        // Warm up: JIT the paths and populate the process-global caches so the
+        // measured window reflects steady state, not first-use cost.
+        await ProcessOnceAsync(batch).ConfigureAwait(false);
+
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        var json = await MeasureAsync(batch, seconds).ConfigureAwait(false);
+
+        Console.WriteLine(json);
+
+        var outPath = Environment.GetEnvironmentVariable("GC_PROFILE_OUT");
+        if (!string.IsNullOrEmpty(outPath))
+        {
+            await File.WriteAllTextAsync(outPath, json, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false)).ConfigureAwait(false);
+        }
+
+        return 0;
+    }
+
+
+    private static async Task<string> MeasureAsync(string batch, int seconds)
+    {
+        var allocStart = GC.GetTotalAllocatedBytes(precise: true);
+        var g0 = GC.CollectionCount(0);
+        var g1 = GC.CollectionCount(1);
+        var g2 = GC.CollectionCount(2);
+
+        long records = 0;
+        var sw = Stopwatch.StartNew();
+        var deadline = TimeSpan.FromSeconds(seconds);
+        while (sw.Elapsed < deadline)
+        {
+            records += await ProcessOnceAsync(batch).ConfigureAwait(false);
+        }
+
+        sw.Stop();
+
+        var allocated = GC.GetTotalAllocatedBytes(precise: true) - allocStart;
+        var gen2 = GC.CollectionCount(2) - g2;
+        var mem = GC.GetGCMemoryInfo();
+        var perRecord = records == 0 ? 0d : (double)allocated / records;
+        var gen2PerMillion = records == 0 ? 0d : gen2 / (records / 1_000_000d);
+
+        return new StringBuilder()
+            .Append('{').Append('\n')
+            .AppendField("recordsProcessed", records).Append(",\n")
+            .AppendField("elapsedSeconds", Math.Round(sw.Elapsed.TotalSeconds, 2)).Append(",\n")
+            .AppendField("recordsPerSecond", Math.Round(records / sw.Elapsed.TotalSeconds, 0)).Append(",\n")
+            .AppendField("allocatedBytesTotal", allocated).Append(",\n")
+            .AppendField("allocatedBytesPerRecord", Math.Round(perRecord, 1)).Append(",\n")
+            .AppendField("gen0Collections", GC.CollectionCount(0) - g0).Append(",\n")
+            .AppendField("gen1Collections", GC.CollectionCount(1) - g1).Append(",\n")
+            .AppendField("gen2Collections", gen2).Append(",\n")
+            .AppendField("gen2CollectionsPerMillion", Math.Round(gen2PerMillion, 3)).Append(",\n")
+            .AppendField("heapSizeBytes", mem.HeapSizeBytes).Append(",\n")
+            .AppendField("fragmentedBytes", mem.FragmentedBytes).Append('\n')
+            .Append('}')
+            .ToString();
+    }
+
+
+    private static async Task<int> ProcessOnceAsync(string batch)
+    {
+        var people = new List<PersonRecord>(BatchLines);
+        using (var extractor = new FixedWidthExtractor<PersonRecord>(new StringReader(batch)))
+        {
+            await foreach (var r in extractor.ExtractAsync(CancellationToken.None).ConfigureAwait(false))
+            {
+                people.Add(r);
+            }
+        }
+
+        var transformer = FixedWidthTransformer<PersonRecord, PersonRecord>.ByMatchingProperties();
+        var transformed = new List<PersonRecord>(people.Count);
+        await foreach (var r in transformer.TransformAsync(ToAsync(people), CancellationToken.None).ConfigureAwait(false))
+        {
+            transformed.Add(r);
+        }
+
+        using (var loader = new FixedWidthLoader<PersonRecord>(TextWriter.Null))
+        {
+            await loader.LoadAsync(ToAsync(transformed), CancellationToken.None).ConfigureAwait(false);
+        }
+
+        return transformed.Count;
+    }
+
+
+    private static int ResolveSeconds(string[] args)
+    {
+        if (args.Length > 0 && int.TryParse(args[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var a) && a > 0)
+        {
+            return a;
+        }
+
+        return int.TryParse(Environment.GetEnvironmentVariable("GC_PROFILE_SECONDS"), NumberStyles.Integer, CultureInfo.InvariantCulture, out var e) && e > 0
+            ? e
+            : 10;
+    }
+
+
+    private static string BuildBatch(int lines)
+    {
+        var sb = new StringBuilder(lines * 24);
+        for (var i = 0; i < lines; i++)
+        {
+            sb.AppendFormat(CultureInfo.InvariantCulture, "{0,-10}{1,-10}{2:000}\n", $"First{i % 997}", $"Last{i % 991}", i % 120);
+        }
+
+        return sb.ToString();
+    }
+
+
+#pragma warning disable CS1998
+    private static async IAsyncEnumerable<PersonRecord> ToAsync(IEnumerable<PersonRecord> items)
+    {
+        foreach (var item in items)
+        {
+            yield return item;
+        }
+    }
+#pragma warning restore CS1998
+
+
+    private sealed class PersonRecord
+    {
+        [FixedWidthField(0, 10)]
+        public string FirstName { get; set; } = string.Empty;
+
+        [FixedWidthField(1, 10)]
+        public string LastName { get; set; } = string.Empty;
+
+        [FixedWidthField(2, 3, Alignment = FieldAlignment.Right, Pad = '0')]
+        public int Age { get; set; }
+    }
+
+
+    private static StringBuilder AppendField(this StringBuilder sb, string name, long value)
+        => sb.Append("  \"").Append(name).Append("\": ").Append(value.ToString(CultureInfo.InvariantCulture));
+
+
+    private static StringBuilder AppendField(this StringBuilder sb, string name, double value)
+        => sb.Append("  \"").Append(name).Append("\": ").Append(value.ToString(CultureInfo.InvariantCulture));
+}

--- a/tools/GcProfile/Wolfgang.Etl.FixedWidth.GcProfile.csproj
+++ b/tools/GcProfile/Wolfgang.Etl.FixedWidth.GcProfile.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Sustained-load GC / allocation profiler (#152). Deliberately NOT in
+    "ETL Fixed Width.slnx": it is a long-running console harness driven by the
+    scheduled gc-profile.yaml workflow, not a unit test. It runs extract ->
+    transform -> load in a tight loop for a configurable duration and emits GC
+    metrics as JSON; the workflow compares them against docs/gc-baseline.json and
+    fails on a per-record allocation or gen2-retention regression.
+  -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Wolfgang.Etl.FixedWidth\Wolfgang.Etl.FixedWidth.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/GcProfile/compare.py
+++ b/tools/GcProfile/compare.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Gate a sustained-load GC run against the committed baseline (#152).
+
+Usage: compare.py <run.json> <baseline.json>
+
+Fails (exit 1) when the per-record allocation exceeds the baseline reference by
+more than its tolerance, or when gen2 collections per million records exceed the
+baseline max (a retention leak). Prints a summary either way.
+"""
+import json
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: compare.py <run.json> <baseline.json>", file=sys.stderr)
+        return 2
+
+    with open(sys.argv[1], encoding="utf-8-sig") as f:
+        run = json.load(f)
+    with open(sys.argv[2], encoding="utf-8-sig") as f:
+        base = json.load(f)
+
+    failures = []
+
+    per_record = float(run["allocatedBytesPerRecord"])
+    ref = float(base["allocatedBytesPerRecord"]["reference"])
+    tol = float(base["allocatedBytesPerRecord"]["tolerancePercent"]) / 100.0
+    ceiling = ref * (1.0 + tol)
+    ok = per_record <= ceiling
+    print(f"allocatedBytesPerRecord: {per_record:.1f}  (baseline {ref:.1f}, ceiling {ceiling:.1f})  {'OK' if ok else 'REGRESSION'}")
+    if not ok:
+        failures.append(f"allocatedBytesPerRecord {per_record:.1f} > ceiling {ceiling:.1f}")
+
+    gen2 = float(run["gen2CollectionsPerMillion"])
+    gen2_max = float(base["gen2CollectionsPerMillion"]["max"])
+    ok = gen2 <= gen2_max
+    print(f"gen2CollectionsPerMillion: {gen2:.3f}  (max {gen2_max:.3f})  {'OK' if ok else 'LEAK'}")
+    if not ok:
+        failures.append(f"gen2CollectionsPerMillion {gen2:.3f} > max {gen2_max:.3f}")
+
+    print(f"recordsProcessed: {run.get('recordsProcessed')}  recordsPerSecond: {run.get('recordsPerSecond')}")
+
+    if failures:
+        print("\nGC REGRESSION:\n  - " + "\n  - ".join(failures), file=sys.stderr)
+        return 1
+
+    print("\nGC profile within baseline.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**Non-protected half** of the 0.8.0 `vNext → main` release split. Full CI; **merge this first**.

Carries all 0.8.0 content **except** the 5 workflow files (those ship in the paired protected PR #PROTECTED).

## 0.8.0 contents
- **#23** `FixedWidthSchemaBuilder<T>` + `Schema` override
- **#29** Abstractions #84 error handling + `OnError` dead-letter (`FixedWidthError`)
- **#275** zero-config metrics (removed the always-on 0.7.0 hot-path overhead; listener-gated)
- **#153 / #147 / #152 / #140 / #165** AOT-smoke, concurrency stress, GC profiling, shadow workloads, reproducible-build docs
- Version **0.8.0**, PublicAPI Unshipped→Shipped, baseline **0.7.0**, CHANGELOG `[0.8.0]`, deps **Abstractions 0.21.0 / TestKit 0.14.0**

Additive public API — no breaking changes. Pack validated vs the 0.7.0 baseline; 445/445 unit tests.

## Release sequence
1. **This PR** (full CI) →
2. paired protected workflows PR (admin-bypass) →
3. tag `v0.8.0` (fires `release.yaml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Closes #23, #29, #140, #147, #152, #153, #165, #275.
