### PR TITLE
feat: FixedWidthDataReader<TRecord> — IDataReader over fixed-width (#26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `FixedWidthDataReader<TRecord>` — a forward-only, read-only `IDataReader` over a
+  fixed-width source, with the layout taken from `TRecord`'s `[FixedWidthField]`
+  attributes. It serves each field value directly from the parsed line — **no
+  `TRecord` is allocated per row** — the optimal shape for `SqlBulkCopy`,
+  `DataTable.Load`, and other ADO.NET consumers that would otherwise discard a POCO
+  per row. Supports the extractor's configuration (`HeaderLineCount`,
+  `SkipItemCount`, `MaximumItemCount`, `BlankLineHandling`, `MalformedLineHandling`,
+  `FieldDelimiter`), typed accessors, and `GetSchemaTable()` ([#26]).
+
 ### Changed
 
 ### Deprecated
@@ -365,6 +374,7 @@ changes** — the shipped library is unchanged from 0.5.0.
 [#153]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/153
 [#165]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/165
 [#253]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/253
+[#26]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/26
 [#275]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/issues/275
 [Unreleased]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.8.0...HEAD
 [0.8.0]: https://github.com/Chris-Wolfgang/ETL-FixedWidth/compare/v0.7.0...v0.8.0

--- a/src/Wolfgang.Etl.FixedWidth/FixedWidthDataReader.cs
+++ b/src/Wolfgang.Etl.FixedWidth/FixedWidthDataReader.cs
@@ -1,0 +1,524 @@
+using System;
+using System.Collections;
+using System.Data;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using Wolfgang.Etl.FixedWidth.Enums;
+using Wolfgang.Etl.FixedWidth.Exceptions;
+using Wolfgang.Etl.FixedWidth.Parsing;
+
+namespace Wolfgang.Etl.FixedWidth;
+
+/// <summary>
+/// A forward-only, read-only <see cref="IDataReader"/> over a fixed-width text source, with the
+/// field layout taken from the <c>[FixedWidthField]</c> / <c>[FixedWidthSkip]</c> attributes on
+/// <typeparamref name="TRecord"/> (#26). Serves each field's value directly from the parsed line —
+/// <b>no <typeparamref name="TRecord"/> instance is created per row</b> — which is the optimal shape
+/// for <c>SqlBulkCopy</c>, <see cref="DataTable.Load(IDataReader)"/>, and other ADO.NET consumers
+/// that would otherwise discard a POCO per row.
+/// </summary>
+/// <typeparam name="TRecord">
+/// The type whose <see cref="Attributes.FixedWidthFieldAttribute"/>-decorated properties define the
+/// column layout. It is used only for its layout metadata; instances are never constructed.
+/// </typeparam>
+/// <example>
+/// <code>
+/// using var reader = new FixedWidthDataReader&lt;CustomerRecord&gt;(fileStream);
+/// using var bulkCopy = new SqlBulkCopy(connection) { DestinationTableName = "Customers" };
+/// await bulkCopy.WriteToServerAsync(reader);
+/// </code>
+/// </example>
+public sealed class FixedWidthDataReader<TRecord> : IDataReader
+    where TRecord : notnull
+{
+    private const int DefaultBufferSize = 65536;
+
+    private readonly TextReader _reader;
+    private readonly bool _ownsReader;
+    private readonly FieldMapResult _fieldMap;
+    private readonly string[] _names;
+    private readonly object?[] _current;
+
+    private bool _hasRow;
+    private bool _closed;
+    private long _recordsRead;
+    private long _dataLinesSkipped;
+    private int _headerLinesConsumed;
+    private long _currentLineNumber;
+
+
+
+    /// <summary>
+    /// Initializes a new <see cref="FixedWidthDataReader{TRecord}"/> reading from a
+    /// <see cref="TextReader"/>. The caller owns the reader's lifetime — it is not disposed.
+    /// </summary>
+    /// <param name="reader">The fixed-width text source.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="reader"/> is <see langword="null"/>.</exception>
+    public FixedWidthDataReader(TextReader reader)
+    {
+        _reader = reader ?? throw new ArgumentNullException(nameof(reader));
+        _fieldMap = FieldMap.GetResult<TRecord>();
+        _names = BuildNames(_fieldMap);
+        _current = new object?[_fieldMap.Descriptors.Count];
+    }
+
+
+
+    /// <summary>
+    /// Initializes a new <see cref="FixedWidthDataReader{TRecord}"/> reading from a
+    /// <see cref="Stream"/> via an internal 64 KB-buffered <see cref="StreamReader"/>. The caller
+    /// retains ownership of the stream (it is not closed), but <see cref="Dispose"/> must be called
+    /// to release the internal reader.
+    /// </summary>
+    /// <param name="stream">The readable fixed-width stream.</param>
+    /// <param name="encoding">The encoding to decode with, or <see langword="null"/> for <see cref="Encoding.UTF8"/>.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="stream"/> is <see langword="null"/>.</exception>
+    public FixedWidthDataReader(Stream stream, Encoding? encoding = null)
+    {
+        if (stream == null)
+        {
+            throw new ArgumentNullException(nameof(stream));
+        }
+
+        _reader = new StreamReader(stream, encoding ?? Encoding.UTF8, detectEncodingFromByteOrderMarks: true, DefaultBufferSize, leaveOpen: true);
+        _ownsReader = true;
+        _fieldMap = FieldMap.GetResult<TRecord>();
+        _names = BuildNames(_fieldMap);
+        _current = new object?[_fieldMap.Descriptors.Count];
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Configuration (mirrors FixedWidthExtractor<TRecord>)
+    // ------------------------------------------------------------------
+
+    /// <summary>The number of leading lines to treat as a header and skip. Default 0.</summary>
+    public int HeaderLineCount { get; set; }
+
+    /// <summary>The number of data rows to skip before the first row is served. Default 0.</summary>
+    public long SkipItemCount { get; set; }
+
+    /// <summary>The maximum number of data rows to serve. Default <see cref="long.MaxValue"/>.</summary>
+    public long MaximumItemCount { get; set; } = long.MaxValue;
+
+    /// <summary>How blank lines are handled. Default <see cref="BlankLineHandling.ThrowException"/>.</summary>
+    public BlankLineHandling BlankLineHandling { get; set; } = BlankLineHandling.ThrowException;
+
+    /// <summary>How malformed lines are handled. Default <see cref="MalformedLineHandling.ThrowException"/>.</summary>
+    public MalformedLineHandling MalformedLineHandling { get; set; } = MalformedLineHandling.ThrowException;
+
+    /// <summary>The inter-field delimiter used when the file was written, or <see langword="null"/> for none.</summary>
+    public string? FieldDelimiter { get; set; }
+
+
+
+    // ------------------------------------------------------------------
+    // IDataReader — forward-only iteration
+    // ------------------------------------------------------------------
+
+    /// <inheritdoc/>
+#pragma warning disable MA0051 // the line-reading loop reads best as one method — same call as FixedWidthExtractor.ExtractWorkerAsync
+    public bool Read()
+    {
+        if (_closed)
+        {
+            throw new InvalidOperationException("The data reader is closed.");
+        }
+
+        while (true)
+        {
+            if (_recordsRead >= MaximumItemCount)
+            {
+                _hasRow = false;
+                return false;
+            }
+
+            var line = _reader.ReadLine();
+            if (line == null)
+            {
+                _hasRow = false;
+                return false;
+            }
+
+            _currentLineNumber++;
+
+            // Leading header lines are consumed first and never served.
+            if (_headerLinesConsumed < HeaderLineCount)
+            {
+                _headerLinesConsumed++;
+                continue;
+            }
+
+            if (IsBlank(line))
+            {
+                if (BlankLineHandling == BlankLineHandling.Skip)
+                {
+                    continue;
+                }
+
+                if (BlankLineHandling == BlankLineHandling.ThrowException)
+                {
+                    var delimiterWidth = string.IsNullOrEmpty(FieldDelimiter) ? 0 : FieldDelimiter!.Length;
+                    var expectedWidth = _fieldMap.ExpectedLineWidth + (delimiterWidth * Math.Max(0, _fieldMap.TotalColumnCount - 1));
+                    throw new LineTooShortException($"Blank line encountered at line {_currentLineNumber}.", _currentLineNumber, string.Empty, expectedWidth, 0);
+                }
+
+                // ReturnDefault — participates in the skip/max budgets like a data row.
+                if (_dataLinesSkipped < SkipItemCount)
+                {
+                    _dataLinesSkipped++;
+                    continue;
+                }
+
+                FillDefaultRow();
+                _recordsRead++;
+                _hasRow = true;
+                return true;
+            }
+
+            if (_dataLinesSkipped < SkipItemCount)
+            {
+                _dataLinesSkipped++;
+                continue;
+            }
+
+            try
+            {
+                FillRow(line);
+            }
+            catch (Exception ex) when (ex is LineTooShortException or MalformedLineException or FieldConversionException)
+            {
+                if (MalformedLineHandling == MalformedLineHandling.Skip)
+                {
+                    continue;
+                }
+
+                if (MalformedLineHandling == MalformedLineHandling.ReturnDefault)
+                {
+                    FillDefaultRow();
+                    _recordsRead++;
+                    _hasRow = true;
+                    return true;
+                }
+
+                throw;
+            }
+
+            _recordsRead++;
+            _hasRow = true;
+            return true;
+        }
+    }
+#pragma warning restore MA0051
+
+
+
+    /// <inheritdoc/>
+    public bool NextResult() => false;
+
+    /// <inheritdoc/>
+    public int Depth => 0;
+
+    /// <inheritdoc/>
+    public bool IsClosed => _closed;
+
+    /// <inheritdoc/>
+    public int RecordsAffected => -1;
+
+    /// <inheritdoc/>
+    public void Close()
+    {
+        _closed = true;
+        _hasRow = false;
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // IDataRecord — field metadata
+    // ------------------------------------------------------------------
+
+    /// <inheritdoc/>
+    public int FieldCount => _fieldMap.Descriptors.Count;
+
+    /// <inheritdoc/>
+    public string GetName(int i) => _names[i];
+
+    /// <inheritdoc/>
+    public int GetOrdinal(string name)
+    {
+        if (name == null)
+        {
+            throw new ArgumentNullException(nameof(name));
+        }
+
+        for (var i = 0; i < _names.Length; i++)
+        {
+            if (string.Equals(_names[i], name, StringComparison.Ordinal))
+            {
+                return i;
+            }
+        }
+
+        for (var i = 0; i < _names.Length; i++)
+        {
+            if (string.Equals(_names[i], name, StringComparison.OrdinalIgnoreCase))
+            {
+                return i;
+            }
+        }
+
+        throw new IndexOutOfRangeException($"No field named '{name}'.");
+    }
+
+    /// <inheritdoc/>
+    public Type GetFieldType(int i)
+    {
+        // ADO.NET convention: report the underlying value type for a nullable column (nullness is
+        // signalled through IsDBNull), and DataColumn.DataType rejects Nullable&lt;T&gt; outright.
+        var type = _fieldMap.Descriptors[i].Context.PropertyType;
+        return Nullable.GetUnderlyingType(type) ?? type;
+    }
+
+    /// <inheritdoc/>
+    public string GetDataTypeName(int i) => GetFieldType(i).Name;
+
+
+
+    // ------------------------------------------------------------------
+    // IDataRecord — value access
+    // ------------------------------------------------------------------
+
+    /// <inheritdoc/>
+    public object GetValue(int i)
+    {
+        EnsureRow();
+        return _current[i] ?? DBNull.Value;
+    }
+
+    /// <inheritdoc/>
+    public int GetValues(object[] values)
+    {
+        if (values == null)
+        {
+            throw new ArgumentNullException(nameof(values));
+        }
+
+        EnsureRow();
+        var count = Math.Min(values.Length, _current.Length);
+        for (var i = 0; i < count; i++)
+        {
+            values[i] = _current[i] ?? DBNull.Value;
+        }
+
+        return count;
+    }
+
+    /// <inheritdoc/>
+    public bool IsDBNull(int i)
+    {
+        EnsureRow();
+        return _current[i] == null;
+    }
+
+    /// <inheritdoc/>
+    public object this[int i] => GetValue(i);
+
+    /// <inheritdoc/>
+    public object this[string name] => GetValue(GetOrdinal(name));
+
+    /// <inheritdoc/>
+    public bool GetBoolean(int i) => (bool)GetValue(i);
+
+    /// <inheritdoc/>
+    public byte GetByte(int i) => (byte)GetValue(i);
+
+    /// <inheritdoc/>
+    public char GetChar(int i) => (char)GetValue(i);
+
+    /// <inheritdoc/>
+    public DateTime GetDateTime(int i) => (DateTime)GetValue(i);
+
+    /// <inheritdoc/>
+    public decimal GetDecimal(int i) => (decimal)GetValue(i);
+
+    /// <inheritdoc/>
+    public double GetDouble(int i) => (double)GetValue(i);
+
+    /// <inheritdoc/>
+    public float GetFloat(int i) => (float)GetValue(i);
+
+    /// <inheritdoc/>
+    public Guid GetGuid(int i) => (Guid)GetValue(i);
+
+    /// <inheritdoc/>
+    public short GetInt16(int i) => (short)GetValue(i);
+
+    /// <inheritdoc/>
+    public int GetInt32(int i) => (int)GetValue(i);
+
+    /// <inheritdoc/>
+    public long GetInt64(int i) => (long)GetValue(i);
+
+    /// <inheritdoc/>
+    public string GetString(int i) => (string)GetValue(i);
+
+    /// <inheritdoc/>
+    public long GetBytes(int i, long fieldOffset, byte[]? buffer, int bufferoffset, int length)
+        => throw new NotSupportedException("Binary field access is not supported by the fixed-width data reader.");
+
+    /// <inheritdoc/>
+    public long GetChars(int i, long fieldoffset, char[]? buffer, int bufferoffset, int length)
+    {
+        var text = GetString(i);
+        if (buffer == null)
+        {
+            return text.Length;
+        }
+
+        var available = Math.Max(0, text.Length - (int)fieldoffset);
+        var count = Math.Min(length, available);
+        text.CopyTo((int)fieldoffset, buffer, bufferoffset, count);
+        return count;
+    }
+
+    /// <inheritdoc/>
+    public IDataReader GetData(int i)
+        => throw new NotSupportedException("Nested data readers are not supported by the fixed-width data reader.");
+
+
+
+    // ------------------------------------------------------------------
+    // Schema
+    // ------------------------------------------------------------------
+
+    /// <inheritdoc/>
+    public DataTable GetSchemaTable()
+    {
+        var table = new DataTable("SchemaTable") { Locale = CultureInfo.InvariantCulture };
+        table.Columns.Add("ColumnName", typeof(string));
+        table.Columns.Add("ColumnOrdinal", typeof(int));
+        table.Columns.Add("ColumnSize", typeof(int));
+        table.Columns.Add("DataType", typeof(Type));
+        table.Columns.Add("AllowDBNull", typeof(bool));
+
+        for (var i = 0; i < _fieldMap.Descriptors.Count; i++)
+        {
+            var descriptor = _fieldMap.Descriptors[i];
+            var type = descriptor.Context.PropertyType;
+            var nullable = !type.IsValueType || Nullable.GetUnderlyingType(type) != null;
+            table.Rows.Add(_names[i], i, descriptor.Context.FieldLength, Nullable.GetUnderlyingType(type) ?? type, nullable);
+        }
+
+        return table;
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // IDisposable
+    // ------------------------------------------------------------------
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        Close();
+        if (_ownsReader)
+        {
+            _reader.Dispose();
+        }
+    }
+
+
+
+    // ------------------------------------------------------------------
+    // Internals
+    // ------------------------------------------------------------------
+
+    private void EnsureRow()
+    {
+        if (!_hasRow)
+        {
+            throw new InvalidOperationException("No current row. Call Read() first, and check that it returned true.");
+        }
+    }
+
+    private static bool IsBlank(string line) => line.Length == 0 || string.IsNullOrWhiteSpace(line);
+
+    private static string[] BuildNames(FieldMapResult fieldMap)
+    {
+        var names = new string[fieldMap.Descriptors.Count];
+        for (var i = 0; i < names.Length; i++)
+        {
+            names[i] = fieldMap.Descriptors[i].Context.PropertyName;
+        }
+
+        return names;
+    }
+
+    private void FillRow(string line)
+    {
+        var delimiterWidth = string.IsNullOrEmpty(FieldDelimiter) ? 0 : FieldDelimiter!.Length;
+        var delimiterCount = Math.Max(0, _fieldMap.TotalColumnCount - 1);
+        var fullExpectedWidth = _fieldMap.ExpectedLineWidth + (delimiterWidth * delimiterCount);
+
+        if (line.Length < fullExpectedWidth)
+        {
+            throw new LineTooShortException
+            (
+                $"Line {_currentLineNumber} is too short. Expected {fullExpectedWidth} characters but found {line.Length}.",
+                _currentLineNumber,
+                line,
+                fullExpectedWidth,
+                line.Length
+            );
+        }
+
+        for (var i = 0; i < _fieldMap.Descriptors.Count; i++)
+        {
+            var descriptor = _fieldMap.Descriptors[i];
+            var start = descriptor.Start + (delimiterWidth * descriptor.AbsoluteColumnIndex);
+            var raw = line.AsMemory().Slice(start, descriptor.Attribute.Length);
+            var value = descriptor.Attribute.TrimValue ? raw.TrimMemory() : raw;
+
+            try
+            {
+                _current[i] = FixedWidthConverter.ParseValue
+                (
+                    value,
+                    descriptor.Context.PropertyType,
+                    descriptor.Context.Format,
+                    descriptor.TypeConverter,
+                    descriptor.Context.NumberStyles
+                );
+            }
+            catch (Exception ex) when (!(ex is MalformedLineException))
+            {
+                throw new FieldConversionException
+                (
+                    $"Line {_currentLineNumber}: could not convert value '{value}' to type " +
+                    $"'{descriptor.Context.PropertyType.Name}' for field '{descriptor.Context.PropertyName}'.",
+                    _currentLineNumber,
+                    line,
+                    descriptor.Context.PropertyName,
+                    descriptor.Context.PropertyType,
+                    value.ToString(),
+                    ex
+                );
+            }
+        }
+    }
+
+    private void FillDefaultRow()
+    {
+        for (var i = 0; i < _fieldMap.Descriptors.Count; i++)
+        {
+            var type = _fieldMap.Descriptors[i].Context.PropertyType;
+            _current[i] = type.IsValueType && Nullable.GetUnderlyingType(type) == null
+                ? Activator.CreateInstance(type)
+                : null;
+        }
+    }
+}

--- a/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
+++ b/src/Wolfgang.Etl.FixedWidth/PublicAPI.Unshipped.txt
@@ -1,1 +1,49 @@
 #nullable enable
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.BlankLineHandling.get -> Wolfgang.Etl.FixedWidth.Enums.BlankLineHandling
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.BlankLineHandling.set -> void
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.Close() -> void
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.Depth.get -> int
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.Dispose() -> void
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.FieldCount.get -> int
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.FieldDelimiter.get -> string?
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.FieldDelimiter.set -> void
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.FixedWidthDataReader(System.IO.Stream stream, System.Text.Encoding encoding = null) -> void
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.FixedWidthDataReader(System.IO.TextReader reader) -> void
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.GetBoolean(int i) -> bool
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.GetByte(int i) -> byte
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.GetBytes(int i, long fieldOffset, byte[] buffer, int bufferoffset, int length) -> long
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.GetChar(int i) -> char
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.GetChars(int i, long fieldoffset, char[] buffer, int bufferoffset, int length) -> long
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.GetData(int i) -> System.Data.IDataReader
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.GetDataTypeName(int i) -> string
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.GetDateTime(int i) -> System.DateTime
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.GetDecimal(int i) -> decimal
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.GetDouble(int i) -> double
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.GetFieldType(int i) -> System.Type
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.GetFloat(int i) -> float
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.GetGuid(int i) -> System.Guid
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.GetInt16(int i) -> short
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.GetInt32(int i) -> int
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.GetInt64(int i) -> long
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.GetName(int i) -> string
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.GetOrdinal(string name) -> int
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.GetSchemaTable() -> System.Data.DataTable
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.GetString(int i) -> string
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.GetValue(int i) -> object
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.GetValues(object[] values) -> int
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.HeaderLineCount.get -> int
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.HeaderLineCount.set -> void
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.IsClosed.get -> bool
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.IsDBNull(int i) -> bool
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.MalformedLineHandling.get -> Wolfgang.Etl.FixedWidth.Enums.MalformedLineHandling
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.MalformedLineHandling.set -> void
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.MaximumItemCount.get -> long
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.MaximumItemCount.set -> void
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.NextResult() -> bool
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.Read() -> bool
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.RecordsAffected.get -> int
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.SkipItemCount.get -> long
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.SkipItemCount.set -> void
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.this[int i].get -> object
+Wolfgang.Etl.FixedWidth.FixedWidthDataReader<TRecord>.this[string name].get -> object

--- a/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthDataReaderTests.cs
+++ b/tests/Wolfgang.Etl.FixedWidth.Tests.Unit/FixedWidthDataReaderTests.cs
@@ -1,0 +1,364 @@
+using System;
+using System.Data;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Wolfgang.Etl.FixedWidth.Attributes;
+using Wolfgang.Etl.FixedWidth.Enums;
+using Wolfgang.Etl.FixedWidth.Exceptions;
+using Xunit;
+
+namespace Wolfgang.Etl.FixedWidth.Tests.Unit;
+
+/// <summary>
+/// Covers <see cref="FixedWidthDataReader{TRecord}"/> (#26) — the forward-only <see cref="IDataReader"/>
+/// that serves field values directly from the parsed line without allocating a record per row.
+/// </summary>
+public sealed class FixedWidthDataReaderTests
+{
+    [ExcludeFromCodeCoverage]
+    private sealed record Person
+    {
+        [FixedWidthField(0, 10)]
+        public string FirstName { get; set; } = string.Empty;
+
+        [FixedWidthField(1, 10)]
+        public string LastName { get; set; } = string.Empty;
+
+        [FixedWidthField(2, 3, Alignment = FieldAlignment.Right, Pad = '0')]
+        public int Age { get; set; }
+
+        [FixedWidthField(3, 5)]
+        public int? Score { get; set; }
+    }
+
+
+    // 10 + 10 + 3 + 5 = 28 chars/line.
+    private static string Line(string first, string last, int age, string score)
+        => string.Format(CultureInfo.InvariantCulture, "{0,-10}{1,-10}{2:000}{3,-5}", first, last, age, score);
+
+    private static FixedWidthDataReader<Person> Reader(params string[] lines)
+        => new(new StringReader(string.Join("\n", lines)));
+
+
+    [Fact]
+    public void Read_serves_fields_by_ordinal_name_and_typed_accessor()
+    {
+        using var reader = Reader(Line("Alice", "Smith", 30, "42"));
+
+        Assert.True(reader.Read());
+        Assert.Equal("Alice", reader.GetString(0));
+        Assert.Equal("Smith", reader["LastName"]);
+        Assert.Equal(30, reader.GetInt32(2));
+        Assert.Equal(30, reader.GetValue(reader.GetOrdinal("Age")));
+        Assert.Equal(42, reader.GetValue(3));
+        Assert.False(reader.Read());
+    }
+
+
+    [Fact]
+    public void Field_metadata_matches_the_layout()
+    {
+        using var reader = Reader(Line("Alice", "Smith", 30, "42"));
+
+        Assert.Equal(4, reader.FieldCount);
+        Assert.Equal("FirstName", reader.GetName(0));
+        Assert.Equal(2, reader.GetOrdinal("Age"));
+        Assert.Equal(2, reader.GetOrdinal("age"));   // case-insensitive fallback
+        Assert.Equal(typeof(string), reader.GetFieldType(0));
+        Assert.Equal(typeof(int), reader.GetFieldType(2));
+    }
+
+
+    [Fact]
+    public void IsDBNull_is_true_for_an_empty_nullable_field()
+    {
+        using var reader = Reader(Line("Bob", "Jones", 25, ""));   // Score blank
+
+        Assert.True(reader.Read());
+        Assert.True(reader.IsDBNull(3));
+        Assert.Equal(DBNull.Value, reader.GetValue(3));
+        Assert.False(reader.IsDBNull(0));
+    }
+
+
+    [Fact]
+    public void HeaderLineCount_skips_leading_lines()
+    {
+        using var reader = Reader("HEADER ROW IGNORED         00xxxxx", Line("Alice", "Smith", 30, "1"));
+        reader.HeaderLineCount = 1;
+
+        Assert.True(reader.Read());
+        Assert.Equal("Alice", reader.GetString(0));
+        Assert.False(reader.Read());
+    }
+
+
+    [Fact]
+    public void Skip_and_Maximum_item_counts_are_honored()
+    {
+        using var reader = Reader(
+            Line("A", "1", 1, "1"),
+            Line("B", "2", 2, "2"),
+            Line("C", "3", 3, "3"),
+            Line("D", "4", 4, "4"));
+        reader.SkipItemCount = 1;
+        reader.MaximumItemCount = 2;
+
+        Assert.True(reader.Read());
+        Assert.Equal("B", reader.GetString(0));
+        Assert.True(reader.Read());
+        Assert.Equal("C", reader.GetString(0));
+        Assert.False(reader.Read());   // D is beyond the max
+    }
+
+
+    [Fact]
+    public void BlankLineHandling_Skip_ignores_blank_lines()
+    {
+        using var reader = Reader(Line("A", "1", 1, "1"), "   ", Line("B", "2", 2, "2"));
+        reader.BlankLineHandling = BlankLineHandling.Skip;
+
+        Assert.True(reader.Read());
+        Assert.Equal("A", reader.GetString(0));
+        Assert.True(reader.Read());
+        Assert.Equal("B", reader.GetString(0));
+        Assert.False(reader.Read());
+    }
+
+
+    [Fact]
+    public void BlankLineHandling_ThrowException_throws()
+    {
+        // Blank line first — a trailing empty line is swallowed by TextReader.ReadLine.
+        using var reader = Reader("   ", Line("A", "1", 1, "1"));
+        reader.BlankLineHandling = BlankLineHandling.ThrowException;
+
+        Assert.Throws<LineTooShortException>(() => reader.Read());
+    }
+
+
+    [Fact]
+    public void BlankLineHandling_ReturnDefault_yields_a_default_row()
+    {
+        using var reader = Reader(Line("A", "1", 1, "1"), "   ");
+        reader.BlankLineHandling = BlankLineHandling.ReturnDefault;
+
+        Assert.True(reader.Read());
+        Assert.True(reader.Read());
+        Assert.True(reader.IsDBNull(0));   // reference-type (string) default -> null -> DBNull
+        Assert.Equal(0, reader.GetInt32(2));   // value-type default
+        Assert.True(reader.IsDBNull(3));        // nullable default -> null
+    }
+
+
+    [Fact]
+    public void MalformedLineHandling_Skip_skips_short_lines()
+    {
+        using var reader = Reader(Line("A", "1", 1, "1"), "TOO SHORT", Line("B", "2", 2, "2"));
+        reader.MalformedLineHandling = MalformedLineHandling.Skip;
+
+        Assert.True(reader.Read());
+        Assert.Equal("A", reader.GetString(0));
+        Assert.True(reader.Read());
+        Assert.Equal("B", reader.GetString(0));
+        Assert.False(reader.Read());
+    }
+
+
+    [Fact]
+    public void MalformedLineHandling_ThrowException_throws_on_a_short_line()
+    {
+        using var reader = Reader("TOO SHORT");
+
+        Assert.Throws<LineTooShortException>(() => reader.Read());
+    }
+
+
+    [Fact]
+    public void GetSchemaTable_reflects_the_layout()
+    {
+        using var reader = Reader(Line("A", "1", 1, "1"));
+
+        var schema = reader.GetSchemaTable();
+
+        Assert.Equal(4, schema.Rows.Count);
+        Assert.Equal("FirstName", schema.Rows[0]["ColumnName"]);
+        Assert.Equal(typeof(int), schema.Rows[2]["DataType"]);
+        Assert.Equal(3, schema.Rows[2]["ColumnSize"]);
+        Assert.False((bool)schema.Rows[2]["AllowDBNull"]);   // int (non-nullable)
+        Assert.True((bool)schema.Rows[3]["AllowDBNull"]);    // int? (nullable)
+    }
+
+
+    [Fact]
+    public void DataTable_Load_consumes_the_reader_end_to_end()
+    {
+        using var reader = Reader(Line("Alice", "Smith", 30, "42"), Line("Bob", "Jones", 25, ""));
+
+        var table = new DataTable();
+        table.Load(reader);
+
+        Assert.Equal(2, table.Rows.Count);
+        Assert.Equal("Alice", table.Rows[0]["FirstName"]);
+        Assert.Equal(30, table.Rows[0]["Age"]);
+        Assert.Equal(DBNull.Value, table.Rows[1]["Score"]);
+    }
+
+
+    [Fact]
+    public void Stream_constructor_reads_records()
+    {
+        var bytes = Encoding.UTF8.GetBytes(Line("Alice", "Smith", 30, "7"));
+        using var stream = new MemoryStream(bytes);
+        using var reader = new FixedWidthDataReader<Person>(stream);
+
+        Assert.True(reader.Read());
+        Assert.Equal("Alice", reader.GetString(0));
+    }
+
+
+    [Fact]
+    public void GetValues_fills_the_buffer_and_GetChars_reports_length()
+    {
+        using var reader = Reader(Line("Alice", "Smith", 30, "42"));
+        Assert.True(reader.Read());
+
+        var values = new object[4];
+        Assert.Equal(4, reader.GetValues(values));
+        Assert.Equal("Alice", values[0]);
+
+        Assert.Equal(5, reader.GetChars(0, 0, null, 0, 0));   // "Alice".Length
+    }
+
+
+    [Fact]
+    public void Reading_before_first_Read_or_after_Close_is_rejected()
+    {
+        var reader = Reader(Line("A", "1", 1, "1"));
+
+        Assert.Throws<InvalidOperationException>(() => reader.GetValue(0));   // no current row yet
+
+        reader.Dispose();
+        Assert.True(reader.IsClosed);
+        Assert.Throws<InvalidOperationException>(() => reader.Read());
+    }
+
+
+    [ExcludeFromCodeCoverage]
+    private sealed record Wide
+    {
+        [FixedWidthField(0, 5)]
+        public bool Flag { get; set; }
+
+        [FixedWidthField(1, 4)]
+        public byte B { get; set; }
+
+        [FixedWidthField(2, 1)]
+        public char C { get; set; }
+
+        [FixedWidthField(3, 6)]
+        public short S { get; set; }
+
+        [FixedWidthField(4, 12)]
+        public long L { get; set; }
+
+        [FixedWidthField(5, 8)]
+        public decimal D { get; set; }
+
+        [FixedWidthField(6, 6)]
+        public double Db { get; set; }
+
+        [FixedWidthField(7, 6)]
+        public float F { get; set; }
+
+        [FixedWidthField(8, 8, Format = "yyyyMMdd")]
+        public DateTime Dt { get; set; }
+
+        [FixedWidthField(9, 36)]
+        public Guid G { get; set; }
+    }
+
+
+    [Fact]
+    public void Typed_accessors_return_the_field_clr_values()
+    {
+        var line =
+            "True".PadRight(5) + "12".PadRight(4) + "X" + "123".PadRight(6) +
+            "1234567890".PadRight(12) + "12.34".PadRight(8) + "1.5".PadRight(6) +
+            "2.5".PadRight(6) + "20260101" + "00000000-0000-0000-0000-000000000000";
+        using var reader = new FixedWidthDataReader<Wide>(new StringReader(line));
+
+        Assert.True(reader.Read());
+        Assert.True(reader.GetBoolean(0));
+        Assert.Equal((byte)12, reader.GetByte(1));
+        Assert.Equal('X', reader.GetChar(2));
+        Assert.Equal((short)123, reader.GetInt16(3));
+        Assert.Equal(1234567890L, reader.GetInt64(4));
+        Assert.Equal(12.34m, reader.GetDecimal(5));
+        Assert.Equal(1.5d, reader.GetDouble(6));
+        Assert.Equal(2.5f, reader.GetFloat(7));
+        Assert.Equal(new DateTime(2026, 1, 1), reader.GetDateTime(8));
+        Assert.Equal(Guid.Empty, reader.GetGuid(9));
+        Assert.Equal("Boolean", reader.GetDataTypeName(0));
+        Assert.Equal(typeof(short), reader.GetFieldType(3));
+    }
+
+
+    [Fact]
+    public void Non_forward_and_unsupported_members_behave_as_documented()
+    {
+        using var reader = Reader(Line("Alice", "Smith", 30, "1"));
+
+        Assert.False(reader.NextResult());
+        Assert.Equal(0, reader.Depth);
+        Assert.Equal(-1, reader.RecordsAffected);
+
+        Assert.True(reader.Read());
+        Assert.Throws<NotSupportedException>(() => reader.GetBytes(0, 0, null, 0, 0));
+        Assert.Throws<NotSupportedException>(() => reader.GetData(0));
+
+        var buffer = new char[5];
+        Assert.Equal(5, reader.GetChars(0, 0, buffer, 0, 5));
+        Assert.Equal("Alice", new string(buffer));
+    }
+
+
+    [Fact]
+    public void Argument_validation_and_unknown_field_names()
+    {
+        using var reader = Reader(Line("A", "1", 1, "1"));
+
+        Assert.Throws<ArgumentNullException>(() => reader.GetOrdinal(null!));
+        Assert.Throws<IndexOutOfRangeException>(() => reader.GetOrdinal("Nope"));
+        Assert.Throws<ArgumentNullException>(() => reader.GetValues(null!));
+    }
+
+
+    [Fact]
+    public void MalformedLineHandling_ReturnDefault_yields_a_default_row()
+    {
+        using var reader = Reader("SHORT", Line("A", "1", 1, "1"));
+        reader.MalformedLineHandling = MalformedLineHandling.ReturnDefault;
+
+        Assert.True(reader.Read());
+        Assert.True(reader.IsDBNull(0));   // default row from the short line
+        Assert.True(reader.Read());
+        Assert.Equal("A", reader.GetString(0));
+    }
+
+
+    [Fact]
+    public void BlankLine_ReturnDefault_within_skip_budget_is_skipped()
+    {
+        using var reader = Reader("   ", Line("A", "1", 1, "1"));
+        reader.BlankLineHandling = BlankLineHandling.ReturnDefault;
+        reader.SkipItemCount = 1;   // the blank consumes the skip budget, then A is served
+
+        Assert.True(reader.Read());
+        Assert.Equal("A", reader.GetString(0));
+        Assert.False(reader.Read());
+    }
+}


### PR DESCRIPTION
First increment of **#26**: a native `IDataReader` for fixed-width sources.

## What
`FixedWidthDataReader<TRecord>` — forward-only, read-only `IDataReader` whose column layout comes from `TRecord`'s `[FixedWidthField]` attributes. It serves each field value **directly from the parsed line — no `TRecord` is allocated per row** — the optimal shape for `SqlBulkCopy`, `DataTable.Load`, and other ADO.NET consumers that would otherwise discard a POCO per row.

```csharp
using var reader = new FixedWidthDataReader<CustomerRecord>(fileStream);
using var bulkCopy = new SqlBulkCopy(connection) { DestinationTableName = "Customers" };
await bulkCopy.WriteToServerAsync(reader);
```

- Mirrors the extractor's config: `HeaderLineCount`, `SkipItemCount`, `MaximumItemCount`, `BlankLineHandling`, `MalformedLineHandling`, `FieldDelimiter`
- Full `IDataRecord` surface: typed accessors, `GetValue`/`GetValues`, `IsDBNull`, `GetName`/`GetOrdinal`/`GetFieldType`, `GetSchemaTable()`, indexers
- `TextReader` and `Stream` (64 KB-buffered) constructors

## Scope decision
Built on the **existing** `FieldMapResult`/`FieldDescriptor` metadata + `FixedWidthConverter` value parsing — **no refactor of the just-shipped `FixedWidthExtractor`**. The issue's proposed shared-`FixedWidthReader`-core extraction (internal DRY, no new user value) is a sensible **follow-up**; this PR delivers the user-facing reader with zero regression risk to the extractor.

## Verification
- Full TFM matrix (net462…net10) builds clean, 0 warnings
- **20 tests** incl. a real `DataTable.Load(reader)` end-to-end interop test (which caught a genuine bug: `GetFieldType` must return the underlying type for nullable columns, not `Nullable<T>`)
- **92.6%** line coverage on the new type (clears the 90% gate)
- PublicAPI surface tracked in `Unshipped.txt`, validated by RS0017

## Notes
- `IDataReader.GetBytes`/`GetData` throw `NotSupportedException` (text reader, no nested results); `GetChars` is supported.
- `NextResult()` → false, `Depth` → 0, `RecordsAffected` → -1 (standard forward-only reader).

Part of #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)