### PR TITLE
ci: 0.8.0 workflow files to main (protected — admin-bypass)

### DIFF
--- a/.github/workflows/aot-smoke.yaml
+++ b/.github/workflows/aot-smoke.yaml
@@ -1,0 +1,71 @@
+name: AOT Smoke
+
+# Native-AOT / trim compatibility smoke test (#153).
+#
+# net8.0 / net10.0 consumers may publish with <PublishAot>true</PublishAot>, which
+# also trims. FixedWidth maps records with reflection (GetProperties) and
+# Expression.Compile accessors — both are AOT-legal (Expression.Compile falls back
+# to the interpreter) but the trimmer can silently remove the record property
+# metadata the mapping reflects over. This job publishes a tiny console consumer
+# with Native AOT on Linux, then RUNS the native binary: it exercises every public
+# path against a concrete record type and asserts the results, so a trim/AOT
+# regression exits non-zero and fails the check before merge. Native AOT can't be
+# published on the Windows dev box, so CI is the authoritative gate.
+
+on:
+  pull_request:
+    branches:
+      - main
+      - vNext
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: aot-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  aot-smoke:
+    name: AOT publish + run
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      PROJ: tests/AotSmoke/Wolfgang.Etl.FixedWidth.AotSmoke.csproj
+      OUT: tests/AotSmoke/bin/Release/net10.0/linux-x64/publish/Wolfgang.Etl.FixedWidth.AotSmoke
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Install Native AOT prerequisites
+        run: sudo apt-get update && sudo apt-get install -y clang zlib1g-dev
+
+      - name: Publish Native AOT (linux-x64)
+        run: |
+          dotnet publish "${{ env.PROJ }}" -c Release -r linux-x64 2>&1 | tee publish.log
+
+      - name: Report trim / AOT warnings (informational)
+        if: always()
+        run: |
+          echo '### Trim / AOT analyzer warnings' >> "$GITHUB_STEP_SUMMARY"
+          if grep -oE 'IL[0-9]{4}' publish.log | sort | uniq -c > il.txt && [ -s il.txt ]; then
+            sed 's/^/    /' il.txt >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo 'None.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Run the native binary (the gate)
+        run: |
+          test -x "${{ env.OUT }}" || { echo "native binary not produced at ${{ env.OUT }}"; exit 1; }
+          "${{ env.OUT }}"

--- a/.github/workflows/concurrency.yaml
+++ b/.github/workflows/concurrency.yaml
@@ -1,0 +1,53 @@
+name: Concurrency Stress
+
+# Weekly race-condition stress sweep (#147).
+#
+# tests/Wolfgang.Etl.FixedWidth.Tests.Concurrency asserts correctness under
+# contention — concurrent first-use of the process-global caches, racing
+# disposal, and cross-thread cancellation mid-enumeration. Per-PR the suite runs
+# a modest, fast, deterministic budget; here STRESS_ITERATIONS is cranked up for a
+# generous weekly exploration of schedule interleavings.
+#
+# Coyote (Microsoft's async model checker) is intentionally not used: its
+# IAsyncEnumerable support is rough and its CLI is net8-only, so systematic
+# schedule exploration of a streaming library is unreliable. The xunit stress
+# suite is the gate.
+
+on:
+  schedule:
+    - cron: '17 4 * * 1'   # Mondays 04:17 UTC (scheduled workflows run from the default branch)
+  workflow_dispatch:
+    inputs:
+      iterations:
+        description: 'STRESS_ITERATIONS per test (x fanout)'
+        required: false
+        default: '2000'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: concurrency-stress-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  stress:
+    name: Concurrency stress sweep
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      STRESS_ITERATIONS: ${{ github.event.inputs.iterations || '2000' }}
+      PROJ: tests/Wolfgang.Etl.FixedWidth.Tests.Concurrency/Wolfgang.Etl.FixedWidth.Tests.Concurrency.csproj
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Run concurrency stress suite
+        run: dotnet test "$PROJ" -c Release --filter "Category=Concurrency"

--- a/.github/workflows/gc-profile.yaml
+++ b/.github/workflows/gc-profile.yaml
@@ -54,7 +54,7 @@ jobs:
         run: |
           echo '### Sustained-load GC profile' >> "$GITHUB_STEP_SUMMARY"
           echo '```json' >> "$GITHUB_STEP_SUMMARY"
-          cat gc-run.json >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || echo '(no run produced)' >> "$GITHUB_STEP_SUMMARY"
+          cat "$GC_PROFILE_OUT" >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || echo '(no run produced)' >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload GC run
@@ -62,8 +62,8 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: gc-run
-          path: gc-run.json
+          path: ${{ env.GC_PROFILE_OUT }}
           if-no-files-found: warn
 
       - name: Compare against baseline
-        run: python3 tools/GcProfile/compare.py gc-run.json docs/gc-baseline.json
+        run: python3 tools/GcProfile/compare.py "$GC_PROFILE_OUT" docs/gc-baseline.json

