### PR TITLE
chore: bump PackageValidation baseline to 0.8.0 (post-release)

### DIFF
--- a/src/Wolfgang.Etl.FixedWidth/Wolfgang.Etl.FixedWidth.csproj
+++ b/src/Wolfgang.Etl.FixedWidth/Wolfgang.Etl.FixedWidth.csproj
@@ -22,7 +22,7 @@
          Intentional breaks in a MAJOR bump are recorded via a generated
          CompatibilitySuppressions.xml. -->
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>0.7.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>0.8.0</PackageValidationBaselineVersion>
     <Title>Wolfgang.Etl.FixedWidth</Title>
     <Description>Extractor and Loader implementations for reading and writing fixed-width text files, built on Wolfgang.Etl.Abstractions.</Description>
     <PackageProjectUrl>https://github.com/Chris-Wolfgang/ETL-FixedWidth</PackageProjectUrl>


### PR DESCRIPTION
Post-0.8.0-release housekeeping. Now that **0.8.0 is live on NuGet**, move the ABI-compatibility baseline forward so future packs diff against 0.8.0 instead of 0.7.0.

- `PackageValidationBaselineVersion` **0.7.0 → 0.8.0**

Verified locally: `dotnet pack` resolves the 0.8.0 baseline from NuGet and PackageValidation passes (no NU1102, no ABI break).

Single non-protected csproj change — normal full CI, no split needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)