--- a/.github/workflows/gc-profile.yaml
+++ b/.github/workflows/gc-profile.yaml
@@ -1,0 +1,69 @@
+name: GC Profile
+
+# Sustained-load GC / allocation profiling (#152).
+#
+# BDN micro-benchmarks measure single-call cost; this measures what only shows up
+# under long-running server / ETL load. tools/GcProfile runs extract -> transform
+# -> load in a tight loop for GC_PROFILE_SECONDS, then reports allocated bytes per
+# record and gen2 collections per million records. The run is gated against
+# docs/gc-baseline.json: a per-record allocation jump (hot-path regression) or any
+# meaningful gen2 promotion (retention leak) fails the job.
+
+on:
+  schedule:
+    - cron: '23 5 1 * *'   # 1st of each month, 05:23 UTC (runs from the default branch)
+  workflow_dispatch:
+    inputs:
+      seconds:
+        description: 'GC_PROFILE_SECONDS (sustained-load duration)'
+        required: false
+        default: '600'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: gc-profile-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gc-profile:
+    name: Sustained-load GC profile
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      GC_PROFILE_SECONDS: ${{ github.event.inputs.seconds || '600' }}
+      GC_PROFILE_OUT: gc-run.json
+      PROJ: tools/GcProfile/Wolfgang.Etl.FixedWidth.GcProfile.csproj
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Run sustained-load profiler
+        run: dotnet run --project "$PROJ" -c Release
+
+      - name: Summarize
+        if: always()
+        run: |
+          echo '### Sustained-load GC profile' >> "$GITHUB_STEP_SUMMARY"
+          echo '```json' >> "$GITHUB_STEP_SUMMARY"
+          cat gc-run.json >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || echo '(no run produced)' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload GC run
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: gc-run
+          path: gc-run.json
+          if-no-files-found: warn
+
+      - name: Compare against baseline
+        run: python3 tools/GcProfile/compare.py gc-run.json docs/gc-baseline.json

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -561,6 +561,60 @@ jobs:
           }
 
 
+      - name: Generate reproducible-build manifest
+        if: steps.check-packages.outputs.has-packages == 'true'
+        shell: pwsh
+        # Consumer-side reproducibility (#165): record the expected SHA-256 of each
+        # per-framework assembly (the byte-reproducible artifact) plus the toolchain
+        # that produced them, so a third party can rebuild the tag and compare. The
+        # .nupkg hashes are reference only — a .nupkg is a ZIP with per-entry
+        # timestamps and is not byte-reproducible. See docs/REPRODUCIBLE-BUILD.md.
+        run: |
+          $dir = Join-Path $PWD 'nuget-packages'
+
+          # Hash our per-TFM assembly (the byte-reproducible artifact). Skip the
+          # reference assemblies under each <tfm>/ref/ folder.
+          $binRoot = 'src/Wolfgang.Etl.FixedWidth/bin/Release'
+          $assemblies = Get-ChildItem -Path $binRoot -Recurse -Filter 'Wolfgang.Etl.FixedWidth.dll' |
+            Where-Object { $_.Directory.Name -ne 'ref' } |
+            ForEach-Object {
+              [ordered]@{
+                tfm    = $_.Directory.Name
+                file   = $_.Name
+                sha256 = (Get-FileHash -Algorithm SHA256 -Path $_.FullName).Hash.ToLowerInvariant()
+                bytes  = $_.Length
+              }
+            } | Sort-Object { $_.tfm }
+
+          $packages = Get-ChildItem -Path $dir -File |
+            Where-Object { $_.Extension -in '.nupkg', '.snupkg' } |
+            ForEach-Object {
+              [ordered]@{
+                file   = $_.Name
+                sha256 = (Get-FileHash -Algorithm SHA256 -Path $_.FullName).Hash.ToLowerInvariant()
+                bytes  = $_.Length
+              }
+            }
+
+          $manifest = [ordered]@{
+            repository         = "https://github.com/$env:GITHUB_REPOSITORY"
+            tag                = $env:GITHUB_REF_NAME
+            commit             = $env:GITHUB_SHA
+            dotnetSdk          = (dotnet --version)
+            runnerOs           = $env:RUNNER_OS
+            buildConfiguration = 'Release'
+            deterministic      = $true
+            buildCommand       = 'dotnet build -c Release -p:ContinuousIntegrationBuild=true'
+            note               = 'Verify the per-framework assembly hashes; .nupkg files embed timestamps and are not byte-reproducible. See docs/REPRODUCIBLE-BUILD.md.'
+            assemblies         = @($assemblies)
+            packages           = @($packages)
+          }
+
+          $path = Join-Path $dir 'reproducible-build-manifest.json'
+          $manifest | ConvertTo-Json -Depth 6 | Set-Content -Path $path -Encoding utf8
+          Write-Host "Wrote $path"
+          Get-Content $path
+
       - name: Upload NuGet packages
         uses: actions/upload-artifact@v7
         with:
@@ -795,5 +849,6 @@ jobs:
             ./nuget-packages/*.nupkg
             ./nuget-packages/*.snupkg
             ./nuget-packages/*.bom.json
+            ./nuget-packages/reproducible-build-manifest.json
             release-coverage.zip
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -586,6 +586,13 @@ jobs:
               }
             } | Sort-Object { $_.tfm }
 
+          # Fail fast rather than publish a misleading manifest with an empty assemblies list if the
+          # expected Release build output isn't where we looked (e.g. a path/layout change upstream).
+          if (@($assemblies).Count -eq 0) {
+            Write-Error "Reproducible-build manifest: no 'Wolfgang.Etl.FixedWidth.dll' found under '$binRoot'. Expected the Release build output — failing instead of writing an empty manifest."
+            exit 1
+          }
+
           $packages = Get-ChildItem -Path $dir -File |
             Where-Object { $_.Extension -in '.nupkg', '.snupkg' } |
             ForEach-Object {

--- a/.github/workflows/shadow.yaml
+++ b/.github/workflows/shadow.yaml
@@ -1,0 +1,64 @@
+name: Shadow Workloads
+
+# Shadow-testing against realistic consumer workloads (#140).
+#
+# Unit + property tests prove behaviour on synthetic input; these run realistic
+# end-to-end scenarios (streaming round trip, reformat transform, pipeline
+# composition) nightly and gate them against docs/shadow-baseline.json.
+# allocatedBytes is the hard gate (deterministic managed allocation); medianMs is
+# advisory — wall-clock on shared runners is too noisy to fail on, so it is
+# reported but does not fail the job. Distinct from the P2 BDN gh-pages trend
+# chart: this runs whole-scenario consumer flows, not curated micro-benchmarks.
+
+on:
+  schedule:
+    - cron: '41 3 * * *'   # nightly 03:41 UTC (runs from the default branch)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: shadow-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  shadow:
+    name: Shadow workloads vs baseline
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      SHADOW_OUT: shadow-run.json
+      PROJ: samples/ShadowWorkloads/Wolfgang.Etl.FixedWidth.ShadowWorkloads.csproj
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Run shadow workloads
+        run: dotnet run --project "$PROJ" -c Release -- --measure
+
+      - name: Summarize
+        if: always()
+        run: |
+          echo '### Shadow workloads' >> "$GITHUB_STEP_SUMMARY"
+          echo '```json' >> "$GITHUB_STEP_SUMMARY"
+          cat shadow-run.json >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || echo '(no run produced)' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload shadow run
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: shadow-run
+          path: shadow-run.json
+          if-no-files-found: warn
+
+      - name: Compare against baseline
+        run: python3 samples/ShadowWorkloads/compare.py shadow-run.json docs/shadow-baseline.json

--- a/.github/workflows/shadow.yaml
+++ b/.github/workflows/shadow.yaml
@@ -49,7 +49,7 @@ jobs:
         run: |
           echo '### Shadow workloads' >> "$GITHUB_STEP_SUMMARY"
           echo '```json' >> "$GITHUB_STEP_SUMMARY"
-          cat shadow-run.json >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || echo '(no run produced)' >> "$GITHUB_STEP_SUMMARY"
+          cat "$SHADOW_OUT" >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || echo '(no run produced)' >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload shadow run
@@ -57,8 +57,8 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: shadow-run
-          path: shadow-run.json
+          path: ${{ env.SHADOW_OUT }}
           if-no-files-found: warn
 
       - name: Compare against baseline
-        run: python3 samples/ShadowWorkloads/compare.py shadow-run.json docs/shadow-baseline.json
+        run: python3 samples/ShadowWorkloads/compare.py "$SHADOW_OUT" docs/shadow-baseline.json


### PR DESCRIPTION
**Protected half** of the 0.8.0 `vNext → main` release split. **Trips the `Detect .NET Projects` guard by design** — merge with **admin-bypass**, AFTER the non-protected PR (`release/0.8.0-to-main`) lands.

## Files (all protected `.github/workflows/*`)
- `aot-smoke.yaml` — the #153 AOT/trim gate; runs on **`pull_request` / `push`** (plus manual)
- `concurrency.yaml`, `gc-profile.yaml`, `shadow.yaml` — new **scheduled** sweeps for #147/#152/#140 (weekly/monthly/nightly + manual)
- `release.yaml` — adds the #165 reproducible-build-manifest generation step (`release:published`)

These reference projects (tests/AotSmoke, tools/GcProfile, samples/ShadowWorkloads, tests/…Concurrency) that arrive via the non-protected PR — hence the ordering. None of them runs on **this** PR: a newly-added workflow doesn't execute on the PR that introduces it (GitHub evaluates `pull_request` workflows from the base branch, where these don't exist yet). After merge, `aot-smoke` gates PRs/pushes and the sweeps run on their schedules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
